### PR TITLE
.debug_aranges fixes

### DIFF
--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -50,8 +50,8 @@ fn entry_offsets_for_addresses<Endian>(file: &object::File,
 
     let mut dies: Vec<Option<gimli::DebugInfoOffset>> = (0..addrs.len()).map(|_| None).collect();
     while let Some(arange) = aranges.next().expect("Should parse arange OK") {
-        let start = arange.start();
-        let end = start + arange.len();
+        let start = arange.address();
+        let end = start + arange.length();
 
         for (i, addr) in addrs.iter().enumerate() {
             if *addr >= start && *addr < end {

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -171,18 +171,18 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
         let (rest, address) = try!(parse_address(rest, address_size));
         let (rest, length) = try!(parse_address(rest, address_size));
 
-        Ok((rest,
-            match (segment, address, length) {
-            (0, 0, 0) => None,
+        match (segment, address, length) {
+            (0, 0, 0) => Ok((EndianBuf::new(&[]), None)),
             _ => {
-                Some(ArangeEntry {
+                Ok((rest,
+                    Some(ArangeEntry {
                     segment: segment,
                     address: address,
                     length: length,
                     header: header.clone(),
-                })
+                })))
             }
-        }))
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //!     // `DebugAranges::items` returns a `FallibleIterator`!
 //!     aranges.items()
 //!         // `map` is provided by `FallibleIterator`!
-//!         .map(|arange| arange.len())
+//!         .map(|arange| arange.length())
 //!         // `fold` is provided by `FallibleIterator`!
 //!         .fold(0, |sum, len| sum + len)
 //! }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -919,7 +919,8 @@ impl<'input, Endian> UnitHeader<'input, Endian>
         self.format
     }
 
-    fn header_size(&self) -> usize {
+    /// The serialized size of the header for this compilation unit.
+    pub fn header_size(&self) -> usize {
         Self::size_of_header(self.format)
     }
 


### PR DESCRIPTION
- fix handling of zero tuples
- change our dwarfdump clone to closer match the real dwarfdump

I'm not 100% sure that the zero tuple handling is correct yet. Both dwarfdump and binutils-readelf display these zero tuples. Both llvm-readelf and elfutils-readelf stop reading at the zero tuple. I haven't been able to find anything that actually uses `.debug_aranges` though, so I can't see how clients of the libraries expect to be able to handle them. As far as I can tell, not even the real addr2line uses `.debug_aranges`, although it's a bit hard to follow the code so I'm not sure.