### PR TITLE
Change entries_tree() to take an offset

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -82,7 +82,7 @@ fn bench_parsing_debug_info_tree(b: &mut test::Bencher) {
             let abbrevs = unit.abbreviations(debug_abbrev)
                 .expect("Should parse abbreviations");
 
-            let mut tree = unit.entries_tree(&abbrevs).expect("Should have entries tree");
+            let mut tree = unit.entries_tree(&abbrevs, None).expect("Should have entries tree");
             parse_debug_info_tree(tree.iter());
         }
     });


### PR DESCRIPTION
Also adds an `entries_from()` method that takes an offset, since we probably don't want to change the `entries()` API at this stage. I'm open to better names.