### PR TITLE
DW_FORM_ref_sig8 holds a type signature, not a .debug_types offset

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -243,7 +243,7 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>, debug_str: gimli::Deb
         gimli::AttributeValue::DebugRangesRef(gimli::DebugRangesOffset(offset)) => {
             println!("{}", offset);
         }
-        gimli::AttributeValue::DebugTypesRef(gimli::DebugTypesOffset(offset)) => {
+        gimli::AttributeValue::DebugTypesRef(gimli::DebugTypeSignature(offset)) => {
             println!("0x{:08x}", offset);
         }
         gimli::AttributeValue::DebugStrRef(offset) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,8 @@ mod parser;
 pub use parser::{Error, ParseResult, Format};
 pub use parser::{DebugLocOffset, DebugMacinfoOffset, DebugRangesOffset, UnitOffset};
 pub use parser::{DebugInfo, DebugInfoOffset, UnitHeadersIter, UnitHeader};
-pub use parser::{DebugTypes, DebugTypesOffset, TypeUnitHeadersIter, TypeUnitHeader};
+pub use parser::{DebugTypes, DebugTypesOffset, DebugTypeSignature, TypeUnitHeadersIter,
+                 TypeUnitHeader};
 pub use parser::{EntriesCursor, DebuggingInformationEntry, AttrsIter, Attribute, AttributeValue};
 
 mod abbrev;


### PR DESCRIPTION
Fixes #85.

The bug is that DW_FORM_ref_sig8 holds a type signature, but
parse_attribute converts it to a DebugTypesOffset.  This patch
introduces a new DebugTypeSignature and changes parse_attribute to use
it.  It also updates TypeUnitHeader to use the new type.