### PR TITLE
Add a NamedDwarfSection trait to ease loading of DWARF sections.

### DIFF
--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -6,6 +6,7 @@ use parser::{Error, Result, Format};
 use parser::{parse_unsigned_leb, parse_u8};
 use unit::UnitHeader;
 use std::collections::hash_map;
+use Section;
 
 /// An offset into the `.debug_abbrev` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,6 +50,22 @@ impl<'input, Endian> DebugAbbrev<'input, Endian>
     pub fn abbreviations(&self, debug_abbrev_offset: DebugAbbrevOffset) -> Result<Abbreviations> {
         let input: &[u8] = self.debug_abbrev_section.into();
         Abbreviations::parse(&input[debug_abbrev_offset.0..]).map(|(_, abbrevs)| abbrevs)
+    }
+}
+
+impl<'input, Endian> Section<'input> for DebugAbbrev<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_abbrev"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugAbbrev<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }
 

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -6,6 +6,7 @@ use unit::{DebugInfoOffset, parse_debug_info_offset};
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use Section;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ArangeHeader {
@@ -233,6 +234,22 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
 ///   }
 ///   ```
 pub type DebugAranges<'input, Endian> = DebugLookup<'input, Endian, ArangeParser<'input, Endian>>;
+
+impl<'input, Endian> Section<'input> for DebugAranges<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_aranges"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugAranges<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
+    }
+}
 
 /// An iterator over the aranges from a `.debug_aranges` section.
 ///

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -13,6 +13,7 @@ use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::mem;
 use std::str;
+use Section;
 
 /// An offset into the `.debug_frame` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,6 +87,22 @@ impl<'input, Endian> DebugFrame<'input, Endian>
     }
 }
 
+impl<'input, Endian> Section<'input> for DebugFrame<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_frame"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugFrame<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
+    }
+}
+
 /// `EhFrame` contains the frame unwinding information needed during exception
 /// handling found in the `.eh_frame` section.
 ///
@@ -119,6 +136,22 @@ impl<'input, Endian> EhFrame<'input, Endian>
     /// ```
     pub fn new(section: &'input [u8]) -> EhFrame<'input, Endian> {
         EhFrame(EndianBuf::new(section))
+    }
+}
+
+impl<'input, Endian> Section<'input> for EhFrame<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".eh_frame"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for EhFrame<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,3 +206,25 @@ pub use unit::{DebugTypes, DebugTypesOffset, DebugTypeSignature, TypeUnitHeaders
                TypeUnitHeader};
 pub use unit::{EntriesCursor, EntriesTree, EntriesTreeIter, DebuggingInformationEntry};
 pub use unit::{AttrsIter, Attribute, AttributeValue};
+
+/// A convenience trait for loading DWARF sections from object files.  To be
+/// used like:
+///
+/// ```
+/// use gimli::{DebugInfo, LittleEndian, Section};
+///
+/// fn load_section<'a, S, F>(loader: F) -> S
+///   where S: Section<'a>, F: FnOnce(&'static str) -> &'a [u8]
+/// {
+///   let data = loader(S::section_name());
+///   S::from(data)
+/// }
+///
+/// let buf = [0x00, 0x01, 0x02, 0x03];
+///
+/// let debug_info: DebugInfo<LittleEndian> = load_section(|_: &'static str| &buf);
+/// ```
+pub trait Section<'input> : From<&'input [u8]> {
+    /// Returns the ELF section name for this type.
+    fn section_name() -> &'static str;
+}

--- a/src/line.rs
+++ b/src/line.rs
@@ -4,6 +4,7 @@ use parser;
 use std::ffi;
 use std::fmt;
 use std::marker::PhantomData;
+use Section;
 
 /// An offset into the `.debug_line` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +77,22 @@ impl<'input, Endian> DebugLine<'input, Endian>
         let (_, header) =
             try!(LineNumberProgramHeader::parse(input, address_size, comp_dir, comp_name));
         Ok(header)
