### PR TITLE
Add API for finding sequences within a line number program and resuming at sequence boundaries

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -152,8 +152,9 @@ fn bench_parsing_line_number_program_opcodes(b: &mut test::Bencher) {
     let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
 
     b.iter(|| {
-        let header = debug_line.header(OFFSET, ADDRESS_SIZE, None, None)
+        let program = debug_line.program(OFFSET, ADDRESS_SIZE, None, None)
             .expect("Should parse line number program header");
+        let header = program.header();
 
         let mut opcodes = header.opcodes();
         while let Some(opcode) = opcodes.next_opcode(&header).expect("Should parse opcode") {
@@ -168,10 +169,10 @@ fn bench_executing_line_number_programs(b: &mut test::Bencher) {
     let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
 
     b.iter(|| {
-        let header = debug_line.header(OFFSET, ADDRESS_SIZE, None, None)
+        let program = debug_line.program(OFFSET, ADDRESS_SIZE, None, None)
             .expect("Should parse line number program header");
 
-        let mut rows = header.rows();
+        let mut rows = program.rows();
         while let Some(row) = rows.next_row()
             .expect("Should parse and execute all rows in the line number program") {
             test::black_box(row);

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -881,7 +881,7 @@ pub enum AttributeValue<'input, Endian>
     /// different compilation unit from the current one.
     DebugInfoRef(DebugInfoOffset),
 
-    /// An offset into the `.debug_lines` section.
+    /// An offset into the `.debug_line` section.
     DebugLineRef(DebugLineOffset),
 
     /// An offset into the `.debug_loc` section.

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -82,29 +82,30 @@ fn test_parse_self_debug_line() {
             .and_then(|attr| attr.string_value(&debug_str));
 
         if let Some(AttributeValue::DebugLineRef(offset)) =
-               unit_entry.attr_value(gimli::DW_AT_stmt_list).expect("Should parse stmt_list") {
-            let header = debug_line.header(offset, unit.address_size(), comp_dir, comp_name)
+            unit_entry.attr_value(gimli::DW_AT_stmt_list).expect("Should parse stmt_list") {
+            let program = debug_line.program(offset, unit.address_size(), comp_dir, comp_name)
                 .expect("should parse line number program header");
 
             let mut results = Vec::new();
-            let mut rows = header.rows();
+            let mut rows = program.rows();
             while let Some((_, row)) = rows.next_row()
                 .expect("Should parse and execute all rows in the line number program") {
                 results.push(row.clone());
             }
             results.reverse();
 
-            let header = debug_line.header(offset, unit.address_size(), comp_dir, comp_name)
+            let program = debug_line.program(offset, unit.address_size(), comp_dir, comp_name)
                 .expect("should parse line number program header");
-            let (mut rows, sequences) = header.sequences()
+            let (program, sequences) = program.sequences()
                 .expect("should parse and execute the entire line number program");
-            assert!(rows.next_row().unwrap().is_none());
             assert!(sequences.len() > 0); // Should be at least one sequence.
             for sequence in sequences {
-                rows.resume(&sequence);
+                let mut rows = program.resume_from(&sequence);
                 while let Some((_, row)) = rows.next_row()
                     .expect("Should parse and execute all rows after resuming") {
                     let other_row = results.pop().unwrap();
+                    assert!(row.address() >= sequence.start);
+                    assert!(row.address() <= sequence.end);
                     assert_eq!(row.address(), other_row.address());
                     assert_eq!(row.line(), other_row.line());
                 }


### PR DESCRIPTION
Fixes #178.

Something like this perhaps?  I haven't actually tried modifying `addr2line` to use it yet.