### PR TITLE
Instead of copy-pasting platform specific obj modules, use the object crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,7 @@ leb128 = "0.2.1"
 
 [dev-dependencies]
 getopts = "0.2"
-
-[target.'cfg(target_os="linux")'.dev-dependencies]
-elf = "0.0.9"
-
-[target.'cfg(target_os="macos")'.dev-dependencies]
-mach_o = "0.1.2"
+object = "0.0.1"
 
 [features]
 nightly = []

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -1,5 +1,6 @@
 extern crate gimli;
 extern crate getopts;
+extern crate object;
 
 use std::env;
 
@@ -13,8 +14,8 @@ fn main() {
 
     let matches = opts.parse(&args[1..]).unwrap();
     let file_path = matches.opt_str("e").unwrap_or("a.out".to_string());
-    let file = obj::open(&file_path);
-    if obj::is_little_endian(&file) {
+    let file = object::open(&file_path);
+    if object::is_little_endian(&file) {
         symbolicate::<gimli::LittleEndian>(&file, &matches);
     } else {
         symbolicate::<gimli::BigEndian>(&file, &matches);
@@ -29,12 +30,12 @@ fn parse_uint_from_hex_string(string: &str) -> u64 {
     }
 }
 
-fn entry_offsets_for_addresses<Endian>(file: &obj::File,
+fn entry_offsets_for_addresses<Endian>(file: &object::File,
                                        addrs: &Vec<u64>)
                                        -> Vec<Option<gimli::DebugInfoOffset>>
     where Endian: gimli::Endianity
 {
-    let aranges = obj::get_section(file, ".debug_aranges")
+    let aranges = object::get_section(file, ".debug_aranges")
         .expect("Can't addr2line with no aranges");
     let aranges = gimli::DebugAranges::<Endian>::new(aranges);
     let mut aranges = aranges.aranges();
@@ -86,19 +87,19 @@ fn display_file<Endian>(row: gimli::LineNumberRow<Endian>)
     }
 }
 
-fn symbolicate<Endian>(file: &obj::File, matches: &getopts::Matches)
+fn symbolicate<Endian>(file: &object::File, matches: &getopts::Matches)
     where Endian: gimli::Endianity
 {
     let addrs: Vec<u64> = matches.free.iter().map(|x| parse_uint_from_hex_string(x)).collect();
 
     let offsets = entry_offsets_for_addresses::<Endian>(&file, &addrs);
-    let debug_info = obj::get_section(file, ".debug_info")
+    let debug_info = object::get_section(file, ".debug_info")
         .expect("Can't addr2line without .debug_info");
     let debug_info = gimli::DebugInfo::<Endian>::new(debug_info);
-    let debug_abbrev = obj::get_section(&file, ".debug_abbrev")
+    let debug_abbrev = object::get_section(&file, ".debug_abbrev")
         .expect("Can't addr2line without .debug_abbrev");
     let debug_abbrev = gimli::DebugAbbrev::<Endian>::new(debug_abbrev);
-    let debug_line = obj::get_section(file, ".debug_line")
+    let debug_line = object::get_section(file, ".debug_line")
         .expect("Can't addr2line without .debug_line");
     let debug_line = gimli::DebugLine::<Endian>::new(&debug_line);
 
@@ -125,102 +126,6 @@ fn symbolicate<Endian>(file: &obj::File, matches: &getopts::Matches)
                     }
                 }
             }