+    }
+}
+
+impl<'input, Endian> Section<'input> for DebugLine<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_line"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugLine<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }
 

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -3,6 +3,7 @@ use fallible_iterator::FallibleIterator;
 use parser::{Error, Result, parse_u16, take};
 use ranges::Range;
 use std::marker::PhantomData;
+use Section;
 
 /// An offset into the `.debug_loc` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,6 +80,22 @@ impl<'input, Endian> DebugLoc<'input, Endian>
 
         let input = self.debug_loc_section.range_from(offset.0..);
         Ok(RawLocationListIter::new(input, address_size))
+    }
+}
+
+impl<'input, Endian> Section<'input> for DebugLoc<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_loc"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugLoc<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }
 

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -5,6 +5,7 @@ use unit::{DebugInfoOffset, parse_debug_info_offset};
 use std::ffi;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use Section;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PubNamesHeader {
@@ -132,6 +133,23 @@ pub type DebugPubNames<'input, Endian> = DebugLookup<'input,
                                                      PubStuffParser<'input,
                                                                     Endian,
                                                                     NamesSwitch<'input, Endian>>>;
+
+
+impl<'input, Endian> Section<'input> for DebugPubNames<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_pubnames"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugPubNames<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
+    }
+}
 
 /// An iterator over the pubnames from a `.debug_pubnames` section.
 ///

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -5,6 +5,7 @@ use unit::{DebugTypesOffset, parse_debug_types_offset};
 use std::ffi;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use Section;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PubTypesHeader {
@@ -130,6 +131,22 @@ pub type DebugPubTypes<'input, Endian> = DebugLookup<'input,
                                                      PubStuffParser<'input,
                                                                     Endian,
                                                                     TypesSwitch<'input, Endian>>>;
+
+impl<'input, Endian> Section<'input> for DebugPubTypes<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_pubtypes"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugPubTypes<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
+    }
+}
 
 /// An iterator over the pubtypes from a `.debug_pubtypes` section.
 ///

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -2,6 +2,7 @@ use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
 use parser::{Error, Result, parse_address};
 use std::marker::PhantomData;
+use Section;
 
 /// An offset into the `.debug_ranges` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +78,22 @@ impl<'input, Endian> DebugRanges<'input, Endian>
 
         let input = self.debug_ranges_section.range_from(offset.0..);
         Ok(RawRangesIter::new(input, address_size))
+    }
+}
+
+impl<'input, Endian> Section<'input> for DebugRanges<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_ranges"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugRanges<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -2,6 +2,7 @@ use endianity::{Endianity, EndianBuf};
 use parser::{parse_null_terminated_string, Error, Result};
 use std::ffi;
 use std::marker::PhantomData;
+use Section;
 
 /// An offset into the `.debug_str` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,5 +57,21 @@ impl<'input, Endian> DebugStr<'input, Endian>
         let buf = self.debug_str_section.range_from(offset.0..);
         let result = parse_null_terminated_string(buf.0);
         result.map(|(_, cstr)| cstr)
+    }
+}
+
+impl<'input, Endian> Section<'input> for DebugStr<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_str"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugStr<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 use std::ops::{Range, RangeFrom, RangeTo};
 use std::{u8, u16};
 use str::{DebugStr, DebugStrOffset};
+use Section;
 
 /// An offset into the `.debug_types` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,6 +106,22 @@ impl<'input, Endian> DebugInfo<'input, Endian>
             Ok((_, header)) => Ok(header),
             Err(e) => Err(e),
         }
+    }
+}
+
+impl<'input, Endian> Section<'input> for DebugInfo<'input, Endian>
+    where Endian: Endianity
+{
+    fn section_name() -> &'static str {
+        ".debug_info"
+    }
+}
+
+impl<'input, Endian> From<&'input [u8]> for DebugInfo<'input, Endian>
+    where Endian: Endianity
+{
+    fn from(v: &'input [u8]) -> Self {
+        Self::new(v)
     }
 }
 


### PR DESCRIPTION
This makes life easier for library consumers because I can skip writing some of the loading boilerplate now.  See the doc comment on the trait.