### PR TITLE
Add SectionData/SectionOffset abstractions

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -246,8 +246,8 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>,
         gimli::AttributeValue::UnitRef(gimli::UnitOffset(offset)) => {
             println!("<0x{:08x}>", offset);
         }
-        gimli::AttributeValue::DebugInfoRef(gimli::DebugInfoOffset(offset)) => {
-            println!("<GOFF=0x{:08x}>", offset);
+        gimli::AttributeValue::DebugInfoRef(offset) => {
+            println!("<GOFF=0x{:08x}>", offset.0);
         }
         gimli::AttributeValue::DebugLineRef(gimli::DebugLineOffset(offset)) => {
             println!("0x{:08x}", offset);
@@ -398,11 +398,11 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<Endian>, data: &[u8])
         }
         gimli::Operation::Call { offset } => {
             match offset {
-                gimli::DieReference::UnitRef(gimli::UnitOffset(offset)) => {
-                    print!(" 0x{:08x}", offset);
+                gimli::DieReference::UnitRef(offset) => {
+                    print!(" 0x{:08x}", offset.0);
                 }
-                gimli::DieReference::DebugInfoRef(gimli::DebugInfoOffset(offset)) => {
-                    print!(" 0x{:08x}", offset);
+                gimli::DieReference::DebugInfoRef(offset) => {
+                    print!(" 0x{:08x}", offset.0);
                 }
             }
         }
@@ -569,7 +569,7 @@ fn dump_aranges<Endian>(file: &object::File)
         let debug_aranges = gimli::DebugAranges::<Endian>::new(debug_aranges);
         let debug_info = gimli::DebugInfo::<Endian>::new(debug_info);
 
-        let mut cu_die_offset = gimli::DebugInfoOffset(0);
+        let mut cu_die_offset = gimli::DebugInfoOffset::new(0);
         let mut prev_cu_offset = None;
         let mut aranges = debug_aranges.items();
         while let Some(arange) = aranges.next().expect("Should parse arange OK") {
@@ -577,7 +577,7 @@ fn dump_aranges<Endian>(file: &object::File)
             if Some(cu_offset) != prev_cu_offset {
                 let cu = debug_info.header_from_offset(cu_offset)
                     .expect("Should parse unit header OK");
-                cu_die_offset = gimli::DebugInfoOffset(cu_offset.0 + cu.header_size() as u64);
+                cu_die_offset = gimli::DebugInfoOffset::new(cu_offset.0 + cu.header_size() as u64);
                 prev_cu_offset = Some(cu_offset);
             }
             if let Some(segment) = arange.segment() {

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -4,7 +4,7 @@ use endianity::{Endianity, EndianBuf};
 use lookup::{LookupParser, LookupEntryIter, DebugLookup};
 use parser::{parse_address_size, parse_initial_length, parse_u16, parse_address, Error, Format,
              ParseResult};
-use unit::{DebugInfoOffset, parse_debug_info_offset};
+use unit::DebugInfoOffset;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -121,7 +121,7 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
             return Err(Error::UnknownVersion);
         }
 
-        let (rest, offset) = try!(parse_debug_info_offset(rest, format));
+        let (rest, offset) = try!(DebugInfoOffset::parse(rest, format));
         let (rest, address_size) = try!(parse_address_size(rest));
         let (rest, segment_size) = try!(parse_address_size(rest));
 
@@ -307,7 +307,7 @@ mod tests {
                        format: Format::Dwarf32,
                        length: 0x20,
                        version: 2,
-                       offset: DebugInfoOffset(0x04030201),
+                       offset: DebugInfoOffset::new(0x04030201),
                        address_size: 8,
                        segment_size: 4,
                    });
@@ -319,7 +319,7 @@ mod tests {
             format: Format::Dwarf32,
             length: 0,
             version: 2,
-            offset: DebugInfoOffset(0),
+            offset: DebugInfoOffset::new(0),
             address_size: 4,
             segment_size: 0,
         });
@@ -344,7 +344,7 @@ mod tests {
             format: Format::Dwarf32,
             length: 0,
             version: 2,
-            offset: DebugInfoOffset(0),
+            offset: DebugInfoOffset::new(0),
             address_size: 4,
             segment_size: 8,
         });