-        }
-    }
-}
-
-// All cross platform / object file format compatibility stuff should
-// be contained in the `obj` module. Each supported platform / object
-// file format should implement the `obj` module with an identical
-// interface, but with the `pub type File` changing as needed. Hooray
-// duck typing!
-
-#[cfg(target_os="linux")]
-mod obj {
-    extern crate elf;
-    use std::path::Path;
-
-    /// The parsed object file type.
-    pub type File = elf::File;
-
-    /// Open and parse the object file at the given path.
-    pub fn open<P>(path: P) -> File
-        where P: AsRef<Path>
-    {
-        let path = path.as_ref();
-        elf::File::open_path(path).expect("Could not open file")
-    }
-
-    /// Get the contents of the section named `section_name`, if such
-    /// a section exists.
-    pub fn get_section<'a>(file: &'a File, section_name: &str) -> Option<&'a [u8]> {
-        file.sections
-            .iter()
-            .find(|s| s.shdr.name == section_name)
-            .map(|s| &s.data[..])
-    }
-
-    /// Return true if the file is little endian, false if it is big endian.
-    pub fn is_little_endian(file: &File) -> bool {
-        match file.ehdr.data {
-            elf::types::ELFDATA2LSB => true,
-            elf::types::ELFDATA2MSB => false,
-            otherwise => panic!("Unknown endianity: {}", otherwise),
-        }
-    }
-}
-
-#[cfg(target_os="macos")]
-mod obj {
-    extern crate mach_o;
-
-    use std::ffi::CString;
-    use std::fs;
-    use std::io::Read;
-    use std::mem;
-    use std::path::Path;
-
-    pub type File = Vec<u8>;
-
-    pub fn open<P>(path: P) -> File
-        where P: AsRef<Path>
-    {
-        let mut file = fs::File::open(path).expect("Could not open file");
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf).expect("Could not read file");
-        buf
-    }
-
-    // Translate the "." prefix to the "__" prefix used by OSX/Mach-O, eg
-    // ".debug_info" to "__debug_info".
-    fn translate_section_name(section_name: &str) -> CString {
-        let mut name = Vec::with_capacity(section_name.len() + 1);
-        name.push(b'_');
-        name.push(b'_');
-        for ch in &section_name.as_bytes()[1..] {
-            name.push(*ch);
-        }
-        unsafe { CString::from_vec_unchecked(name) }
-    }
-
-    pub fn get_section<'a>(file: &'a File, section_name: &str) -> Option<&'a [u8]> {
-        let parsed = mach_o::Header::new(&file[..]).expect("Could not parse macho-o file");
-
-        let segment_name = CString::new("__DWARF").unwrap();
-        let section_name = translate_section_name(section_name);
-        parsed.get_section(&segment_name, &section_name).map(|s| s.data())
-    }
-
-    pub fn is_little_endian(file: &File) -> bool {
-        let parsed = mach_o::Header::new(&file[..]).expect("Could not parse macho-o file");
-
-        let bytes = [1, 0, 0, 0u8];
-        let int: u32 = unsafe { mem::transmute(bytes) };
-        let native_byteorder_is_little = int == 1;
-
-        match (native_byteorder_is_little, parsed.is_native_byteorder()) {
-            (true, b) => b,
-            (false, b) => !b,
         }
     }
 }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -1,4 +1,5 @@
 extern crate gimli;
+extern crate object;
 
 use std::cell::Cell;
 use std::env;
