### PR TITLE
Rename gimli::ParseResult to gimli::Result

### DIFF
--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -198,7 +198,7 @@ impl Unit {
 
     fn lines<'a, Endian>(&self,
                          debug_line: gimli::DebugLine<'a, Endian>)
-                         -> gimli::ParseResult<gimli::StateMachine<'a, Endian>>
+                         -> gimli::Result<gimli::StateMachine<'a, Endian>>
         where Endian: gimli::Endianity
     {
         let header = try!(gimli::LineNumberProgramHeader::new(debug_line,

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -1,7 +1,7 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{LookupParser, LookupEntryIter, DebugLookup};
 use parser::{parse_address_size, parse_initial_length, parse_u16, parse_address, Error, Format,
-             ParseResult};
+             Result};
 use unit::{DebugInfoOffset, parse_debug_info_offset};
 use std::cmp::Ordering;
 use std::marker::PhantomData;
@@ -106,7 +106,7 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
     /// Parse an arange set header. Returns a tuple of the remaining arange sets, the aranges to be
     /// parsed for this set, and the newly created ArangeHeader struct.
     fn parse_header(input: EndianBuf<Endian>)
-                    -> ParseResult<(EndianBuf<Endian>, EndianBuf<Endian>, Rc<Self::Header>)> {
+                    -> Result<(EndianBuf<Endian>, EndianBuf<Endian>, Rc<Self::Header>)> {
         let (rest, (length, format)) = try!(parse_initial_length(input));
         if length as usize > rest.len() {
             return Err(Error::UnexpectedEof);
@@ -158,7 +158,7 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
     /// Parse a single arange. Return `None` for the null arange, `Some` for an actual arange.
     fn parse_entry(input: EndianBuf<'input, Endian>,
                    header: &Rc<Self::Header>)
-                   -> ParseResult<(EndianBuf<'input, Endian>, Option<Self::Entry>)> {
+                   -> Result<(EndianBuf<'input, Endian>, Option<Self::Entry>)> {
         let address_size = header.address_size;
         let segment_size = header.segment_size; // May be zero!
 
@@ -237,7 +237,7 @@ pub type DebugAranges<'input, Endian> = DebugLookup<'input, Endian, ArangeParser
 ///
 /// Provides:
 ///
-/// * `next(self: &mut) -> ParseResult<Option<ArangeEntry>>`
+/// * `next(self: &mut) -> gimli::Result<Option<ArangeEntry>>`
 ///
 ///   Advance the iterator and return the next arange.
 ///

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -658,6 +658,6 @@ dw!(DwOp(u8) {
     DW_OP_implicit_value = 0x9e,
     DW_OP_stack_value = 0x9f,
 
-    // GNU extensions that are supported by our expression evaluator.
+// GNU extensions that are supported by our expression evaluator.
     DW_OP_GNU_push_tls_address = 0xe0,
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,10 +127,10 @@
 //!
 //! // Use the `FallibleIterator` trait so its methods are in scope!
 //! use fallible_iterator::FallibleIterator;
-//! use gimli::{DebugAranges, LittleEndian, ParseResult};
+//! use gimli::{DebugAranges, LittleEndian};
 //!
 //! fn find_sum_of_address_range_lengths(aranges: DebugAranges<LittleEndian>)
-//!     -> ParseResult<u64>
+//!     -> gimli::Result<u64>
 //! {
 //!     // `DebugAranges::items` returns a `FallibleIterator`!
 //!     aranges.items()
@@ -159,7 +159,7 @@ mod endianity;
 pub use endianity::{Endianity, EndianBuf, LittleEndian, BigEndian, NativeEndian};
 
 mod parser;
-pub use parser::{Error, ParseResult, Format};
+pub use parser::{Error, Result, Format};
 pub use parser::{DebugLocOffset, DebugMacinfoOffset};
 
 mod abbrev;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,7 @@ use std::error;
 use std::ffi;
 use std::fmt::{self, Debug};
 use std::io;
+use std::result;
 
 use constants;
 use endianity::{Endianity, EndianBuf};
@@ -98,7 +99,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
         Debug::fmt(self, f)
     }
 }
@@ -172,12 +173,12 @@ impl error::Error for Error {
 }
 
 /// The result of a parse.
-pub type ParseResult<T> = Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// Parse a `u8` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u8(input: &[u8]) -> ParseResult<(&[u8], u8)> {
+pub fn parse_u8(input: &[u8]) -> Result<(&[u8], u8)> {
     if input.len() == 0 {
         Err(Error::UnexpectedEof)
     } else {
@@ -188,7 +189,7 @@ pub fn parse_u8(input: &[u8]) -> ParseResult<(&[u8], u8)> {
 /// Parse a `i8` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i8(input: &[u8]) -> ParseResult<(&[u8], i8)> {
+pub fn parse_i8(input: &[u8]) -> Result<(&[u8], i8)> {
     if input.len() == 0 {
         Err(Error::UnexpectedEof)
     } else {
@@ -199,7 +200,7 @@ pub fn parse_i8(input: &[u8]) -> ParseResult<(&[u8], i8)> {
 /// Parse a `u16` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u16<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, u16)>
+pub fn parse_u16<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u16)>
     where Endian: Endianity
 {
     if input.len() < 2 {
@@ -212,7 +213,7 @@ pub fn parse_u16<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<End
 /// Parse a `i16` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i16<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, i16)>
+pub fn parse_i16<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i16)>
     where Endian: Endianity
 {
     if input.len() < 2 {
@@ -225,7 +226,7 @@ pub fn parse_i16<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<End
 /// Parse a `u32` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u32<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, u32)>
+pub fn parse_u32<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u32)>
     where Endian: Endianity
 {
     if input.len() < 4 {
@@ -238,7 +239,7 @@ pub fn parse_u32<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<End
 /// Parse a `i32` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i32<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, i32)>
+pub fn parse_i32<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i32)>
     where Endian: Endianity
 {
     if input.len() < 4 {
@@ -251,7 +252,7 @@ pub fn parse_i32<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<End
 /// Parse a `u64` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u64<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, u64)>
+pub fn parse_u64<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u64)>
     where Endian: Endianity
 {
     if input.len() < 8 {
@@ -264,7 +265,7 @@ pub fn parse_u64<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<End
 /// Parse a `i64` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i64<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, i64)>
+pub fn parse_i64<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i64)>
     where Endian: Endianity
 {
     if input.len() < 8 {
@@ -278,7 +279,7 @@ pub fn parse_i64<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<End
 #[doc(hidden)]
 #[inline]
 pub fn parse_u8e<'input, Endian>(bytes: EndianBuf<'input, Endian>)
-                                 -> ParseResult<(EndianBuf<'input, Endian>, u8)>
+                                 -> Result<(EndianBuf<'input, Endian>, u8)>
     where Endian: Endianity
 {
     let (bytes, value) = try!(parse_u8(bytes.into()));
@@ -289,7 +290,7 @@ pub fn parse_u8e<'input, Endian>(bytes: EndianBuf<'input, Endian>)
 #[doc(hidden)]
 #[inline]
 pub fn parse_i8e<'input, Endian>(bytes: EndianBuf<'input, Endian>)
-                                 -> ParseResult<(EndianBuf<'input, Endian>, i8)>
+                                 -> Result<(EndianBuf<'input, Endian>, i8)>
     where Endian: Endianity
 {
     let (bytes, value) = try!(parse_i8(bytes.into()));
@@ -300,7 +301,7 @@ pub fn parse_i8e<'input, Endian>(bytes: EndianBuf<'input, Endian>)
 #[doc(hidden)]
 #[inline]
 pub fn parse_unsigned_lebe<'input, Endian>(bytes: EndianBuf<'input, Endian>)
-                                           -> ParseResult<(EndianBuf<'input, Endian>, u64)>
+                                           -> Result<(EndianBuf<'input, Endian>, u64)>
     where Endian: Endianity
 {
     let (bytes, value) = try!(parse_unsigned_leb(bytes.into()));
@@ -311,7 +312,7 @@ pub fn parse_unsigned_lebe<'input, Endian>(bytes: EndianBuf<'input, Endian>)
 #[doc(hidden)]
 #[inline]
 pub fn parse_signed_lebe<'input, Endian>(bytes: EndianBuf<'input, Endian>)
-                                         -> ParseResult<(EndianBuf<'input, Endian>, i64)>
+                                         -> Result<(EndianBuf<'input, Endian>, i64)>
     where Endian: Endianity
 {
     let (bytes, value) = try!(parse_signed_leb(bytes.into()));
@@ -321,7 +322,7 @@ pub fn parse_signed_lebe<'input, Endian>(bytes: EndianBuf<'input, Endian>)
 /// Parse a `u32` from the input and return it as a `u64`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u32_as_u64<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, u64)>
+pub fn parse_u32_as_u64<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u64)>
     where Endian: Endianity
 {
     if input.len() < 4 {
@@ -336,7 +337,7 @@ pub fn parse_u32_as_u64<Endian>(input: EndianBuf<Endian>) -> ParseResult<(Endian
 #[inline]
 pub fn parse_word<Endian>(input: EndianBuf<Endian>,
                           format: Format)
-                          -> ParseResult<(EndianBuf<Endian>, u64)>
+                          -> Result<(EndianBuf<Endian>, u64)>
     where Endian: Endianity
 {
     match format {
@@ -350,7 +351,7 @@ pub fn parse_word<Endian>(input: EndianBuf<Endian>,
 #[inline]
 pub fn parse_address<Endian>(input: EndianBuf<Endian>,
                              address_size: u8)
-                             -> ParseResult<(EndianBuf<Endian>, u64)>
+                             -> Result<(EndianBuf<Endian>, u64)>
     where Endian: Endianity
 {
     if input.len() < address_size as usize {
@@ -370,7 +371,7 @@ pub fn parse_address<Endian>(input: EndianBuf<Endian>,
 /// Parse a null-terminated slice from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_null_terminated_string(input: &[u8]) -> ParseResult<(&[u8], &ffi::CStr)> {
+pub fn parse_null_terminated_string(input: &[u8]) -> Result<(&[u8], &ffi::CStr)> {
     let null_idx = input.iter().position(|ch| *ch == 0);
 
     if let Some(idx) = null_idx {
@@ -396,7 +397,7 @@ pub struct DebugMacinfoOffset(pub u64);
 
 /// Parse an unsigned LEB128 encoded integer.
 #[inline]
-pub fn parse_unsigned_leb(mut input: &[u8]) -> ParseResult<(&[u8], u64)> {
+pub fn parse_unsigned_leb(mut input: &[u8]) -> Result<(&[u8], u64)> {
     match leb128::read::unsigned(&mut input) {
         Ok(val) => Ok((input, val)),
         Err(leb128::read::Error::IoError(ref e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
@@ -408,7 +409,7 @@ pub fn parse_unsigned_leb(mut input: &[u8]) -> ParseResult<(&[u8], u64)> {
 
 /// Parse a signed LEB128 encoded integer.
 #[inline]
-pub fn parse_signed_leb(mut input: &[u8]) -> ParseResult<(&[u8], i64)> {
+pub fn parse_signed_leb(mut input: &[u8]) -> Result<(&[u8], i64)> {
     match leb128::read::signed(&mut input) {
         Ok(val) => Ok((input, val)),
         Err(leb128::read::Error::IoError(ref e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
@@ -434,7 +435,7 @@ const DWARF_64_INITIAL_UNIT_LENGTH: u64 = 0xffffffff;
 /// Parse the compilation unit header's length.
 #[doc(hidden)]
 pub fn parse_initial_length<Endian>(input: EndianBuf<Endian>)
-                                    -> ParseResult<(EndianBuf<Endian>, (u64, Format))>
+                                    -> Result<(EndianBuf<Endian>, (u64, Format))>
     where Endian: Endianity
 {
     let (rest, val) = try!(parse_u32_as_u64(input));
@@ -519,7 +520,7 @@ fn test_parse_initial_length_64_incomplete() {
 }
 
 /// Parse the size of addresses (in bytes) on the target architecture.
-pub fn parse_address_size<Endian>(input: EndianBuf<Endian>) -> ParseResult<(EndianBuf<Endian>, u8)>
+pub fn parse_address_size<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u8)>
     where Endian: Endianity
 {
     parse_u8(input.into()).map(|(r, u)| (EndianBuf::new(r), u))
@@ -539,7 +540,7 @@ fn test_parse_address_size_ok() {
 #[inline]
 pub fn take<Endian>(bytes: usize,
                     input: EndianBuf<Endian>)
-                    -> ParseResult<(EndianBuf<Endian>, EndianBuf<Endian>)>
+                    -> Result<(EndianBuf<Endian>, EndianBuf<Endian>)>
     where Endian: Endianity
 {
     if input.len() < bytes {
@@ -554,7 +555,7 @@ pub fn take<Endian>(bytes: usize,
 /// second element of the result tuple.
 #[doc(hidden)]
 pub fn parse_length_uleb_value<Endian>(input: EndianBuf<Endian>)
-                                       -> ParseResult<(EndianBuf<Endian>, EndianBuf<Endian>)>
+                                       -> Result<(EndianBuf<Endian>, EndianBuf<Endian>)>
     where Endian: Endianity
 {
     let (rest, len) = try!(parse_unsigned_leb(input.into()));

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -1,6 +1,6 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
-use parser::{Format, ParseResult};
+use parser::{Format, Result};
 use unit::{DebugInfoOffset, parse_debug_info_offset};
 use std::ffi;
 use std::marker::PhantomData;
@@ -77,7 +77,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for NamesSwitch<'input, 
 
     fn parse_offset(input: EndianBuf<Endian>,
                     format: Format)
-                    -> ParseResult<(EndianBuf<Endian>, Self::Offset)> {
+                    -> Result<(EndianBuf<Endian>, Self::Offset)> {
         parse_debug_info_offset(input, format)
     }
 
@@ -136,7 +136,7 @@ pub type DebugPubNames<'input, Endian> = DebugLookup<'input,
 ///
 /// Provides:
 ///
-/// * `next_entry(self: &mut) -> ParseResult<Option<PubNamesEntry>>`
+/// * `next_entry(self: &mut) -> gimli::Result<Option<PubNamesEntry>>`
 ///
 ///   Advance the iterator and return the next pubname.
 ///

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -1,6 +1,6 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
-use parser::{Format, ParseResult};
+use parser::{Format, Result};
 use unit::{DebugTypesOffset, parse_debug_types_offset};
 use std::ffi;
 use std::marker::PhantomData;
@@ -76,7 +76,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
 
     fn parse_offset(input: EndianBuf<Endian>,
                     format: Format)
-                    -> ParseResult<(EndianBuf<Endian>, Self::Offset)> {
+                    -> Result<(EndianBuf<Endian>, Self::Offset)> {
         parse_debug_types_offset(input, format)
     }
 
@@ -134,7 +134,7 @@ pub type DebugPubTypes<'input, Endian> = DebugLookup<'input,
 ///
 /// Provides:
 ///
-/// * `next_entry(self: &mut) -> ParseResult<Option<PubTypesEntry>>`
+/// * `next_entry(self: &mut) -> gimli::Result<Option<PubTypesEntry>>`
 ///
 ///   Advance the iterator and return the next pubtype.
 ///

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,6 +1,6 @@
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
-use parser::{Error, ParseResult, parse_address};
+use parser::{Error, Result, parse_address};
 use std::marker::PhantomData;
 
 /// An offset into the `.debug_ranges` section.
@@ -50,7 +50,7 @@ impl<'input, Endian> DebugRanges<'input, Endian>
                   offset: DebugRangesOffset,
                   address_size: u8,
                   base_address: u64)
-                  -> ParseResult<RangesIter<Endian>> {
+                  -> Result<RangesIter<Endian>> {
         let offset = offset.0 as usize;
         if self.debug_ranges_section.len() < offset {
             return Err(Error::UnexpectedEof);
@@ -72,7 +72,7 @@ impl<'input, Endian> DebugRanges<'input, Endian>
     pub fn raw_ranges(&self,
                       offset: DebugRangesOffset,
                       address_size: u8)
-                      -> ParseResult<RawRangesIter<Endian>> {
+                      -> Result<RawRangesIter<Endian>> {
         let offset = offset.0 as usize;
         if self.debug_ranges_section.len() < offset {
             return Err(Error::UnexpectedEof);
@@ -109,7 +109,7 @@ impl<'input, Endian> RawRangesIter<'input, Endian>
     }
 
     /// Advance the iterator to the next range.
-    pub fn next(&mut self) -> ParseResult<Option<Range>> {
+    pub fn next(&mut self) -> Result<Option<Range>> {
         if self.input.is_empty() {
             return Ok(None);
         }
@@ -137,7 +137,7 @@ impl<'input, Endian> FallibleIterator for RawRangesIter<'input, Endian>
     type Item = Range;
     type Error = Error;
 
-    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
         RawRangesIter::next(self)
     }
 }
@@ -166,7 +166,7 @@ impl<'input, Endian> RangesIter<'input, Endian>
     }
 
     /// Advance the iterator to the next range.
-    pub fn next(&mut self) -> ParseResult<Option<Range>> {
+    pub fn next(&mut self) -> Result<Option<Range>> {
         loop {
             let range = match try!(self.raw.next()) {
                 Some(range) => range,
@@ -210,7 +210,7 @@ impl<'input, Endian> FallibleIterator for RangesIter<'input, Endian>
     type Item = Range;
     type Error = Error;
 
-    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
         RangesIter::next(self)
     }
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,5 +1,5 @@
 use endianity::{Endianity, EndianBuf};
-use parser::{parse_null_terminated_string, Error, ParseResult};
+use parser::{parse_null_terminated_string, Error, Result};
 use std::ffi;
 use std::marker::PhantomData;
 
@@ -49,7 +49,7 @@ impl<'input, Endian> DebugStr<'input, Endian>
     /// let debug_str = DebugStr::<LittleEndian>::new(read_debug_str_section_somehow());
     /// println!("Found string {:?}", debug_str.get_str(debug_str_offset_somehow()));
     /// ```
-    pub fn get_str(&self, offset: DebugStrOffset) -> ParseResult<&'input ffi::CStr> {
+    pub fn get_str(&self, offset: DebugStrOffset) -> Result<&'input ffi::CStr> {
         if self.debug_str_section.len() < offset.0 as usize {
             return Err(Error::UnexpectedEof);
         }


### PR DESCRIPTION
Follows conventions established by std::io::Result and std::fmt::Result, etc.

r? @philipc 

heads up @tromey 