### PR TITLE
Remove unnecessary `#![deny(missing_docs)]` attributes

### DIFF
--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -1,7 +1,5 @@
 //! Functions for parsing DWARF debugging abbreviations.
 
-#![deny(missing_docs)]
-
 use constants;
 use endianity::{Endianity, EndianBuf};
 use parser::{Error, ParseResult, Format};

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 use endianity::{Endianity, EndianBuf};
 use lookup::{LookupParser, LookupEntryIter, DebugLookup};
 use parser::{parse_address_size, parse_initial_length, parse_u16, parse_address, Error, Format,

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -1,7 +1,5 @@
 //! Types for compile-time endianity.
 
-#![deny(missing_docs)]
-
 use byteorder;
 use std::fmt::Debug;
 use std::marker::PhantomData;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
 use parser::{parse_null_terminated_string, parse_initial_length, parse_u16, parse_word, Format,

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,7 +1,5 @@
 //! Functions for parsing and evaluating DWARF expressions.
 
-#![deny(missing_docs)]
-
 use constants;
 use parser::{Error, ParseResult, Format, parse_u8e, parse_i8e, parse_u16, parse_i16, parse_u32,
              parse_i32, parse_u64, parse_i64, parse_unsigned_lebe, parse_signed_lebe, parse_word,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,5 @@
 //! Functions for parsing DWARF debugging information.
 
-#![deny(missing_docs)]
-
 use std::error;
 use std::ffi;
 use std::fmt::{self, Debug};

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, ParseResult};

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, ParseResult};

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,7 +1,5 @@
 //! Functions for parsing DWARF `.debug_info` and `.debug_types` sections.
 
-#![deny(missing_docs)]
-
 use constants;
 #[cfg(test)]
 use leb128;


### PR DESCRIPTION
Only the one in lib.rs is needed.

r? @philipc 