### PR TITLE
Change AttributeValue::Addr to u64

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -451,29 +451,10 @@ impl<'input> Opcode<'input> {
                 constants::DW_LNE_end_sequence => Ok((rest, Opcode::EndSequence)),
 
                 constants::DW_LNE_set_address => {
-                    if instr_rest.len() < header.address_size as usize {
-                        return Err(parser::Error::UnexpectedEof);
-                    }
-
-                    match header.address_size {
-                        8 => {
-                            let address = Endian::read_u64(instr_rest);
-                            Ok((rest, Opcode::SetAddress(address)))
-                        }
-                        4 => {
-                            let address = Endian::read_u32(instr_rest) as u64;
-                            Ok((rest, Opcode::SetAddress(address)))
-                        }
-                        2 => {
-                            let address = Endian::read_u16(instr_rest) as u64;
-                            Ok((rest, Opcode::SetAddress(address)))
-                        }
-                        1 => {
-                            let address = instr_rest[0] as u64;
-                            Ok((rest, Opcode::SetAddress(address)))
-                        }
-                        otherwise => Err(parser::Error::UnsupportedAddressSize(otherwise)),
-                    }
+                    let (_, address) =
+                        try!(parser::parse_address(EndianBuf::<Endian>::new(instr_rest),
+                                                   header.address_size));
+                    Ok((rest, Opcode::SetAddress(address)))
                 }
 
                 constants::DW_LNE_define_file => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -245,6 +245,28 @@ pub fn parse_word<Endian>(input: EndianBuf<Endian>,
     }
 }
 
+/// Parse an address-sized integer, and return it as a `u64`.
+#[doc(hidden)]
+#[inline]
+pub fn parse_address<Endian>(input: EndianBuf<Endian>,
+                             address_size: u8)
+                             -> ParseResult<(EndianBuf<Endian>, u64)>
+    where Endian: Endianity
+{
+    if input.len() < address_size as usize {
+        Err(Error::UnexpectedEof)
+    } else {
+        let address = match address_size {
+            8 => Endian::read_u64(&input),
+            4 => Endian::read_u32(&input) as u64,
+            2 => Endian::read_u16(&input) as u64,
+            1 => input[0] as u64,
+            otherwise => return Err(Error::UnsupportedAddressSize(otherwise)),
+        };
+        Ok((input.range_from(address_size as usize..), address))
+    }
+}
+
 /// Parse a null-terminated slice from the input.
 #[doc(hidden)]
 #[inline]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1375,8 +1375,8 @@ impl<'input, 'abbrev, 'unit, Endian> DebuggingInformationEntry<'input, 'abbrev, 
 pub enum AttributeValue<'input, Endian>
     where Endian: Endianity
 {
-    /// A slice that is UnitHeaderHeader::address_size bytes long.
-    Addr(EndianBuf<'input, Endian>),
+    /// "Refers to some location in the address space of the described program."
+    Addr(u64),
 
     /// A slice of an arbitrary number of bytes.
     Block(EndianBuf<'input, Endian>),
@@ -1538,7 +1538,7 @@ fn parse_attribute<'input, 'unit, Endian>
                 continue;
             }
             constants::DW_FORM_addr => {
-                return take(unit.address_size() as usize, input.into()).map(|(rest, addr)| {
+                return parse_address(input, unit.address_size()).map(|(rest, addr)| {
                     let attr = Attribute {
                         name: spec.name(),
                         value: AttributeValue::Addr(addr),
@@ -1814,7 +1814,7 @@ fn test_parse_attribute_addr() {
     let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
     let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf32);
     let form = constants::DW_FORM_addr;
-    let value = AttributeValue::Addr(EndianBuf::new(&buf[..4]));
+    let value = AttributeValue::Addr(0x04030201);
     test_parse_attribute(&buf, 4, &unit, form, value);
 }
 
@@ -1823,7 +1823,7 @@ fn test_parse_attribute_addr8() {
     let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
     let unit = test_parse_attribute_unit::<LittleEndian>(8, Format::Dwarf32);
     let form = constants::DW_FORM_addr;
-    let value = AttributeValue::Addr(EndianBuf::new(&buf[..8]));
+    let value = AttributeValue::Addr(0x0807060504030201);
     test_parse_attribute(&buf, 8, &unit, form, value);
 }
 
@@ -2218,7 +2218,7 @@ fn test_attrs_iter() {
             assert_eq!(attr,
                        Attribute {
                            name: constants::DW_AT_low_pc,
-                           value: AttributeValue::Addr(EndianBuf::new(&[0x2a, 0x00, 0x00, 0x00])),
+                           value: AttributeValue::Addr(0x2a),
                        });
         }
         otherwise => {
@@ -2234,7 +2234,7 @@ fn test_attrs_iter() {
             assert_eq!(attr,
                        Attribute {
                            name: constants::DW_AT_high_pc,
-                           value: AttributeValue::Addr(EndianBuf::new(&[0x39, 0x05, 0x00, 0x00])),
+                           value: AttributeValue::Addr(0x539),
                        });
         }
         otherwise => {


### PR DESCRIPTION
I think this is the form that the user will always want. The alternative is to do this conversion in Attribute::value(), but that requires adding another enum variant, and I thought that would be confusing (what to call it?).