@@ -8,8 +9,8 @@ fn main() {
         println!("{}", file_path);
         println!("");
 
-        let file = obj::open(&file_path);
-        if obj::is_little_endian(&file) {
+        let file = object::open(&file_path);
+        if object::is_little_endian(&file) {
             dump_file::<gimli::LittleEndian>(file);
         } else {
             dump_file::<gimli::BigEndian>(file);
@@ -17,13 +18,13 @@ fn main() {
     }
 }
 
-fn dump_file<Endian>(file: obj::File)
+fn dump_file<Endian>(file: object::File)
     where Endian: gimli::Endianity
 {
-    let debug_abbrev = obj::get_section(&file, ".debug_abbrev")
+    let debug_abbrev = object::get_section(&file, ".debug_abbrev")
         .expect("Does not have .debug_abbrev section");
     let debug_abbrev = gimli::DebugAbbrev::<Endian>::new(debug_abbrev);
-    let debug_str = obj::get_section(&file, ".debug_str")
+    let debug_str = object::get_section(&file, ".debug_str")
         .expect("Does not have .debug_str section");
     let debug_str = gimli::DebugStr::<Endian>::new(debug_str);
 
@@ -33,12 +34,12 @@ fn dump_file<Endian>(file: obj::File)
     dump_aranges::<Endian>(&file);
 }
 
-fn dump_info<Endian>(file: &obj::File,
+fn dump_info<Endian>(file: &object::File,
                      debug_abbrev: gimli::DebugAbbrev<Endian>,
                      debug_str: gimli::DebugStr<Endian>)
     where Endian: gimli::Endianity
 {
-    if let Some(debug_info) = obj::get_section(file, ".debug_info") {
+    if let Some(debug_info) = object::get_section(file, ".debug_info") {
         println!(".debug_info");
         println!("");
 
@@ -55,12 +56,12 @@ fn dump_info<Endian>(file: &obj::File,
     }
 }
 
-fn dump_types<Endian>(file: &obj::File,
+fn dump_types<Endian>(file: &object::File,
                       debug_abbrev: gimli::DebugAbbrev<Endian>,
                       debug_str: gimli::DebugStr<Endian>)
     where Endian: gimli::Endianity
 {
-    if let Some(debug_types) = obj::get_section(file, ".debug_types") {
+    if let Some(debug_types) = object::get_section(file, ".debug_types") {
         println!(".debug_types");
         println!("");
 
@@ -106,11 +107,11 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>,
     }
 }
 
-fn dump_line<Endian>(file: &obj::File, debug_abbrev: gimli::DebugAbbrev<Endian>)
+fn dump_line<Endian>(file: &object::File, debug_abbrev: gimli::DebugAbbrev<Endian>)
     where Endian: gimli::Endianity
 {
-    let debug_line = obj::get_section(file, ".debug_line");
-    let debug_info = obj::get_section(file, ".debug_info");
+    let debug_line = object::get_section(file, ".debug_line");
+    let debug_info = object::get_section(file, ".debug_info");
 
     if let (Some(debug_line), Some(debug_info)) = (debug_line, debug_info) {
         println!(".debug_line");
@@ -199,10 +200,10 @@ fn dump_line<Endian>(file: &obj::File, debug_abbrev: gimli::DebugAbbrev<Endian>)
     }
 }
 
-fn dump_aranges<Endian>(file: &obj::File)
+fn dump_aranges<Endian>(file: &object::File)
     where Endian: gimli::Endianity
 {
-    if let Some(debug_aranges) = obj::get_section(file, ".debug_aranges") {
+    if let Some(debug_aranges) = object::get_section(file, ".debug_aranges") {
         println!(".debug_aranges");
         let debug_aranges = gimli::DebugAranges::<Endian>::new(debug_aranges);
 
@@ -212,102 +213,6 @@ fn dump_aranges<Endian>(file: &obj::File)
                      arange.start(),
                      arange.len(),
                      arange.debug_info_offset());
-        }
-    }
-}
-
-// All cross platform / object file format compatibility stuff should
-// be contained in the `obj` module. Each supported platform / object
-// file format should implement the `obj` module with an identical
-// interface, but with the `pub type File` changing as needed. Hooray
-// duck typing!
-
-#[cfg(target_os="linux")]
-mod obj {
-    extern crate elf;
-    use std::path::Path;
-
-    /// The parsed object file type.
-    pub type File = elf::File;
-
-    /// Open and parse the object file at the given path.
-    pub fn open<P>(path: P) -> File
-        where P: AsRef<Path>
-    {
-        let path = path.as_ref();
-        elf::File::open_path(path).expect("Could not open file")
-    }
-
-    /// Get the contents of the section named `section_name`, if such
-    /// a section exists.
-    pub fn get_section<'a>(file: &'a File, section_name: &str) -> Option<&'a [u8]> {
-        file.sections
-            .iter()
-            .find(|s| s.shdr.name == section_name)
-            .map(|s| &s.data[..])
-    }
-
-    /// Return true if the file is little endian, false if it is big endian.
-    pub fn is_little_endian(file: &File) -> bool {
-        match file.ehdr.data {
-            elf::types::ELFDATA2LSB => true,
-            elf::types::ELFDATA2MSB => false,
-            otherwise => panic!("Unknown endianity: {}", otherwise),
-        }
-    }
-}
-
-#[cfg(target_os="macos")]
-mod obj {
-    extern crate mach_o;
-
-    use std::ffi::CString;
-    use std::fs;
-    use std::io::Read;
-    use std::mem;
-    use std::path::Path;
-
-    pub type File = Vec<u8>;
-
-    pub fn open<P>(path: P) -> File
-        where P: AsRef<Path>
-    {
-        let mut file = fs::File::open(path).expect("Could not open file");
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf).expect("Could not read file");
-        buf
-    }
-
-    // Translate the "." prefix to the "__" prefix used by OSX/Mach-O, eg
-    // ".debug_info" to "__debug_info".
-    fn translate_section_name(section_name: &str) -> CString {
-        let mut name = Vec::with_capacity(section_name.len() + 1);
-        name.push(b'_');
-        name.push(b'_');
-        for ch in &section_name.as_bytes()[1..] {
-            name.push(*ch);
-        }
-        unsafe { CString::from_vec_unchecked(name) }
-    }
-
-    pub fn get_section<'a>(file: &'a File, section_name: &str) -> Option<&'a [u8]> {
-        let parsed = mach_o::Header::new(&file[..]).expect("Could not parse macho-o file");
-
-        let segment_name = CString::new("__DWARF").unwrap();
-        let section_name = translate_section_name(section_name);
-        parsed.get_section(&segment_name, &section_name).map(|s| s.data())
-    }
-
-    pub fn is_little_endian(file: &File) -> bool {
-        let parsed = mach_o::Header::new(&file[..]).expect("Could not parse macho-o file");
-
-        let bytes = [1, 0, 0, 0u8];
-        let int: u32 = unsafe { mem::transmute(bytes) };
-        let native_byteorder_is_little = int == 1;
-
-        match (native_byteorder_is_little, parsed.is_native_byteorder()) {
-            (true, b) => b,
-            (false, b) => !b,
         }
     }
 }


### PR DESCRIPTION
The object crate is identical, but we don't have copy-paste all over the place
anymore.

Mostly just testing that travis ci still works with the migration to the gimli-rs github org...