### PR TITLE
addr2line improvements

### DIFF
--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -42,11 +42,12 @@ fn parse_uint_from_hex_string(string: &str) -> u64 {
     }
 }
 
-fn display_file<Endian>(row: gimli::LineNumberRow<Endian>)
+fn display_file<Endian>(header: &gimli::LineNumberProgramHeader<Endian>,
+                        row: &gimli::LineNumberRow)
     where Endian: gimli::Endianity
 {
-    let file = row.file().unwrap();
-    if let Some(directory) = file.directory(row.header()) {
+    let file = row.file(header).unwrap();
+    if let Some(directory) = file.directory(header) {
         println!("{}/{}:{}",
                  directory.to_string_lossy(),
                  file.path_name().to_string_lossy(),
@@ -92,8 +93,8 @@ fn find_address<Endian>(debug_line: gimli::DebugLine<Endian>, units: &[Unit], ad
     for unit in units {
         if unit.contains_address(addr) {
             if let Ok(mut lines) = unit.lines(debug_line) {
-                if let Ok(Some(row)) = lines.run_to_address(&addr) {
-                    display_file(row);
+                if let Ok(Some((header, row))) = lines.run_to_address(&addr) {
+                    display_file(header, row);
                     return;
                 };
             }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -545,7 +545,7 @@ fn dump_line<Endian>(file: &object::File, debug_abbrev: gimli::DebugAbbrev<Endia
                 println!("<pc>        [lno,col]");
                 let mut state_machine = gimli::StateMachine::new(header);
                 let mut file_index = 0;
-                while let Some(row) = state_machine.next_row()
+                while let Some((header, row)) = state_machine.next_row()
                     .expect("Should parse row OK") {
                     let line = row.line().unwrap_or(0);
                     let column = match row.column() {
@@ -576,8 +576,8 @@ fn dump_line<Endian>(file: &object::File, debug_abbrev: gimli::DebugAbbrev<Endia
                     }
                     if file_index != row.file_index() {
                         file_index = row.file_index();
-                        if let Ok(file) = row.file() {
-                            if let Some(directory) = file.directory(row.header()) {
+                        if let Ok(file) = row.file(header) {
+                            if let Some(directory) = file.directory(header) {
                                 print!(" uri: \"{}/{}\"",
                                        directory.to_string_lossy(),
                                        file.path_name().to_string_lossy());


### PR DESCRIPTION
Handle addresses within rows, and display compilation unit directory. As usual, some of this logic needs moving into the library eventually.

Needed a change to `LineNumberRow`. Open to suggestions for other ways to fix this.

Fixes #79 