### PR TITLE
Add `#![deny(missing_debug_implementations)]` to the crate

### DIFF
--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -90,6 +90,7 @@ impl Ord for ArangeEntry {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct ArangeParser<'input, Endian>
     where Endian: 'input + Endianity
 {

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -69,6 +69,7 @@ impl<'input, Endian> DebugFrame<'input, Endian>
 ///
 /// Can be [used with
 /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
+#[derive(Clone, Debug)]
 pub struct CfiEntriesIter<'input, Endian>
     where Endian: Endianity
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@
 //! ```
 
 #![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
 
 extern crate byteorder;
 extern crate fallible_iterator;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -37,6 +37,7 @@ pub trait LookupParser<'input, Endian>
 }
 
 #[allow(missing_docs)]
+#[derive(Clone, Debug)]
 pub struct DebugLookup<'input, Endian, Parser>
     where Endian: Endianity,
           Parser: LookupParser<'input, Endian>
@@ -68,6 +69,7 @@ impl<'input, Endian, Parser> DebugLookup<'input, Endian, Parser>
 }
 
 #[allow(missing_docs)]
+#[derive(Clone, Debug)]
 pub struct LookupEntryIter<'input, Endian, Parser>
     where Endian: Endianity,
           Parser: LookupParser<'input, Endian>
@@ -151,6 +153,7 @@ pub trait NamesOrTypesSwitch<'input, Endian>
     fn format_from(header: &Self::Header) -> Format;
 }
 
+#[derive(Clone, Debug)]
 pub struct PubStuffParser<'input, Endian, Switch>
     where Endian: 'input + Endianity,
           Switch: 'input + NamesOrTypesSwitch<'input, Endian>

--- a/src/op.rs
+++ b/src/op.rs
@@ -11,6 +11,7 @@ use std::marker::PhantomData;
 use endianity::LittleEndian;
 #[cfg(test)]
 use leb128;
+use std::fmt;
 #[cfg(test)]
 use std::io::Write;
 
@@ -25,7 +26,7 @@ pub enum DieReference {
 }
 
 /// Supply information to a DWARF expression evaluation.
-pub trait EvaluationContext<'input> {
+pub trait EvaluationContext<'input>: fmt::Debug {
     /// Read the indicated number of bytes from memory at the
     /// indicated address.  The number of bytes is guaranteed to be
     /// less than the word size of the target architecture.
@@ -1357,6 +1358,7 @@ fn test_op_parse_implicit_value() {
 }
 
 /// A DWARF expression evaluation.
+#[derive(Debug)]
 pub struct Evaluation<'context, 'input, Endian>
     where Endian: 'context + Endianity,
           'input: 'context
@@ -1824,7 +1826,7 @@ impl<'context, 'input, Endian> Evaluation<'context, 'input, Endian>
 }
 
 #[cfg(test)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct TestEvaluationContext {
     base: Result<u64>,
     cfa: Result<u64>,

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -36,6 +36,7 @@ impl<'input> PubNamesEntry<'input> {
 }
 
 
+#[derive(Clone, Debug)]
 pub struct NamesSwitch<'input, Endian>
     where Endian: 'input + Endianity
 {

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -35,6 +35,7 @@ impl<'input> PubTypesEntry<'input> {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct TypesSwitch<'input, Endian>
     where Endian: 'input + Endianity
 {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -112,6 +112,7 @@ impl<'input, Endian> DebugInfo<'input, Endian>
 ///
 /// See the [documentation on
 /// `DebugInfo::units`](./struct.DebugInfo.html#method.units) for more detail.
+#[derive(Clone, Debug)]
 pub struct UnitHeadersIter<'input, Endian>
     where Endian: Endianity
 {
@@ -2977,6 +2978,7 @@ impl<'input, Endian> DebugTypes<'input, Endian>
 /// See the [documentation on
 /// `DebugTypes::units`](./struct.DebugTypes.html#method.units) for
 /// more detail.
+#[derive(Clone, Debug)]
 pub struct TypeUnitHeadersIter<'input, Endian>
     where Endian: Endianity
 {


### PR DESCRIPTION
Also, fill in the missing Debug implementations. Also, fill in `Clone` implementations where possible.

Unsure whether the `Debug` trait bound on `EvaluationContext` is the right way to handle this... Open to alternatives.

See issue #48.