### PR TITLE
Change AttributeValue::Data from reference to value 

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -306,7 +306,10 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>,
             }
             println!("");
         }
-        gimli::AttributeValue::Data(_) => {
+        gimli::AttributeValue::Data1(_) |
+        gimli::AttributeValue::Data2(_) |
+        gimli::AttributeValue::Data4(_) |
+        gimli::AttributeValue::Data8(_) => {
             if let (Some(udata), Some(sdata)) = (attr.udata_value(), attr.sdata_value()) {
                 if sdata >= 0 {
                     println!("{}", udata);

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -13,8 +13,10 @@ use parser::{Error, Result, Format, DebugMacinfoOffset, parse_u8, parse_u16, par
              parse_address_as_offset, u64_to_offset};
 use ranges::DebugRangesOffset;
 use std::cell::Cell;
+use std::convert::AsMut;
 use std::ffi;
 use std::marker::PhantomData;
+use std::mem;
 use std::ops::{Range, RangeFrom, RangeTo};
 use std::{u8, u16};
 use str::{DebugStr, DebugStrOffset};
@@ -908,13 +910,33 @@ pub enum AttributeValue<'input, Endian>
     /// A slice of an arbitrary number of bytes.
     Block(EndianBuf<'input, Endian>),
 
-    /// A one, two, four, or eight byte constant data value. How to interpret
-    /// the bytes depends on context.
+    /// A one byte constant data value. How to interpret the byte depends on context.
     ///
     /// From section 7 of the standard: "Depending on context, it may be a
     /// signed integer, an unsigned integer, a floating-point constant, or
     /// anything else."
-    Data(EndianBuf<'input, Endian>),
+    Data1([u8; 1]),
+
+    /// A two byte constant data value. How to interpret the bytes depends on context.
+    ///
+    /// From section 7 of the standard: "Depending on context, it may be a
+    /// signed integer, an unsigned integer, a floating-point constant, or
+    /// anything else."
+    Data2([u8; 2]),
+
+    /// A four byte constant data value. How to interpret the bytes depends on context.
+    ///
+    /// From section 7 of the standard: "Depending on context, it may be a
+    /// signed integer, an unsigned integer, a floating-point constant, or
+    /// anything else."
+    Data4([u8; 4]),
+
+    /// An eight byte constant data value. How to interpret the bytes depends on context.
+    ///
+    /// From section 7 of the standard: "Depending on context, it may be a
+    /// signed integer, an unsigned integer, a floating-point constant, or
+    /// anything else."
+    Data8([u8; 8]),
 
     /// A signed integer constant.
     Sdata(i64),
@@ -1447,10 +1469,10 @@ impl<'input, Endian> Attribute<'input, Endian>
     /// Try to convert this attribute's value to an unsigned integer.
     pub fn udata_value(&self) -> Option<u64> {
         Some(match self.value {
-            AttributeValue::Data(data) if data.len() == 1 => data[0] as u64,
-            AttributeValue::Data(data) if data.len() == 2 => Endian::read_u16(data.into()) as u64,
-            AttributeValue::Data(data) if data.len() == 4 => Endian::read_u32(data.into()) as u64,
-            AttributeValue::Data(data) if data.len() == 8 => Endian::read_u64(data.into()),
+            AttributeValue::Data1(ref data) => data[0] as u64,
+            AttributeValue::Data2(ref data) => Endian::read_u16(data) as u64,
+            AttributeValue::Data4(ref data) => Endian::read_u32(data) as u64,
+            AttributeValue::Data8(ref data) => Endian::read_u64(data),
             AttributeValue::Udata(data) => data,
             _ => return None,
         })
@@ -1459,14 +1481,14 @@ impl<'input, Endian> Attribute<'input, Endian>
     /// Try to convert this attribute's value to a signed integer.
     pub fn sdata_value(&self) -> Option<i64> {
         Some(match self.value {
-            AttributeValue::Data(data) if data.len() == 1 => data[0] as i8 as i64,
-            AttributeValue::Data(data) if data.len() == 2 => {
-                Endian::read_u16(data.into()) as i16 as i64
+            AttributeValue::Data1(ref data) => data[0] as i8 as i64,
+            AttributeValue::Data2(ref data) => {
+                Endian::read_u16(data) as i16 as i64
             }
-            AttributeValue::Data(data) if data.len() == 4 => {
-                Endian::read_u32(data.into()) as i32 as i64
+            AttributeValue::Data4(ref data) => {
+                Endian::read_u32(data) as i32 as i64
             }
-            AttributeValue::Data(data) if data.len() == 8 => Endian::read_u64(data.into()) as i64,
+            AttributeValue::Data8(ref data) => Endian::read_u64(data) as i64,
             AttributeValue::Sdata(data) => data,
             _ => return None,
         })
@@ -1477,12 +1499,12 @@ impl<'input, Endian> Attribute<'input, Endian>
     /// Offsets will be `Data` in DWARF version 2/3, and `SecOffset` otherwise.
     pub fn offset_value(&self) -> Option<usize> {
         match self.value {
-            AttributeValue::Data(data) => {
-                let offset = match data.len() {
-                    4 => Endian::read_u32(data.into()) as u64,
-                    8 => Endian::read_u64(data.into()),
-                    _ => return None,
-                };
+            AttributeValue::Data4(ref data) => {
+                let offset = Endian::read_u32(data) as u64;
+                u64_to_offset(offset).ok()
+            }
+            AttributeValue::Data8(ref data) => {
+                let offset = Endian::read_u64(data);
                 u64_to_offset(offset).ok()
             }
             AttributeValue::SecOffset(offset) => Some(offset),
@@ -1542,6 +1564,20 @@ fn length_u32_value<Endian>(input: EndianBuf<Endian>)
     take(len as usize, rest)
 }
 
+fn parse_u8_array<A>(input: &[u8]) -> Result<(&[u8], A)>
+    where A: Sized + Default + AsMut<[u8]>
+{
+    let len = mem::size_of::<A>();
+    if input.len() < len {
+        Err(Error::UnexpectedEof)
+    } else {
+        let (data, rest) = input.split_at(len);
+        let mut a = Default::default();
+        <A as AsMut<[u8]>>::as_mut(&mut a).clone_from_slice(data);
+        Ok((rest, a))
+    }
+}
+
 fn parse_attribute<'input, 'unit, Endian>
     (mut input: EndianBuf<'input, Endian>,
      unit: &'unit UnitHeader<'input, Endian>,
@@ -1579,12 +1615,12 @@ fn parse_attribute<'input, 'unit, Endian>
                 (rest, AttributeValue::Block(block))
             }
             constants::DW_FORM_data1 => {
-                let (rest, data) = take(1, input.into())?;
-                (rest, AttributeValue::Data(data))
+                let (rest, data) = parse_u8_array(input.into())?;
+                (EndianBuf::new(rest), AttributeValue::Data1(data))
             }
             constants::DW_FORM_data2 => {
-                let (rest, data) = take(2, input.into())?;
-                (rest, AttributeValue::Data(data))
+                let (rest, data) = parse_u8_array(input.into())?;
+                (EndianBuf::new(rest), AttributeValue::Data2(data))
             }
             constants::DW_FORM_data4 => {
                 // DWARF version 2/3 may use DW_FORM_data4/8 for section offsets.
@@ -1597,8 +1633,8 @@ fn parse_attribute<'input, 'unit, Endian>
                     let offset = u64_to_offset(offset as u64)?;
                     (rest, AttributeValue::SecOffset(offset as usize))
                 } else {
-                    let (rest, data) = take(4, input.into())?;
-                    (rest, AttributeValue::Data(data))
+                    let (rest, data) = parse_u8_array(input.into())?;
+                    (EndianBuf::new(rest), AttributeValue::Data4(data))
                 }
             }
             constants::DW_FORM_data8 => {
@@ -1612,8 +1648,8 @@ fn parse_attribute<'input, 'unit, Endian>
                     let offset = u64_to_offset(offset)?;
                     (rest, AttributeValue::SecOffset(offset as usize))
                 } else {
-                    let (rest, data) = take(8, input.into())?;
-                    (rest, AttributeValue::Data(data))
+                    let (rest, data) = parse_u8_array(input.into())?;
+                    (EndianBuf::new(rest), AttributeValue::Data8(data))
                 }
             }
             constants::DW_FORM_udata => {
@@ -1742,8 +1778,9 @@ impl<'input, 'abbrev, 'entry, 'unit, Endian> AttrsIter<'input, 'abbrev, 'entry, 
         }
 
         let attr = self.attributes[0];
+        let rest_attr = &self.attributes[1..];
         let (rest, attr) = try!(parse_attribute(EndianBuf::new(self.input), self.entry.unit, attr));
-        self.attributes = &self.attributes[1..];
+        self.attributes = rest_attr;
         self.input = rest.into();
         Ok(Some(attr))
     }
@@ -3163,7 +3200,7 @@ mod tests {
                       constants::DW_AT_data_member_location,
                       constants::DW_FORM_data4,
                       data4,
-                      AttributeValue::Data(data4),
+                      AttributeValue::Data4([4, 3, 2, 1]),
                       AttributeValue::Udata(0x01020304)),
                      (2,
                       constants::DW_AT_data_member_location,
@@ -3175,7 +3212,7 @@ mod tests {
                       constants::DW_AT_data_member_location,
                       constants::DW_FORM_data8,
                       data8,
-                      AttributeValue::Data(data8),
+                      AttributeValue::Data8([8, 7, 6, 5, 4, 3, 2, 1]),
                       AttributeValue::Udata(0x0102030405060708))];
 
         for test in tests.iter() {
@@ -3191,31 +3228,14 @@ mod tests {
 
     #[test]
     fn test_attribute_udata_sdata_value() {
-        let buf = section_contents(|s| s.D8(1));
-        let p1i8 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D8(std::u8::MAX));
-        let n1i8 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D16(1));
-        let p1i16 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D16(std::u16::MAX));
-        let n1i16 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D32(1));
-        let p1i32 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D32(std::u32::MAX));
-        let n1i32 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D64(1));
-        let p1i64 = EndianBuf::<LittleEndian>::new(&buf);
-        let buf = section_contents(|s| s.D64(std::u64::MAX));
-        let n1i64 = EndianBuf::<LittleEndian>::new(&buf);
-
-        let tests = [(AttributeValue::Data(p1i8), Some(1), Some(1)),
-                     (AttributeValue::Data(n1i8), Some(std::u8::MAX as u64), Some(-1)),
-                     (AttributeValue::Data(p1i16), Some(1), Some(1)),
-                     (AttributeValue::Data(n1i16), Some(std::u16::MAX as u64), Some(-1)),
-                     (AttributeValue::Data(p1i32), Some(1), Some(1)),
-                     (AttributeValue::Data(n1i32), Some(std::u32::MAX as u64), Some(-1)),
-                     (AttributeValue::Data(p1i64), Some(1), Some(1)),
-                     (AttributeValue::Data(n1i64), Some(std::u64::MAX), Some(-1)),
+        let tests: &[(AttributeValue<LittleEndian>, _, _)] = &[(AttributeValue::Data1([1]), Some(1), Some(1)),
+                     (AttributeValue::Data1([255]), Some(std::u8::MAX as u64), Some(-1)),
+                     (AttributeValue::Data2([1, 0]), Some(1), Some(1)),
+                     (AttributeValue::Data2([255; 2]), Some(std::u16::MAX as u64), Some(-1)),
+                     (AttributeValue::Data4([1, 0, 0, 0]), Some(1), Some(1)),
+                     (AttributeValue::Data4([255; 4]), Some(std::u32::MAX as u64), Some(-1)),
+                     (AttributeValue::Data8([1, 0, 0, 0, 0, 0, 0, 0]), Some(1), Some(1)),
+                     (AttributeValue::Data8([255; 8]), Some(std::u64::MAX), Some(-1)),
                      (AttributeValue::Sdata(1), None, Some(1)),
                      (AttributeValue::Udata(1), Some(1), None)];
         for test in tests.iter() {
@@ -3335,7 +3355,7 @@ mod tests {
         let buf = [0x03];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data1;
-        let value = AttributeValue::Data(EndianBuf::new(&buf[..]));
+        let value = AttributeValue::Data1([0x03]);
         test_parse_attribute(&buf, 1, &unit, form, value);
     }
 
@@ -3344,7 +3364,7 @@ mod tests {
         let buf = [0x02, 0x01, 0x0];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data2;
-        let value = AttributeValue::Data(EndianBuf::new(&buf[..2]));
+        let value = AttributeValue::Data2([0x02, 0x01]);
         test_parse_attribute(&buf, 2, &unit, form, value);
     }
 
@@ -3353,7 +3373,7 @@ mod tests {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data4;
-        let value = AttributeValue::Data(EndianBuf::new(&buf[..4]));
+        let value = AttributeValue::Data4([0x01, 0x02, 0x03, 0x04]);
         test_parse_attribute(&buf, 4, &unit, form, value);
     }
 
@@ -3362,7 +3382,7 @@ mod tests {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data8;
-        let value = AttributeValue::Data(EndianBuf::new(&buf[..8]));
+        let value = AttributeValue::Data8([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
         test_parse_attribute(&buf, 8, &unit, form, value);
     }
 


### PR DESCRIPTION
The first commit improves performance for `parse_attribute`. Without this, the second commit results in a decrease in performance, but with it we have a net gain.

The second commit changes `AttributeValue::Data` from reference to value. I did this as a step towards changing gimli to use a `Reader` trait. This should be more efficient than either allocating memory, or  storing an offset/length for something that is only up to 8 bytes, and then needing to dereference it via the Reader trait later.

For future work, there's still other reference variants in `AttributeValue` that can't be changed to inline values (`Block`, `ExprLoc` and `String`). Not sure if we have decided what direction to take for things like these: do we want to change these to offsets, or allocate memory for them immediately (possibly using `Cow`)? My preference is to use offsets, so that we're not paying an allocation for cases where we don't actually need these values. For cases where we do need them, the value should still be in the buffer of the `Reader`.