### PR TITLE
Implement support for evaluating call frame unwinding programs

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -250,7 +250,7 @@ fn dump_entries<Endian>(offset: u64,
             unit.comp_dir = match entry.attr(gimli::DW_AT_comp_dir) {
                 Some(attr) => {
                     attr.string_value(&debug_str)
-                    .map(|dir| dir.to_string_lossy().into_owned())
+                        .map(|dir| dir.to_string_lossy().into_owned())
                 }
                 _ => None,
             };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -98,6 +98,12 @@ pub enum Error {
     InvalidAddressRange,
     /// The end offset of a loc list entry was before the beginning.
     InvalidLocationAddressRange,
+    /// Encountered a call frame instruction in a context in which it is not
+    /// valid.
+    CfiInstructionInInvalidContext,
+    /// When evaluating call frame instructions, found a `DW_CFA_restore_state`
+    /// stack pop instruction, but the stack was empty, and had nothing to pop.
+    PopWithEmptyStack,
 }
 
 impl fmt::Display for Error {
@@ -172,6 +178,13 @@ impl error::Error for Error {
             }
             Error::InvalidLocationAddressRange => {
                 "The end offset of a location list entry must not be before the beginning."
+            }
+            Error::CfiInstructionInInvalidContext => {
+                "Encountered a call frame instruction in a context in which it is not valid."
+            }
+            Error::PopWithEmptyStack => {
+                "When evaluating call frame instructions, found a `DW_CFA_restore_state` stack pop \
+                 instruction, but the stack was empty, and had nothing to pop."
             }
         }
     }


### PR DESCRIPTION
Continuing work on #7... Phew!

This commit adds support for evaluating `CallFrameInstruction`s, yielding what
the standard calls the "virtual unwind table". The virtual unwind table is
represented here as a streaming iterator over its rows.

To minimize the number of allocations required when repeatedly running many CFI
programs (for example, when unwinding the whole stack), the context in which a
CFI program runs has been split out into its own re-usable type. Furthermore,
because the `DW_CFA_restore` instruction allows a register's rule to be restored
to the value defined after evaluating the CIE's initial instructions but before
evaluating any of the FDE's instructions, we need to keep track of the initial
register rules and if we evaluated them or not yet. To shelter library users
from tracking this state manually, we push it into the type system via
new-types (`InitializedUnwindContext` and `UninitializedUnwindContext`), and
only these new-types are exposed publicly.

r? @philipc @tromey -- I think this is big (and important) enough to get both of your
eyes on it.

Still TODO in follow ups:

* Be robust against overflow / casting outside of target type's range
* Support `.eh_frame` augmentation
* Benches
* Self-parse integration test (requires the `.eh_frame` augmentation)
* Output this info in dwarfdump.rs
* A single, orchestrating `DebugFrame::unwind_info_for_address(&self, ctx: &mut UninitializedUnwindContext, address: u64) -> UnwindTableRow` method (for folks who don't have any kind of CIE/FDE caching or anything like that)