### PR TITLE
Add the `DebugFrame::unwind_info_for_address` method

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -102,6 +102,8 @@ pub enum Error {
     /// When evaluating call frame instructions, found a `DW_CFA_restore_state`
     /// stack pop instruction, but the stack was empty, and had nothing to pop.
     PopWithEmptyStack,
+    /// Do not have unwind info for the given address.
+    NoUnwindInfoForAddress,
 }
 
 impl fmt::Display for Error {
@@ -183,6 +185,7 @@ impl error::Error for Error {
                 "When evaluating call frame instructions, found a `DW_CFA_restore_state` stack pop \
                  instruction, but the stack was empty, and had nothing to pop."
             }
+            Error::NoUnwindInfoForAddress => "Do not have unwind info for the given address.",
         }
     }
 }


### PR DESCRIPTION
The `unwind_info_for_address` method provides sane default behavior for quickly
and easily getting the unwind information for a given address for folks who
don't want to do anything too crazy like cache parsed CIEs and FDEs or CFI
evaluation results.

Fixes #117.

r? @philipc 