@@ -378,7 +378,7 @@ mod tests {
             format: Format::Dwarf32,
             length: 0,
             version: 2,
-            offset: DebugInfoOffset(0),
+            offset: DebugInfoOffset::new(0),
             address_size: 4,
             segment_size: 0,
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,9 @@ pub use pubnames::{DebugPubNames, PubNamesEntryIter, PubNamesEntry};
 mod pubtypes;
 pub use pubtypes::{DebugPubTypes, PubTypesEntryIter, PubTypesEntry};
 
+mod section;
+pub use section::{SectionData, SectionOffset};
+
 mod str;
 pub use str::*;
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -4,7 +4,7 @@
 
 use constants;
 use parser::{Error, ParseResult, Format, parse_u8e, parse_i8e, parse_u16, parse_i16, parse_u32,
-             parse_i32, parse_u64, parse_i64, parse_unsigned_lebe, parse_signed_lebe, parse_word,
+             parse_i32, parse_u64, parse_i64, parse_unsigned_lebe, parse_signed_lebe,
              parse_address, parse_length_uleb_value};
 use endianity::{Endianity, EndianBuf};
 use unit::{UnitOffset, DebugInfoOffset};
@@ -803,9 +803,8 @@ impl<'input, Endian> Operation<'input, Endian>
                     Operation::Call { offset: DieReference::UnitRef(UnitOffset(value as u64)) }))
             }
             constants::DW_OP_call_ref => {
-                let (newbytes, value) = try!(parse_word(bytes, format));
-                Ok((newbytes,
-                    Operation::Call { offset: DieReference::DebugInfoRef(DebugInfoOffset(value)) }))
+                let (newbytes, value) = try!(DebugInfoOffset::parse(bytes, format));
+                Ok((newbytes, Operation::Call { offset: DieReference::DebugInfoRef(value) }))
             }
             constants::DW_OP_form_tls_address => Ok((bytes, Operation::TLS)),
             constants::DW_OP_call_frame_cfa => Ok((bytes, Operation::CallFrameCFA)),
