### PR TITLE
line: handle comp_dir and name

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -118,7 +118,7 @@ fn bench_parsing_line_number_program_opcodes(b: &mut test::Bencher) {
     let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
 
     b.iter(|| {
-        let header = debug_line.header(OFFSET, ADDRESS_SIZE)
+        let header = debug_line.header(OFFSET, ADDRESS_SIZE, None, None)
             .expect("Should parse line number program header");
 
         let mut opcodes = header.opcodes();
@@ -134,7 +134,7 @@ fn bench_executing_line_number_programs(b: &mut test::Bencher) {
     let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
 
     b.iter(|| {
-        let header = debug_line.header(OFFSET, ADDRESS_SIZE)
+        let header = debug_line.header(OFFSET, ADDRESS_SIZE, None, None)
             .expect("Should parse line number program header");
 
         let mut rows = header.rows();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,8 +65,6 @@ pub enum Error {
     LineRangeZero,
     /// The opcode base must not be zero.
     OpcodeBaseZero,
-    /// The specified file index was out of bounds.
-    BadFileIndex,
     /// Found an invalid UTF-8 string.
     BadUtf8,
     /// Expected to find the CIE ID, but found something else.
@@ -156,7 +154,6 @@ impl error::Error for Error {
             }
             Error::LineRangeZero => "The line range must not be zero.",
             Error::OpcodeBaseZero => "The opcode base must not be zero.",
-            Error::BadFileIndex => "The specified file index was out of bounds.",
             Error::BadUtf8 => "Found an invalid UTF-8 string.",
             Error::NotCieId => "Expected to find the CIE ID, but found something else.",
             Error::NotCiePointer => "Expected to find a CIE pointer, but found the CIE ID instead.",


### PR DESCRIPTION
Handle the interpretation of 0 indices for directories and files.  We
do this by storing the compilation unit directory and file references
inside the header struct.  This will be compatible with DWARF 5, which
stores copies of these values in the .debug_line section.

Fixes #59