### PR TITLE
dwarfdump fixes

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -217,7 +217,7 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
             println!("<0x{:08x}>", offset);
         }
         gimli::AttributeValue::DebugInfoRef(gimli::DebugInfoOffset(offset)) => {
-            println!("0x{:08x}", offset);
+            println!("<GOFF=0x{:08x}>", offset);
         }
         gimli::AttributeValue::DebugLineRef(gimli::DebugLineOffset(offset)) => {
             println!("0x{:08x}", offset);
@@ -227,13 +227,13 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
         }
         gimli::AttributeValue::DebugStrRef(offset) => {
             if let Ok(s) = debug_str.get_str(offset) {
-                println!("\"{}\"", s.to_string_lossy());
+                println!("{}", s.to_string_lossy());
             } else {
                 println!("{:?}", value);
             }
         }
         gimli::AttributeValue::String(s) => {
-            println!("\"{}\"", s.to_string_lossy());
+            println!("{}", s.to_string_lossy());
         }
         gimli::AttributeValue::Encoding(value) => {
             println!("{}", value);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -204,10 +204,11 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
             };
         }
         gimli::AttributeValue::Flag(true) => {
+            // We don't record what the value was, so assume 1.
             println!("yes(1)");
         }
         gimli::AttributeValue::Flag(false) => {
-            println!("no(0)");
+            println!("no");
         }
         gimli::AttributeValue::SecOffset(offset) => {
             println!("0x{:08x}", offset);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -156,6 +156,7 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>,
     let mut depth = 0;
     while let Some((delta_depth, entry)) = entries.next_dfs().expect("Should parse next dfs") {
         depth += delta_depth;
+        assert!(depth >= 0);
         let indent = depth as usize * 2 + 2;
         println!("<{:2}><0x{:08x}>{:indent$}{}",
                  depth,

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -292,9 +292,6 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
         gimli::AttributeValue::Ordering(value) => {
             println!("{}", value);
         }
-        gimli::AttributeValue::DiscrList(value) => {
-            println!("{}", value);
-        }
     }
 }
 

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -185,6 +185,12 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
         gimli::AttributeValue::Addr(address) => {
             println!("0x{:08x}", address);
         }
+        gimli::AttributeValue::Block(_) => {
+            println!("{:?}", value);
+        }
+        gimli::AttributeValue::Data(_) => {
+            println!("{:?}", value);
+        }
         gimli::AttributeValue::Sdata(data) => {
             println!("0x{:08x}", data);
         }
@@ -202,6 +208,9 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
                     println!("0x{:08x}", data);
                 }
             };
+        }
+        gimli::AttributeValue::Exprloc(_) => {
+            println!("{:?}", value);
         }
         gimli::AttributeValue::Flag(true) => {
             // We don't record what the value was, so assume 1.
@@ -221,6 +230,18 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
         }
         gimli::AttributeValue::DebugLineRef(gimli::DebugLineOffset(offset)) => {
             println!("0x{:08x}", offset);
+        }
+        gimli::AttributeValue::DebugLocRef(gimli::DebugLocOffset(offset)) => {
+            println!("<loclist at offset 0x{:08x} with {} entries follows>",
+                     offset,
+                     0);
+            // TODO: print loclist
+        }
+        gimli::AttributeValue::DebugMacinfoRef(gimli::DebugMacinfoOffset(offset)) => {
+            println!("{}", offset);
+        }
+        gimli::AttributeValue::DebugRangesRef(gimli::DebugRangesOffset(offset)) => {
+            println!("{}", offset);
         }
         gimli::AttributeValue::DebugTypesRef(gimli::DebugTypesOffset(offset)) => {
             println!("0x{:08x}", offset);
@@ -274,7 +295,6 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
         gimli::AttributeValue::DiscrList(value) => {
             println!("{}", value);
         }
-        _ => println!("{:?}", value),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub use endianity::{Endianity, EndianBuf, LittleEndian, BigEndian, NativeEndian}
 
 mod parser;
 pub use parser::{Error, ParseResult, Format};
-pub use parser::{DebugLocOffset, DebugMacinfoOffset, UnitOffset};
+pub use parser::{DebugLocOffset, DebugMacinfoOffset, DebugRangesOffset, UnitOffset};
 pub use parser::{DebugInfo, DebugInfoOffset, UnitHeadersIter, UnitHeader};
 pub use parser::{DebugTypes, DebugTypesOffset, TypeUnitHeadersIter, TypeUnitHeader};
 pub use parser::{EntriesCursor, DebuggingInformationEntry, AttrsIter, Attribute, AttributeValue};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1457,9 +1457,6 @@ pub enum AttributeValue<'input, Endian>
 
     /// The value of a `DW_AT_ordering` attribute.
     Ordering(constants::DwOrd),
-
-    /// The value of a `DW_AT_discr_list` attribute.
-    DiscrList(constants::DwDsc),
 }
 
 /// An attribute in a `DebuggingInformationEntry`, consisting of a name and
@@ -1625,11 +1622,6 @@ impl<'input, Endian> Attribute<'input, Endian>
             }
             // DW_AT_declaration: flag
             // DW_AT_discr_list: block
-            constants::DW_AT_discr_list => {
-                if let Some(value) = self.u8_value() {
-                    return AttributeValue::DiscrList(constants::DwDsc(value));
-                }
-            }
             // DW_AT_encoding: constant
             constants::DW_AT_encoding => {
                 if let Some(value) = self.u8_value() {


### PR DESCRIPTION
Fix various things I found while running gimli-dwarfdump on the libdwarf regression tests.

Also filled out more of `Attribute::value`. Heavy macro usage, but I think it is more understandable that way. No tests for this yet... I'm reluctant to add them because I don't think they would provide any value in this case.