@@ -1118,7 +1117,7 @@ fn test_op_parse_fivebyte() {
           Operation::Call { offset: DieReference::UnitRef(UnitOffset(0x12345678)) }),
          (constants::DW_OP_call_ref,
           0x12345678,
-          Operation::Call { offset: DieReference::DebugInfoRef(DebugInfoOffset(0x12345678)) })];
+          Operation::Call { offset: DieReference::DebugInfoRef(DebugInfoOffset::new(0x12345678)) })];
 
     for item in inputs.iter() {
         let (op, mut val, ref expect) = *item;
@@ -1157,7 +1156,7 @@ fn test_op_parse_ninebyte() {
                   (constants::DW_OP_call_ref,
                    0x1234567812345678,
                    Operation::Call {
-                      offset: DieReference::DebugInfoRef(DebugInfoOffset(0x1234567812345678)),
+                      offset: DieReference::DebugInfoRef(DebugInfoOffset::new(0x1234567812345678)),
                   })];
 
     for item in inputs.iter() {

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -3,7 +3,7 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, ParseResult};
-use unit::{DebugInfoOffset, parse_debug_info_offset};
+use unit::DebugInfoOffset;
 use std::ffi;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -80,7 +80,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for NamesSwitch<'input, 
     fn parse_offset(input: EndianBuf<Endian>,
                     format: Format)
                     -> ParseResult<(EndianBuf<Endian>, Self::Offset)> {
-        parse_debug_info_offset(input, format)
+        DebugInfoOffset::parse(input, format)
     }
 
     fn format_from(header: &PubNamesHeader) -> Format {

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -3,7 +3,7 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, ParseResult};
-use unit::{DebugTypesOffset, parse_debug_types_offset};
+use unit::DebugTypesOffset;
 use std::ffi;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -79,7 +79,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
     fn parse_offset(input: EndianBuf<Endian>,
                     format: Format)
                     -> ParseResult<(EndianBuf<Endian>, Self::Offset)> {
-        parse_debug_types_offset(input, format)
+        DebugTypesOffset::parse(input, format)
     }
 
     fn format_from(header: &PubTypesHeader) -> Format {

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,0 +1,105 @@
+use endianity::{Endianity, EndianBuf};
+use parser::{Format, ParseResult, parse_word};
+use std::marker::PhantomData;
+
+/// The `SectionData` struct represents the data in a DWARF section.
+#[derive(Debug, Clone, Copy)]
+pub struct SectionData<'input, Endian, Section>
+    where Endian: Endianity
+{
+    data: EndianBuf<'input, Endian>,
+    section: PhantomData<Section>,
+}
+
+impl<'input, Endian, Section> SectionData<'input, Endian, Section>
+    where Endian: Endianity
+{
+    /// Construct a new `SectionData` instance from the data in the section.
+    ///
+    /// It is the caller's responsibility to read the section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on OSX, etc.
+    pub fn new(data: &'input [u8]) -> SectionData<'input, Endian, Section> {
+        SectionData {
+            data: EndianBuf(data, PhantomData),
+            section: PhantomData,
+        }
+    }
+
+    /// Return the data in this section.
+    pub fn data(&self) -> EndianBuf<'input, Endian> {
+        self.data
+    }
+}
+
+/// An offset into a DWARF section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SectionOffset<Section>(pub u64, PhantomData<Section>);
+
+impl<Section> SectionOffset<Section> {
+    /// Construct a new `SectionOffset` instance.
+    pub fn new(offset: u64) -> Self {
+        SectionOffset::<Section>(offset, PhantomData)
+    }
+
+    /// Parse an offset according to the DWARF format.
+    pub fn parse<Endian>(input: EndianBuf<Endian>,
+                         format: Format)
+                         -> ParseResult<(EndianBuf<Endian>, Self)>
+        where Endian: Endianity
+    {
+        parse_word(input, format).map(|(rest, offset)| (rest, Self::new(offset)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use endianity::{EndianBuf, LittleEndian};
+    use parser::{Error, Format};
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum TestSection {}
+
+    type TestOffset = SectionOffset<TestSection>;
+
+    #[test]
+    fn test_parse_offset_32() {
+        let buf = [0x01, 0x02, 0x03, 0x04];
+
+        match TestOffset::parse(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf32) {
+            Ok((_, val)) => assert_eq!(val, TestOffset::new(0x04030201)),
+            otherwise => panic!("Unexpected result: {:?}", otherwise),
+        };
+    }
+
+    #[test]
+    fn test_parse_offset_32_incomplete() {
+        let buf = [0x01, 0x02];
+
+        match TestOffset::parse(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf32) {
+            Err(Error::UnexpectedEof) => assert!(true),
+            otherwise => panic!("Unexpected result: {:?}", otherwise),
+        };
+    }
+
+    #[test]
+    fn test_parse_offset_64() {
+        let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+        match TestOffset::parse(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf64) {
+            Ok((_, val)) => assert_eq!(val, TestOffset::new(0x0807060504030201)),
+            otherwise => panic!("Unexpected result: {:?}", otherwise),
+        };
+    }
+
+    #[test]
+    fn test_parse_offset_64_incomplete() {
+        let buf = [0x01, 0x02];
+
+        match TestOffset::parse(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf64) {
+            Err(Error::UnexpectedEof) => assert!(true),
+            otherwise => panic!("Unexpected result: {:?}", otherwise),
+        };
+    }
+}


### PR DESCRIPTION
Reduces the amount of copy/paste for sections and offsets, while keeping mostly the same API. The main difference in the API is the need to use `new` to create offsets, but that is generally only used in tests.

@fitzgen  I haven't finished converting everything. Let me know if you agree with the direction this is heading; I'm not too sure about it myself. The main problem I can see with this approach is that the documentation doesn't pick up all the extra functions for the type aliases, such as `DebugInfo::units`, so we will need to manually do what we did for `DebugPubNames` and `DebugPubTypes` (or fix rustdoc; other people have reported similar problems with type aliases so it's a needed feature).

Also a general doc comment: I think we need to start exposing modules, because the main page is too long (or at least expose the `constants` module).