### PR TITLE
Add EntriesTree

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,4 +203,5 @@ pub use unit::{DebugInfo, DebugInfoOffset, CompilationUnitHeadersIter, Compilati
                UnitOffset};
 pub use unit::{DebugTypes, DebugTypesOffset, DebugTypeSignature, TypeUnitHeadersIter,
                TypeUnitHeader};
-pub use unit::{EntriesCursor, DebuggingInformationEntry, AttrsIter, Attribute, AttributeValue};
+pub use unit::{EntriesCursor, EntriesTree, EntriesTreeIter, DebuggingInformationEntry};
+pub use unit::{AttrsIter, Attribute, AttributeValue};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -56,6 +56,8 @@ pub enum Error {
     UnknownAbbreviation,
     /// Hit the end of input before it was expected.
     UnexpectedEof,
+    /// Read a null entry before it was expected.
+    UnexpectedNull,
     /// Found an unknown standard opcode.
     UnknownStandardOpcode(constants::DwLns),
     /// Found an unknown extended opcode.
@@ -175,6 +177,7 @@ impl error::Error for Error {
             }
             Error::UnknownAbbreviation => "Found a record with an unknown abbreviation code",
             Error::UnexpectedEof => "Hit the end of input before it was expected",
+            Error::UnexpectedNull => "Read a null entry before it was expected.",
             Error::UnknownStandardOpcode(_) => "Found an unknown standard opcode",
             Error::UnknownExtendedOpcode(_) => "Found an unknown extended opcode",
             Error::UnsupportedAddressSize(_) => "The specified address size is not supported",

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1782,9 +1782,7 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
     /// If the cursor is not pointing at an entry, or if the current entry is a
     /// null entry, then `None` is returned.
     #[inline]
-    pub fn current<'me>
-        (&'me self)
-         -> Option<&'me DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>> {
+    pub fn current(&self) -> Option<&DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>> {
         self.cached_current.as_ref()
     }
 
@@ -1970,9 +1968,9 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
     /// println!("The first entry with no children is {:?}",
     ///          first_entry_with_no_children.unwrap());
     /// ```
-    pub fn next_dfs<'me>
-        (&'me mut self)
-         -> Result<Option<(isize, &'me DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>)>> {
+    pub fn next_dfs
+        (&mut self)
+         -> Result<Option<(isize, &DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>)>> {
         let mut delta_depth = self.delta_depth;
         loop {
             // Keep eating null entries that mark the end of an entry's children.
@@ -2109,9 +2107,9 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
     ///     }
     /// }
     /// ```
-    pub fn next_sibling<'me>
-        (&'me mut self)
-         -> Result<Option<(&'me DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>)>> {
+    pub fn next_sibling
+        (&mut self)
+         -> Result<Option<(&DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>)>> {
         if self.current().is_none() {
             // We're already at the null for the end of the sibling list.
             return Ok(None);

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -2187,6 +2187,37 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
 /// tree, following the parent/child relationships. It maintains a single
 /// `EntriesCursor` that is used to parse the entries, allowing it to avoid
 /// any duplicate parsing of entries.
+///
+/// ## Example Usage
+/// ```rust,no_run
+/// extern crate gimli;
+///
+/// # fn example() -> Result<(), gimli::Error> {
+/// # let debug_info = gimli::DebugInfo::<gimli::LittleEndian>::new(&[]);
+/// # let get_some_unit = || debug_info.units().next().unwrap().unwrap();
+/// let unit = get_some_unit();
+/// # let debug_abbrev = gimli::DebugAbbrev::<gimli::LittleEndian>::new(&[]);
+/// # let get_abbrevs_for_unit = |_| unit.abbreviations(debug_abbrev).unwrap();
+/// let abbrevs = get_abbrevs_for_unit(&unit);
+///
+/// let mut tree = try!(unit.entries_tree(&abbrevs));
+/// try!(process_tree(tree.iter()));
+/// # Ok(())
+/// # }
+///
+/// fn process_tree<E>(mut iter: gimli::EntriesTreeIter<E>) -> gimli::Result<()>
+///     where E: gimli::Endianity
+/// {
+///     if let Some(entry) = iter.entry() {
+///         // Examine the entry attributes.
+///     }
+///     while let Some(child) = try!(iter.next()) {
+///         // Recursively process a child.
+///         process_tree(child);
+///     }
+///     Ok(())
+/// }
+/// ```
 #[derive(Clone, Debug)]
 pub struct EntriesTree<'input, 'abbrev, 'unit, Endian>
     where 'input: 'unit,


### PR DESCRIPTION
This allows recursive iteration of DIEs as a tree, without the caller needing to manage the depth changes, even if some levels of the tree are only partially iterated.  It is implemented using a single `EntriesCursor`, so there is no duplicate parsing of entries, and `next_sibling` is used where possible.  However, there is still some overhead compared to a DFS iteration:

```
test bench_parsing_debug_info       ...  bench:   2,398,562 ns/iter (+/- 68,747)
test bench_parsing_debug_info_tree  ...  bench:   2,840,048 ns/iter (+/- 72,544)
```

See the `bench_parsing_debug_info_tree` benchmark for an example of its usage.

My motivation for adding this is that it allows simpler use of gimli in ruby-stacktrace. However, I'm not sure how much of that benefit will remain once gimli gains higher level interpretation of the DIE tree.