### PR TITLE
Make everything a FallibleIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.6.0"
 [dependencies]
 byteorder = "0.5.3"
 leb128 = "0.2.1"
+fallible-iterator = "0.1.2"
 
 [dev-dependencies]
 getopts = "0.2"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,6 @@ extern crate test;
 
 use gimli::{DebugAbbrev, DebugAranges, DebugInfo, DebugLine, DebugLineOffset, DebugPubNames,
             DebugPubTypes, LineNumberProgramHeader, LittleEndian, StateMachine};
-
 use std::env;
 use std::fs::File;
 use std::io::Read;
@@ -52,8 +51,8 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
     b.iter(|| {
         let debug_info = DebugInfo::<LittleEndian>::new(&debug_info);
 
-        for unit in debug_info.units() {
-            let unit = unit.expect("Should parse compilation unit");
+        let mut iter = debug_info.units();
+        while let Some(unit) = iter.next().expect("Should parse compilation unit") {
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Should parse abbreviations");
 
@@ -75,7 +74,7 @@ fn bench_parsing_debug_aranges(b: &mut test::Bencher) {
 
     b.iter(|| {
         let mut aranges = debug_aranges.items();
-        while let Some(arange) = aranges.next_entry().expect("Should parse arange OK") {
+        while let Some(arange) = aranges.next().expect("Should parse arange OK") {
             test::black_box(arange);
         }
     });
@@ -88,7 +87,7 @@ fn bench_parsing_debug_pubnames(b: &mut test::Bencher) {
 
     b.iter(|| {
         let mut pubnames = debug_pubnames.items();
-        while let Some(pubname) = pubnames.next_entry().expect("Should parse pubname OK") {
+        while let Some(pubname) = pubnames.next().expect("Should parse pubname OK") {
             test::black_box(pubname);
         }
     });
@@ -101,7 +100,7 @@ fn bench_parsing_debug_types(b: &mut test::Bencher) {
 
     b.iter(|| {
         let mut pubtypes = debug_pubtypes.items();
-        while let Some(pubtype) = pubtypes.next_entry().expect("Should parse pubtype OK") {
+        while let Some(pubtype) = pubtypes.next().expect("Should parse pubtype OK") {
             test::black_box(pubtype);
         }
     });

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -49,7 +49,7 @@ fn entry_offsets_for_addresses<Endian>(file: &object::File,
     let mut aranges = aranges.items();
 
     let mut dies: Vec<Option<gimli::DebugInfoOffset>> = (0..addrs.len()).map(|_| None).collect();
-    while let Some(arange) = aranges.next_entry().expect("Should parse arange OK") {
+    while let Some(arange) = aranges.next().expect("Should parse arange OK") {
         let start = arange.start();
         let end = start + arange.len();
 

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -50,9 +50,8 @@ fn dump_info<Endian>(file: &object::File,
 
         let debug_info = gimli::DebugInfo::<Endian>::new(&debug_info);
 
-        for unit in debug_info.units() {
-            let unit = unit.expect("Should parse the unit OK");
-
+        let mut iter = debug_info.units();
+        while let Some(unit) = iter.next().expect("Should parse compilation unit") {
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Error parsing abbreviations");
 
@@ -72,9 +71,8 @@ fn dump_types<Endian>(file: &object::File,
 
         let debug_types = gimli::DebugTypes::<Endian>::new(&debug_types);
 
-        for unit in debug_types.units() {
-            let unit = unit.expect("Should parse the unit OK");
-
+        let mut iter = debug_types.units();
+        while let Some(unit) = iter.next().expect("Should parse the unit OK") {
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Error parsing abbreviations");
 
@@ -125,9 +123,8 @@ fn dump_line<Endian>(file: &object::File, debug_abbrev: gimli::DebugAbbrev<Endia
         let debug_line = gimli::DebugLine::<Endian>::new(&debug_line);
         let debug_info = gimli::DebugInfo::<Endian>::new(&debug_info);
 
-        for unit in debug_info.units() {
-            let unit = unit.expect("Should parse unit header OK");
-
+        let mut iter = debug_info.units();
+        while let Some(unit) = iter.next().expect("Should parse unit header OK") {
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Error parsing abbreviations");
 
@@ -255,7 +252,7 @@ fn dump_aranges<Endian>(file: &object::File)
         let debug_aranges = gimli::DebugAranges::<Endian>::new(debug_aranges);
 
         let mut aranges = debug_aranges.items();
-        while let Some(arange) = aranges.next_entry().expect("Should parse arange OK") {
+        while let Some(arange) = aranges.next().expect("Should parse arange OK") {
             println!("arange starts at 0x{:08x}, length of 0x{:08x}, cu_die_offset = {:?}",
                      arange.start(),
                      arange.len(),

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -182,7 +182,8 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
 /// found in the `.debug_aranges` section.
 ///
 /// Provides:
-///   new(input: EndianBuf<'input, Endian>) -> DebugAranges<'input, Endian>
+///
+/// * `new(input: EndianBuf<'input, Endian>) -> DebugAranges<'input, Endian>`
 ///
 ///   Construct a new `DebugAranges` instance from the data in the `.debug_aranges`
 ///   section.
@@ -195,11 +196,11 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
 ///   use gimli::{DebugAranges, LittleEndian};
 ///
 ///   # let buf = [];
-///   # let read_debug_aranges_section_somehow = || &buf;
-///   let debug_aranges = DebugAranges::<LittleEndian>::new(read_debug_aranges_section_somehow());
+///   # let read_debug_aranges_section = || &buf;
+///   let debug_aranges = DebugAranges::<LittleEndian>::new(read_debug_aranges_section());
 ///   ```
 ///
-///   items(&self) -> ArangeEntryIter<'input, Endian>
+/// * `items(&self) -> ArangeEntryIter<'input, Endian>`
 ///
 ///   Iterate the aranges in the `.debug_aranges` section.
 ///
@@ -207,12 +208,12 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
 ///   use gimli::{DebugAranges, LittleEndian};
 ///
 ///   # let buf = [];
-///   # let read_debug_aranges_section_somehow = || &buf;
-///   let debug_aranges = DebugAranges::<LittleEndian>::new(read_debug_aranges_section_somehow());
+///   # let read_debug_aranges_section = || &buf;
+///   let debug_aranges = DebugAranges::<LittleEndian>::new(read_debug_aranges_section());
 ///
 ///   let mut iter = debug_aranges.items();
-///   while let Some(arange) = iter.next_entry().unwrap() {
-///     println!("arange starts at {}, has length {}", arange.start(), arange.len());
+///   while let Some(arange) = iter.next().unwrap() {
+///       println!("arange starts at {}, has length {}", arange.start(), arange.len());
 ///   }
 ///   ```
 pub type DebugAranges<'input, Endian> = DebugLookup<'input, Endian, ArangeParser<'input, Endian>>;
@@ -220,14 +221,18 @@ pub type DebugAranges<'input, Endian> = DebugLookup<'input, Endian, ArangeParser
 /// An iterator over the aranges from a .debug_aranges section.
 ///
 /// Provides:
-///   next_entry(self: &mut) -> ParseResult<Option<ArangeEntry>>
+///
+/// * `next(self: &mut) -> ParseResult<Option<ArangeEntry>>`
 ///
 ///   Advance the iterator and return the next arange.
 ///
-///   Returns the newly parsed arange as `Ok(Some(arange))`. Returns
-///   `Ok(None)` when iteration is complete and all aranges have already been
-///   parsed and yielded. If an error occurs while parsing the next arange,
-///   then this error is returned on all subsequent calls as `Err(e)`.
+///   Returns the newly parsed arange as `Ok(Some(arange))`. Returns `Ok(None)`
+///   when iteration is complete and all aranges have already been parsed and
+///   yielded. If an error occurs while parsing the next arange, then this error
+///   is returned on all subsequent calls as `Err(e)`.
+///
+///   Can be [used with
+///   `FallibleIterator`](./index.html#using-with-fallibleiterator).
 pub type ArangeEntryIter<'input, Endian> = LookupEntryIter<'input,
                                                            Endian,
                                                            ArangeParser<'input, Endian>>;

--- a/src/line.rs
+++ b/src/line.rs
@@ -240,6 +240,9 @@ impl<'input, Endian> StateMachine<'input, Endian>
     /// is complete, and there are no more new rows in the line number matrix,
     /// then `Ok(None)` is returned. If there was an error parsing an opcode,
     /// then `Err(e)` is returned.
+    ///
+    /// Unfortunately, the `'me` lifetime means that this cannot be a
+    /// `FallibleIterator`.
     pub fn next_row<'me>(&'me mut self)
                          -> parser::ParseResult<Option<LineNumberRow<'me, 'input, Endian>>> {
         // Perform any reset that was required after copying the previous row.
@@ -606,6 +609,9 @@ impl<'input, Endian> OpcodesIter<'input, Endian>
     /// `Ok(None)` when iteration is complete and all opcodes have already been
     /// parsed and yielded. If an error occurs while parsing the next attribute,
     /// then this error is returned on all subsequent calls as `Err(e)`.
+    ///
+    /// Unfortunately, the `header` parameter means that this cannot be a
+    /// `FallibleIterator`.
     pub fn next_opcode(&mut self,
                        header: &LineNumberProgramHeader<'input, Endian>)
                        -> parser::ParseResult<Option<Opcode<'input>>> {

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -91,7 +91,8 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for NamesSwitch<'input, 
 /// found in the `.debug_pubnames` section.
 ///
 /// Provides:
-///   new(input: EndianBuf<'input, Endian>) -> DebugPubNames<'input, Endian>
+///
+/// * `new(input: EndianBuf<'input, Endian>) -> DebugPubNames<'input, Endian>`
 ///
 ///   Construct a new `DebugPubNames` instance from the data in the `.debug_pubnames`
 ///   section.
@@ -109,7 +110,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for NamesSwitch<'input, 
 ///       DebugPubNames::<LittleEndian>::new(read_debug_pubnames_section_somehow());
 ///   ```
 ///
-///   items(&self) -> PubNamesEntryIter<'input, Endian>
+/// * `items(&self) -> PubNamesEntryIter<'input, Endian>`
 ///
 ///   Iterate the pubnames in the `.debug_pubnames` section.
 ///
@@ -122,7 +123,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for NamesSwitch<'input, 
 ///       DebugPubNames::<LittleEndian>::new(read_debug_pubnames_section_somehow());
 ///
 ///   let mut iter = debug_pubnames.items();
-///   while let Some(pubname) = iter.next_entry().unwrap() {
+///   while let Some(pubname) = iter.next().unwrap() {
 ///     println!("pubname {} found!", pubname.name().to_string_lossy());
 ///   }
 ///   ```
@@ -135,7 +136,8 @@ pub type DebugPubNames<'input, Endian> = DebugLookup<'input,
 /// An iterator over the pubnames from a .debug_pubnames section.
 ///
 /// Provides:
-///   next_entry(self: &mut) -> ParseResult<Option<PubNamesEntry>>
+///
+/// * `next_entry(self: &mut) -> ParseResult<Option<PubNamesEntry>>`
 ///
 ///   Advance the iterator and return the next pubname.
 ///
@@ -143,6 +145,9 @@ pub type DebugPubNames<'input, Endian> = DebugLookup<'input,
 ///   `Ok(None)` when iteration is complete and all pubnames have already been
 ///   parsed and yielded. If an error occurs while parsing the next pubname,
 ///   then this error is returned on all subsequent calls as `Err(e)`.
+///
+///   Can be [used with
+///   `FallibleIterator`](./index.html#using-with-fallibleiterator).
 pub type PubNamesEntryIter<'input, Endian> = LookupEntryIter<'input,
                                                              Endian,
                                                              PubStuffParser<'input,

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -90,7 +90,8 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
 /// found in the `.debug_types` section.
 ///
 /// Provides:
-///   new(input: EndianBuf<'input, Endian>) -> DebugPubTypes<'input, Endian>
+///
+/// * `new(input: EndianBuf<'input, Endian>) -> DebugPubTypes<'input, Endian>`
 ///
 ///   Construct a new `DebugPubTypes` instance from the data in the `.debug_pubtypes`
 ///   section.
@@ -103,12 +104,11 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
 ///   use gimli::{DebugPubTypes, LittleEndian};
 ///
 ///   # let buf = [];
-///   # let read_debug_pubtypes_section_somehow = || &buf;
-///   let debug_pubtypes =
-///       DebugPubTypes::<LittleEndian>::new(read_debug_pubtypes_section_somehow());
+///   # let read_debug_pubtypes_somehow = || &buf;
+///   let debug_pubtypes = DebugPubTypes::<LittleEndian>::new(read_debug_pubtypes_somehow());
 ///   ```
 ///
-///   items(&self) -> PubTypesEntryIter<'input, Endian>
+/// * `items(&self) -> PubTypesEntryIter<'input, Endian>`
 ///
 ///   Iterate the pubtypes in the `.debug_pubtypes` section.
 ///
@@ -121,7 +121,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
 ///       DebugPubTypes::<LittleEndian>::new(read_debug_pubtypes_section_somehow());
 ///
 ///   let mut iter = debug_pubtypes.items();
-///   while let Some(pubtype) = iter.next_entry().unwrap() {
+///   while let Some(pubtype) = iter.next().unwrap() {
 ///     println!("pubtype {} found!", pubtype.name().to_string_lossy());
 ///   }
 ///   ```
@@ -134,7 +134,8 @@ pub type DebugPubTypes<'input, Endian> = DebugLookup<'input,
 /// An iterator over the pubtypes from a .debug_pubtypes section.
 ///
 /// Provides:
-///   next_entry(self: &mut) -> ParseResult<Option<PubTypesEntry>>
+///
+/// * `next_entry(self: &mut) -> ParseResult<Option<PubTypesEntry>>`
 ///
 ///   Advance the iterator and return the next pubtype.
 ///
@@ -142,6 +143,9 @@ pub type DebugPubTypes<'input, Endian> = DebugLookup<'input,
 ///   `Ok(None)` when iteration is complete and all pubtypes have already been
 ///   parsed and yielded. If an error occurs while parsing the next pubtype,
 ///   then this error is returned on all subsequent calls as `Err(e)`.
+///
+///   Can be [used with
+///   `FallibleIterator`](./index.html#using-with-fallibleiterator).
 pub type PubTypesEntryIter<'input, Endian> = LookupEntryIter<'input,
                                                              Endian,
                                                              PubStuffParser<'input,

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -30,8 +30,8 @@ fn test_parse_self_debug_info() {
     let debug_abbrev = read_section("debug_abbrev");
     let debug_abbrev = DebugAbbrev::<LittleEndian>::new(&debug_abbrev);
 
-    for unit in debug_info.units() {
-        let unit = unit.expect("Should parse compilation unit");
+    let mut iter = debug_info.units();
+    while let Some(unit) = iter.next().expect("Should parse compilation unit") {
         let abbrevs = unit.abbreviations(debug_abbrev)
             .expect("Should parse abbreviations");
 
@@ -58,9 +58,8 @@ fn test_parse_self_debug_line() {
     let debug_line = read_section("debug_line");
     let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
 
-    for unit in debug_info.units() {
-        let unit = unit.expect("Should parse the unit OK");
-
+    let mut iter = debug_info.units();
+    while let Some(unit) = iter.next().expect("Should parse compilation unit") {
         let abbrevs = unit.abbreviations(debug_abbrev)
             .expect("Should parse abbreviations");
 
@@ -88,7 +87,7 @@ fn test_parse_self_debug_aranges() {
     let debug_aranges = DebugAranges::<LittleEndian>::new(&debug_aranges);
 
     let mut aranges = debug_aranges.items();
-    while let Some(_) = aranges.next_entry().expect("Should parse arange OK") {
+    while let Some(_) = aranges.next().expect("Should parse arange OK") {
         // Not really anything else we can check right now.
     }
 }
@@ -99,7 +98,7 @@ fn test_parse_self_debug_pubnames() {
     let debug_pubnames = DebugPubNames::<LittleEndian>::new(&debug_pubnames);
 
     let mut pubnames = debug_pubnames.items();
-    while let Some(_) = pubnames.next_entry().expect("Should parse pubname OK") {
+    while let Some(_) = pubnames.next().expect("Should parse pubname OK") {
         // Not really anything else we can check right now.
     }
 }
@@ -110,7 +109,7 @@ fn test_parse_self_debug_pubtypes() {
     let debug_pubtypes = DebugPubTypes::<LittleEndian>::new(&debug_pubtypes);
 
     let mut pubtypes = debug_pubtypes.items();
-    while let Some(_) = pubtypes.next_entry().expect("Should parse pubtype OK") {
+    while let Some(_) = pubtypes.next().expect("Should parse pubtype OK") {
         // Not really anything else we can check right now.
     }
 }


### PR DESCRIPTION
* Change `fn next_foo(&mut self) -> ParseResult<Option<T>>` to
  `fn next(...) -> ...`.

* Add a `FallibleIterator` implementation for that method. By still having a
  non-trait-impl `next` method we don't force API consumers to
  `use FallibleIterator;` unless they want the helper methods.

* Change existing `Iterator<Item=ParseResult<T>>` implementations over to
  `FallibleIterator<Item=T>` implementations.

Fixes #44.

Look good @philipc ?