### PR TITLE
Force inlining of AttrsIter::next()

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1737,6 +1737,7 @@ impl<'input, 'abbrev, 'entry, 'unit, Endian> AttrsIter<'input, 'abbrev, 'entry, 
     /// Returns `None` when iteration is finished. If an error
     /// occurs while parsing the next attribute, then this error
     /// is returned on all subsequent calls.
+    #[inline(always)]
     pub fn next(&mut self) -> Result<Option<Attribute<'input, Endian>>> {
         if self.attributes.len() == 0 {
             // Now that we have parsed all of the attributes, we know where


### PR DESCRIPTION
Before:
test bench_parsing_debug_info      ... bench:   2,423,653 ns/iter (+/- 50,801)
test bench_parsing_debug_info_tree ... bench:   2,767,421 ns/iter (+/- 22,242)

After:
test bench_parsing_debug_info      ... bench:   1,521,066 ns/iter (+/- 35,440)
test bench_parsing_debug_info_tree ... bench:   1,740,148 ns/iter (+/- 73,535)

It's a bit worrying that this makes such a large difference.
