### PR TITLE
[DO NOT MERGE] Cursor rework

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -56,7 +56,7 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Should parse abbreviations");
 
-            let mut cursor = unit.entries(&abbrevs);
+            let mut cursor = unit.entries(&abbrevs).expect("Should parse root entry");
             while let Some((_, entry)) = cursor.next_dfs().expect("Should parse next dfs") {
                 let mut attrs = entry.attrs();
                 while let Some(attr) = attrs.next().expect("Should parse entry's attribute") {
@@ -90,8 +90,7 @@ fn bench_parsing_debug_info_tree(b: &mut test::Bencher) {
 
 fn parse_debug_info_tree(mut iter: EntriesTreeIter<LittleEndian>) {
     {
-        let entry = iter.entry().expect("Should have current entry");
-        let mut attrs = entry.attrs();
+        let mut attrs = iter.entry().attrs();
         while let Some(attr) = attrs.next().expect("Should parse entry's attribute") {
             test::black_box(&attr);
         }

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -137,10 +137,8 @@ impl<'input> Unit<'input> {
         where Endian: gimli::Endianity
     {
         let abbrev = header.abbreviations(*debug_abbrev).expect("Fail");
-        let mut entries = header.entries(&abbrev);
-        let (_, entry) = entries.next_dfs()
-            .expect("Should parse first entry OK")
-            .expect("And first entry should exist!");
+        let entries = header.entries(&abbrev).expect("Should parse first entry OK");
+        let entry = entries.current();
         assert_eq!(entry.tag(), gimli::DW_TAG_compile_unit);
 
         let ranges = if let Some(ranges) =

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -145,7 +145,7 @@ fn dump_info<Endian>(file: &object::File,
                 .expect("Error parsing abbreviations");
 
             dump_entries(unit.offset().0,
-                         unit.entries(&abbrevs),
+                         unit.entries(&abbrevs).unwrap(),
                          unit.address_size(),
                          unit.format(),
                          debug_line,
@@ -185,7 +185,7 @@ fn dump_types<Endian>(file: &object::File,
                      unit.type_offset().0);
 
             dump_entries(unit.offset().0,
-                         unit.entries(&abbrevs),
+                         unit.entries(&abbrevs).unwrap(),
                          unit.address_size(),
                          unit.format(),
                          debug_line,
@@ -702,10 +702,8 @@ fn dump_line<Endian>(file: &object::File, debug_abbrev: gimli::DebugAbbrev<Endia
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Error parsing abbreviations");
 
-            let mut cursor = unit.entries(&abbrevs);
-            cursor.next_dfs().expect("Should parse next dfs");
-
-            let root = cursor.current().expect("Should have a root DIE");
+            let cursor = unit.entries(&abbrevs).expect("Should parse root DIE");
+            let root = cursor.current();
             let offset = match root.attr_value(gimli::DW_AT_stmt_list) {
                 Some(gimli::AttributeValue::DebugLineRef(offset)) => offset,
                 _ => continue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!     let abbrevs = try!(unit.abbreviations(debug_abbrev));
 //!
 //!     // Iterate over all of this compilation unit's entries.
-//!     let mut entries = unit.entries(&abbrevs);
+//!     let mut entries = try!(unit.entries(&abbrevs));
 //!     while let Some((_, entry)) = try!(entries.next_dfs()) {
 //!         // If we find an entry for a function, print it.
 //!         if entry.tag() == gimli::DW_TAG_subprogram {

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -37,12 +37,10 @@ fn test_parse_self_debug_info() {
         let abbrevs = unit.abbreviations(debug_abbrev)
             .expect("Should parse abbreviations");
 
-        let mut cursor = unit.entries(&abbrevs);
+        let mut cursor = unit.entries(&abbrevs).expect("Should parse root entry");
 
         while cursor.next_dfs().expect("Should parse next dfs").is_some() {
-            let entry = cursor.current().expect("Should have a current entry");
-
-            let mut attrs = entry.attrs();
+            let mut attrs = cursor.current().attrs();
             while let Some(_) = attrs.next().expect("Should parse entry's attribute") {
             }
         }
@@ -68,12 +66,10 @@ fn test_parse_self_debug_line() {
         let abbrevs = unit.abbreviations(debug_abbrev)
             .expect("Should parse abbreviations");
 
-        let mut cursor = unit.entries(&abbrevs);
-        cursor.next_dfs().expect("Should parse next dfs");
+        // TODO: avoid cursor usage
+        let cursor = unit.entries(&abbrevs).expect("Should parse root entry");
 
-        let unit_entry = cursor.current()
-            .expect("Should have a root entry");
-
+        let unit_entry = cursor.current();
         let comp_dir = unit_entry.attr(gimli::DW_AT_comp_dir)
             .and_then(|attr| attr.string_value(&debug_str));
         let comp_name = unit_entry.attr(gimli::DW_AT_name)


### PR DESCRIPTION
These changes are still incomplete/buggy, but have a look through if you want.

My goal is to change `EntriesCursor::cached_current` to no longer be an `Option`. I think this simplifies the code, and it shows ~25% improvement for `bench_parsing_debug_info`. This simplification will also follow through to the `EntriesTree` API.

The meaning of this change is that cursor will always have a valid current value. The main implications of this are:
- the root entry is parsed in `UnitHeader::entries()`
- `next_dfs()` doesn't update `cached_current` when it reaches EOF
- `next_entry()` is no longer meaningful, because `cached_current` can no longer be a null entry. I'm not concerned about this though, because `EntriesTree` provides the behaviour that I previously wanted `next_entry` for.

I don't know what behaviour `next_sibling()` should have. Currently we leave the cursor pointing at a null entry after the last sibling, but that will no longer be possible. If it's left pointing at the last sibling, then there's not really any further meaningful operations that you can perform on the cursor, but I don't think it makes sense to advance to the next valid entry either. For my purposes, `EntriesTree` replaces `next_sibling()` for full tree traversals, so it's probably ok if `next_sibling()` can only be used for navigating one level of the tree.

Any opinions on whether this change is for the better?
