### PR TITLE
Add `NativeEndian` as a type alias for `BigEndian` or `LittleEndian` depending on target platform

### DIFF
--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -82,6 +82,12 @@ impl byteorder::ByteOrder for BigEndian {
 
 impl Endianity for BigEndian {}
 
+/// The native endianity for the target platform.
+#[cfg(target_endian = "little")]
+pub type NativeEndian = LittleEndian;
+#[cfg(target_endian = "big")]
+pub type NativeEndian = BigEndian;
+
 /// A `&[u8]` slice with compile-time endianity metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EndianBuf<'input, Endian>(pub &'input [u8], pub PhantomData<Endian>)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod constants;
 pub use constants::*;
 
 mod endianity;
-pub use endianity::{Endianity, EndianBuf, LittleEndian, BigEndian};
+pub use endianity::{Endianity, EndianBuf, LittleEndian, BigEndian, NativeEndian};
 
 mod parser;
 pub use parser::{Error, ParseResult, Format};


### PR DESCRIPTION
It's a small convenience.

r? @philipc 