### PR TITLE
WIP Preparation for Reader trait

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -306,7 +306,7 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>,
             println!("0x{:08x}", address);
         }
         gimli::AttributeValue::Block(data) => {
-            for byte in data.0 {
+            for byte in data.buf() {
                 print!("{:02x}", byte);
             }
             println!("");
@@ -369,7 +369,7 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<Endian>,
         gimli::AttributeValue::Exprloc(data) => {
             if let gimli::AttributeValue::Exprloc(_) = attr.raw_value() {
                 print!("len 0x{:04x}: ", data.len());
-                for byte in data.0 {
+                for byte in data.buf() {
                     print!("{:02x}", byte);
                 }
                 print!(": ");
@@ -514,7 +514,7 @@ fn dump_exprloc<Endian>(data: gimli::EndianBuf<Endian>, unit: &Unit<Endian>)
                 } else {
                     space = true;
                 }
-                dump_op(dwop, op, pc.0);
+                dump_op(dwop, op, pc.buf());
             }
             Err(gimli::Error::InvalidExpression(op)) => {
                 writeln!(&mut std::io::stderr(),
@@ -620,7 +620,7 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<Endian>, newpc: &[u8]
         }
         gimli::Operation::EntryValue { expression } => {
             print!(" 0x{:08x} contents 0x", expression.len());
-            for byte in expression.0 {
+            for byte in expression.buf() {
                 print!("{:02x}", byte);
             }
         }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -507,15 +507,14 @@ fn dump_exprloc<Endian>(data: gimli::EndianBuf<Endian>, unit: &Unit<Endian>)
     let mut space = false;
     while pc.len() != 0 {
         let dwop = gimli::DwOp(pc[0]);
-        match gimli::Operation::parse(pc, data, unit.address_size, unit.format) {
-            Ok((newpc, op)) => {
+        match gimli::Operation::parse(&mut pc, data, unit.address_size, unit.format) {
+            Ok(op) => {
                 if space {
                     print!(" ");
                 } else {
                     space = true;
                 }
-                dump_op(dwop, op, newpc.0);
-                pc = newpc;
+                dump_op(dwop, op, pc.0);
             }
             Err(gimli::Error::InvalidExpression(op)) => {
                 writeln!(&mut std::io::stderr(),

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -48,9 +48,9 @@ impl<'input, Endian> DebugAbbrev<'input, Endian>
     ///
     /// The `offset` should generally be retrieved from a unit header.
     pub fn abbreviations(&self, debug_abbrev_offset: DebugAbbrevOffset) -> Result<Abbreviations> {
-        let input = self.debug_abbrev_section
+        let input = &mut self.debug_abbrev_section
             .range_from(debug_abbrev_offset.0..);
-        Abbreviations::parse(input).map(|(_, abbrevs)| abbrevs)
+        Abbreviations::parse(input)
     }
 }
 
@@ -134,26 +134,18 @@ impl Abbreviations {
     }
 
     /// Parse a series of abbreviations, terminated by a null abbreviation.
-    fn parse<Endian>(mut input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, Abbreviations)>
+    fn parse<Endian>(input: &mut EndianBuf<Endian>) -> Result<Abbreviations>
         where Endian: Endianity
     {
         let mut abbrevs = Abbreviations::empty();
 
-        loop {
-            let (rest, abbrev) = Abbreviation::parse(input)?;
-            input = rest;
-
-            match abbrev {
-                None => break,
-                Some(abbrev) => {
-                    if abbrevs.insert(abbrev).is_err() {
-                        return Err(Error::DuplicateAbbreviationCode);
-                    }
-                }
+        while let Some(abbrev) = Abbreviation::parse(input)? {
+            if abbrevs.insert(abbrev).is_err() {
+                return Err(Error::DuplicateAbbreviationCode);
             }
         }
 
-        Ok((input, abbrevs))
+        Ok(abbrevs)
     }
 }
 
@@ -212,26 +204,25 @@ impl Abbreviation {
     }
 
     /// Parse an abbreviation's tag.
-    fn parse_tag<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, constants::DwTag)>
+    fn parse_tag<Endian>(input: &mut EndianBuf<Endian>) -> Result<constants::DwTag>
         where Endian: Endianity
     {
-        let (rest, val) = parse_unsigned_leb(input)?;
+        let val = parse_unsigned_leb(input)?;
         if val == 0 {
             Err(Error::AbbreviationTagZero)
         } else {
-            Ok((rest, constants::DwTag(val)))
+            Ok(constants::DwTag(val))
         }
     }
 
     /// Parse an abbreviation's "does the type have children?" byte.
-    fn parse_has_children<Endian>(input: EndianBuf<Endian>)
-                                  -> Result<(EndianBuf<Endian>, constants::DwChildren)>
+    fn parse_has_children<Endian>(input: &mut EndianBuf<Endian>) -> Result<constants::DwChildren>
         where Endian: Endianity
     {
-        let (rest, val) = parse_u8(input)?;
+        let val = parse_u8(input)?;
         let val = constants::DwChildren(val);
         if val == constants::DW_CHILDREN_no || val == constants::DW_CHILDREN_yes {
-            Ok((rest, val))
+            Ok(val)
         } else {
             Err(Error::BadHasChildren)
         }
@@ -239,40 +230,34 @@ impl Abbreviation {
 
     /// Parse a series of attribute specifications, terminated by a null attribute
     /// specification.
-    fn parse_attributes<Endian>(mut input: EndianBuf<Endian>)
-                                -> Result<(EndianBuf<Endian>, Vec<AttributeSpecification>)>
+    fn parse_attributes<Endian>(input: &mut EndianBuf<Endian>)
+                                -> Result<Vec<AttributeSpecification>>
         where Endian: Endianity
     {
         let mut attrs = Vec::new();
 
-        loop {
-            let (rest, attr) = AttributeSpecification::parse(input)?;
-            input = rest;
-
-            match attr {
-                None => break,
-                Some(attr) => attrs.push(attr),
-            };
+        while let Some(attr) = AttributeSpecification::parse(input)? {
+            attrs.push(attr);
         }
 
-        Ok((input, attrs))
+        Ok(attrs)
     }
 
     /// Parse an abbreviation. Return `None` for the null abbreviation, `Some`
     /// for an actual abbreviation.
-    fn parse<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, Option<Abbreviation>)>
+    fn parse<Endian>(input: &mut EndianBuf<Endian>) -> Result<Option<Abbreviation>>
         where Endian: Endianity
     {
-        let (rest, code) = parse_unsigned_leb(input)?;
+        let code = parse_unsigned_leb(input)?;
         if code == 0 {
-            return Ok((rest, None));
+            return Ok(None);
         }
 
-        let (rest, tag) = Self::parse_tag(rest)?;
-        let (rest, has_children) = Self::parse_has_children(rest)?;
-        let (rest, attributes) = Self::parse_attributes(rest)?;
+        let tag = Self::parse_tag(input)?;
+        let has_children = Self::parse_has_children(input)?;
+        let attributes = Self::parse_attributes(input)?;
         let abbrev = Abbreviation::new(code, tag, has_children, attributes);
-        Ok((rest, Some(abbrev)))
+        Ok(Some(abbrev))
     }
 }
 
@@ -357,39 +342,37 @@ impl AttributeSpecification {
     }
 
     /// Parse an attribute's form.
-    fn parse_form<Endian>(input: EndianBuf<Endian>)
-                          -> Result<(EndianBuf<Endian>, constants::DwForm)>
+    fn parse_form<Endian>(input: &mut EndianBuf<Endian>) -> Result<constants::DwForm>
         where Endian: Endianity
     {
-        let (rest, val) = parse_unsigned_leb(input)?;
+        let val = parse_unsigned_leb(input)?;
         if val == 0 {
             Err(Error::AttributeFormZero)
         } else {
-            Ok((rest, constants::DwForm(val)))
+            Ok(constants::DwForm(val))
         }
     }
 
     /// Parse an attribute specification. Returns `None` for the null attribute
     /// specification, `Some` for an actual attribute specification.
-    fn parse<Endian>(input: EndianBuf<Endian>)
-                     -> Result<(EndianBuf<Endian>, Option<AttributeSpecification>)>
+    fn parse<Endian>(input: &mut EndianBuf<Endian>) -> Result<Option<AttributeSpecification>>
         where Endian: Endianity
     {
-        let (rest, name) = parse_unsigned_leb(input)?;
+        let name = parse_unsigned_leb(input)?;
         if name == 0 {
             // Parse the null attribute specification.
-            let (rest, form) = parse_unsigned_leb(rest)?;
+            let form = parse_unsigned_leb(input)?;
             return if form == 0 {
-                Ok((rest, None))
+                Ok(None)
             } else {
                 Err(Error::ExpectedZero)
             };
         }
 
         let name = constants::DwAt(name);
-        let (rest, form) = Self::parse_form(rest)?;
+        let form = Self::parse_form(input)?;
         let spec = AttributeSpecification::new(name, form);
-        Ok((rest, Some(spec)))
+        Ok(Some(spec))
     }
 }
 
@@ -582,7 +565,7 @@ pub mod tests {
             .append_bytes(&expected_rest)
             .get_contents()
             .unwrap();
-        let buf = EndianBuf::<LittleEndian>::new(&*buf);
+        let rest = &mut EndianBuf::<LittleEndian>::new(&*buf);
 
         let abbrev1 =
             Abbreviation::new(1,
@@ -599,10 +582,10 @@ pub mod tests {
                                         vec![AttributeSpecification::new(constants::DW_AT_name,
                                                                constants::DW_FORM_string)]);
 
-        let (rest, abbrevs) = Abbreviations::parse(buf).expect("Should parse abbreviations");
+        let abbrevs = Abbreviations::parse(rest).expect("Should parse abbreviations");
         assert_eq!(abbrevs.get(1), Some(&abbrev1));
         assert_eq!(abbrevs.get(2), Some(&abbrev2));
-        assert_eq!(*rest, expected_rest);
+        assert_eq!(*rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -622,7 +605,7 @@ pub mod tests {
             .append_bytes(&expected_rest)
             .get_contents()
             .unwrap();
-        let buf = EndianBuf::<LittleEndian>::new(&*buf);
+        let buf = &mut EndianBuf::<LittleEndian>::new(&*buf);
 
         match Abbreviations::parse(buf) {
             Err(Error::DuplicateAbbreviationCode) => {}
@@ -633,16 +616,16 @@ pub mod tests {
     #[test]
     fn test_parse_abbreviation_tag_ok() {
         let buf = [0x01, 0x02];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, tag) = Abbreviation::parse_tag(buf).expect("Should parse tag");
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let tag = Abbreviation::parse_tag(rest).expect("Should parse tag");
         assert_eq!(tag, constants::DW_TAG_array_type);
-        assert_eq!(*rest, *buf.range_from(1..));
+        assert_eq!(*rest, EndianBuf::new(&buf[1..]));
     }
 
     #[test]
     fn test_parse_abbreviation_tag_zero() {
         let buf = [0x00];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
         match Abbreviation::parse_tag(buf) {
             Err(Error::AbbreviationTagZero) => {}
             otherwise => panic!("Unexpected result: {:?}", otherwise),
@@ -652,10 +635,10 @@ pub mod tests {
     #[test]
     fn test_parse_abbreviation_has_children() {
         let buf = [0x00, 0x01, 0x02];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, val) = Abbreviation::parse_has_children(buf).expect("Should parse children");
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let val = Abbreviation::parse_has_children(rest).expect("Should parse children");
         assert_eq!(val, constants::DW_CHILDREN_no);
-        let (rest, val) = Abbreviation::parse_has_children(rest).expect("Should parse children");
+        let val = Abbreviation::parse_has_children(rest).expect("Should parse children");
         assert_eq!(val, constants::DW_CHILDREN_yes);
         match Abbreviation::parse_has_children(rest) {
             Err(Error::BadHasChildren) => {}
@@ -673,7 +656,7 @@ pub mod tests {
             .append_bytes(&expected_rest)
             .get_contents()
             .unwrap();
-        let buf = EndianBuf::<LittleEndian>::new(&*buf);
+        let rest = &mut EndianBuf::<LittleEndian>::new(&*buf);
 
         let expect = Some(Abbreviation::new(1,
                                             constants::DW_TAG_subprogram,
@@ -681,9 +664,9 @@ pub mod tests {
                                             vec![AttributeSpecification::new(constants::DW_AT_name,
                                                                     constants::DW_FORM_string)]));
 
-        let (rest, abbrev) = Abbreviation::parse(buf).expect("Should parse abbreviation");
+        let abbrev = Abbreviation::parse(rest).expect("Should parse abbreviation");
         assert_eq!(abbrev, expect);
-        assert_eq!(*rest, expected_rest);
+        assert_eq!(*rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -694,26 +677,26 @@ pub mod tests {
             .append_bytes(&expected_rest)
             .get_contents()
             .unwrap();
-        let buf = EndianBuf::<LittleEndian>::new(&*buf);
+        let rest = &mut EndianBuf::<LittleEndian>::new(&*buf);
 
-        let (rest, abbrev) = Abbreviation::parse(buf).expect("Should parse null abbreviation");
+        let abbrev = Abbreviation::parse(rest).expect("Should parse null abbreviation");
         assert!(abbrev.is_none());
-        assert_eq!(*rest, expected_rest);
+        assert_eq!(*rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
     fn test_parse_attribute_form_ok() {
         let buf = [0x01, 0x02];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, tag) = AttributeSpecification::parse_form(buf).expect("Should parse form");
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let tag = AttributeSpecification::parse_form(rest).expect("Should parse form");
         assert_eq!(tag, constants::DW_FORM_addr);
-        assert_eq!(*rest, *buf.range_from(1..));
+        assert_eq!(*rest, EndianBuf::new(&buf[1..]));
     }
 
     #[test]
     fn test_parse_attribute_form_zero() {
         let buf = [0x00];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
         match AttributeSpecification::parse_form(buf) {
             Err(Error::AttributeFormZero) => {}
             otherwise => panic!("Unexpected result: {:?}", otherwise),
@@ -723,17 +706,17 @@ pub mod tests {
     #[test]
     fn test_parse_null_attribute_specification_ok() {
         let buf = [0x00, 0x00, 0x01];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, attr) = AttributeSpecification::parse(buf)
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let attr = AttributeSpecification::parse(rest)
             .expect("Should parse null attribute specification");
         assert!(attr.is_none());
-        assert_eq!(*rest, [0x01]);
+        assert_eq!(*rest, EndianBuf::new(&buf[2..]));
     }
 
     #[test]
     fn test_parse_attribute_specifications_name_zero() {
         let buf = [0x00, 0x01, 0x00, 0x00];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
         match AttributeSpecification::parse(buf) {
             Err(Error::ExpectedZero) => {}
             otherwise => panic!("Unexpected result: {:?}", otherwise),
@@ -743,7 +726,7 @@ pub mod tests {
     #[test]
     fn test_parse_attribute_specifications_form_zero() {
         let buf = [0x01, 0x00, 0x00, 0x00];
-        let buf = EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
         match AttributeSpecification::parse(buf) {
             Err(Error::AttributeFormZero) => {}
             otherwise => panic!("Unexpected result: {:?}", otherwise),

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -1,7 +1,7 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{LookupParser, LookupEntryIter, DebugLookup};
-use parser::{parse_address_size, parse_initial_length, parse_u16, parse_address, Error, Format,
-             Result};
+use parser::{parse_address_size, parse_initial_length, parse_u16, parse_address, take, Error,
+             Format, Result};
 use unit::{DebugInfoOffset, parse_debug_info_offset};
 use std::cmp::Ordering;
 use std::marker::PhantomData;
@@ -111,11 +111,7 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
     fn parse_header(input: &mut EndianBuf<'input, Endian>)
                     -> Result<(EndianBuf<'input, Endian>, Rc<Self::Header>)> {
         let (length, format) = parse_initial_length(input)?;
-        if length as usize > input.len() {
-            return Err(Error::UnexpectedEof);
-        }
-        let rest = &mut input.range_to(..length as usize);
-        *input = input.range_from(length as usize..);
+        let rest = &mut take(length as usize, input)?;
 
         let version = parse_u16(rest)?;
         if version != 2 {

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -108,23 +108,23 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
     /// Parse an arange set header. Returns a tuple of the remaining arange sets, the aranges to be
     /// parsed for this set, and the newly created ArangeHeader struct.
     #[allow(type_complexity)]
-    fn parse_header(input: EndianBuf<Endian>)
-                    -> Result<(EndianBuf<Endian>, EndianBuf<Endian>, Rc<Self::Header>)> {
-        let (rest, (length, format)) = parse_initial_length(input)?;
-        if length as usize > rest.len() {
+    fn parse_header(input: &mut EndianBuf<'input, Endian>)
+                    -> Result<(EndianBuf<'input, Endian>, Rc<Self::Header>)> {
+        let (length, format) = parse_initial_length(input)?;
+        if length as usize > input.len() {
             return Err(Error::UnexpectedEof);
         }
-        let after_set = rest.range_from(length as usize..);
-        let rest = rest.range_to(..length as usize);
+        let rest = &mut input.range_to(..length as usize);
+        *input = input.range_from(length as usize..);
 
-        let (rest, version) = parse_u16(rest)?;
+        let version = parse_u16(rest)?;
         if version != 2 {
             return Err(Error::UnknownVersion);
         }
 
-        let (rest, offset) = parse_debug_info_offset(rest, format)?;
-        let (rest, address_size) = parse_address_size(rest)?;
-        let (rest, segment_size) = parse_address_size(rest)?;
+        let offset = parse_debug_info_offset(rest, format)?;
+        let address_size = parse_address_size(rest)?;
+        let segment_size = parse_address_size(rest)?;
 
         // unit_length + version + offset + address_size + segment_size
         let header_length = match format {
@@ -146,8 +146,7 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
         }
         let rest = rest.range_from(padding..);
 
-        Ok((after_set,
-            rest,
+        Ok((rest,
             Rc::new(ArangeHeader {
                         format: format,
                         length: length,
@@ -159,38 +158,38 @@ impl<'input, Endian> LookupParser<'input, Endian> for ArangeParser<'input, Endia
     }
 
     /// Parse a single arange. Return `None` for the null arange, `Some` for an actual arange.
-    fn parse_entry(input: EndianBuf<'input, Endian>,
+    fn parse_entry(input: &mut EndianBuf<'input, Endian>,
                    header: &Rc<Self::Header>)
-                   -> Result<(EndianBuf<'input, Endian>, Option<Self::Entry>)> {
+                   -> Result<Option<Self::Entry>> {
         let address_size = header.address_size;
         let segment_size = header.segment_size; // May be zero!
 
         let tuple_length = (2 * address_size + segment_size) as usize;
         if tuple_length > input.len() {
-            return Ok((EndianBuf::new(&[]), None));
+            *input = EndianBuf::new(&[]);
+            return Ok(None);
         }
 
-        let (rest, segment) = if segment_size != 0 {
+        let segment = if segment_size != 0 {
             parse_address(input, segment_size)?
         } else {
-            (input, 0)
+            0
         };
-        let (rest, address) = parse_address(rest, address_size)?;
-        let (rest, length) = parse_address(rest, address_size)?;
+        let address = parse_address(input, address_size)?;
+        let length = parse_address(input, address_size)?;
 
         match (segment, address, length) {
             // There may be multiple sets of tuples, each terminated by a zero tuple.
             // It's not clear what purpose these zero tuples serve.  For now, we
             // simply skip them.
-            (0, 0, 0) => Self::parse_entry(rest, header),
+            (0, 0, 0) => Self::parse_entry(input, header),
             _ => {
-                Ok((rest,
-                    Some(ArangeEntry {
-                             segment: segment,
-                             address: address,
-                             length: length,
-                             header: header.clone(),
-                         })))
+                Ok(Some(ArangeEntry {
+                            segment: segment,
+                            address: address,
+                            length: length,
+                            header: header.clone(),
+                        }))
             }
         }
     }
@@ -312,12 +311,12 @@ mod tests {
             0x00, 0x00, 0x00, 0x00,
         ];
 
-        let input = EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
 
-        let (rest, tuples, header) = ArangeParser::parse_header(input)
+        let (tuples, header) = ArangeParser::parse_header(rest)
             .expect("should parse header ok");
 
-        assert_eq!(rest, EndianBuf::new(&buf[buf.len() - 16..]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 16..]));
         assert_eq!(tuples, EndianBuf::new(&buf[buf.len() - 32..buf.len() - 16]));
         assert_eq!(*header,
                    ArangeHeader {
@@ -341,10 +340,9 @@ mod tests {
                                  segment_size: 0,
                              });
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
-        let input = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, entry) = ArangeParser::parse_entry(input, &header)
-            .expect("should parse entry ok");
-        assert_eq!(rest, EndianBuf::new(&buf[buf.len() - 1..]));
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let entry = ArangeParser::parse_entry(rest, &header).expect("should parse entry ok");
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..]));
         assert_eq!(entry,
                    Some(ArangeEntry {
                             segment: 0,
@@ -375,10 +373,10 @@ mod tests {
             // Next tuple.
             0x09
         ];
-        let input = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, entry) = ArangeParser::parse_entry(input, &header)
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let entry = ArangeParser::parse_entry(rest, &header)
             .expect("should parse entry ok");
-        assert_eq!(rest, EndianBuf::new(&buf[buf.len() - 1..]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..]));
         assert_eq!(entry,
                    Some(ArangeEntry {
                        segment: 0x1817161514131211,
@@ -409,10 +407,10 @@ mod tests {
             // Next tuple.
             0x09
         ];
-        let input = EndianBuf::<LittleEndian>::new(&buf);
-        let (rest, entry) = ArangeParser::parse_entry(input, &header)
+        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let entry = ArangeParser::parse_entry(rest, &header)
             .expect("should parse entry ok");
-        assert_eq!(rest, EndianBuf::new(&buf[buf.len() - 1..]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..]));
         assert_eq!(entry,
                    Some(ArangeEntry {
                        segment: 0,

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -443,18 +443,9 @@ impl<'input, Endian> _UnwindSectionPrivate<'input, Endian> for EhFrame<'input, E
         debug_assert!(section.len() > 0);
         debug_assert!(input_before_offset.len() > 0);
 
-        // Additionally, the input_before_offset slice must be a subset of the
-        // section's slice.
-        debug_assert!(section.as_ptr() as usize <= input_before_offset.as_ptr() as usize);
-        debug_assert!(input_before_offset.as_ptr() as usize + input_before_offset.len() <=
-                      section.as_ptr() as usize + section.len());
-
-        let offset_ptr = (input_before_offset.as_ptr() as usize)
-            .saturating_sub(input_relative_offset);
-        if section.as_ptr() as usize <= offset_ptr &&
-           offset_ptr < section.as_ptr() as usize + section.len() {
-            let section_relative_offset = offset_ptr - section.as_ptr() as usize;
-            Some(section_relative_offset)
+        let input_offset = input_before_offset.offset_from(section);
+        if input_relative_offset <= input_offset {
+            Some(input_offset - input_relative_offset)
         } else {
             None
         }
@@ -1121,7 +1112,7 @@ impl<'input, Endian, Section> FrameDescriptionEntry<'input, Endian, Section>
 
         {
             let mut func = bases.func.borrow_mut();
-            let offset = rest.as_ptr() as usize - section.section().as_ptr() as usize;
+            let offset = rest.offset_from(section.section());
             *func = Some(offset as u64);
         }
 

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -5,8 +5,8 @@ use fallible_iterator::FallibleIterator;
 use parser::{Error, Format, Pointer, Result, parse_address, parse_encoded_pointer,
              parse_initial_length, parse_length_uleb_value, parse_null_terminated_string,
              parse_pointer_encoding, parse_signed_leb, parse_u8, parse_u16, parse_u32,
-             parse_u32_as_u64, parse_u64, parse_unsigned_leb, parse_unsigned_leb_as_u8,
-             take, u64_to_offset};
+             parse_u32_as_u64, parse_u64, parse_unsigned_leb, parse_unsigned_leb_as_u8, take,
+             u64_to_offset};
 use std::cell::RefCell;
 use std::fmt::Debug;
 use std::iter::FromIterator;
@@ -653,12 +653,7 @@ fn parse_cfi_entry_common<'input, Endian, Section>
         return Ok(None);
     }
 
-    if length as usize > input.len() {
-        return Err(Error::BadLength);
-    }
-
-    let cie_offset_input = input.range_to(..length as usize);
-    *input = input.range_from(length as usize..);
+    let cie_offset_input = take(length as usize, input)?;
 
     let mut rest = cie_offset_input;
     let cie_id_or_offset = match Section::cie_offset_encoding(format) {
@@ -3060,7 +3055,7 @@ mod tests {
         assert_eq!(DebugFrameCie::parse(&bases,
                                         DebugFrame::new(&contents),
                                         &mut EndianBuf::<LittleEndian>::new(&contents)),
-                   Err(Error::BadLength));
+                   Err(Error::UnexpectedEof));
     }
 
     #[test]

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -6,7 +6,7 @@ use parser::{Error, Format, Pointer, Result, parse_address, parse_encoded_pointe
              parse_initial_length, parse_length_uleb_value, parse_null_terminated_string,
              parse_pointer_encoding, parse_signed_leb, parse_u8, parse_u16, parse_u32,
              parse_u32_as_u64, parse_u64, parse_unsigned_leb, parse_unsigned_leb_as_u8,
-             u64_to_offset};
+             take, u64_to_offset};
 use std::cell::RefCell;
 use std::fmt::Debug;
 use std::iter::FromIterator;
@@ -804,9 +804,7 @@ impl Augmentation {
         let mut augmentation = Augmentation::default();
 
         let augmentation_length = parse_unsigned_leb(input)?;
-        let (mut rest, rest_rest) = input.try_split_at(augmentation_length as usize)?;
-        *input = rest_rest;
-        let rest = &mut rest;
+        let rest = &mut take(augmentation_length as usize, input)?;
 
         for ch in chars {
             match ch {
@@ -859,9 +857,7 @@ impl AugmentationData {
         // can just check for its presence directly.
 
         let aug_data_len = parse_unsigned_leb(input)?;
-        let (mut rest, rest_rest) = input.try_split_at(aug_data_len as usize)?;
-        *input = rest_rest;
-        let rest = &mut rest;
+        let rest = &mut take(aug_data_len as usize, input)?;
         let mut augmentation_data = AugmentationData::default();
         if let Some(encoding) = augmentation.lsda {
             let lsda =

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -1,7 +1,10 @@
 //! Types for compile-time endianity.
 
 use byteorder;
+use std::cmp;
 use std::fmt::Debug;
+use std::io;
+use std::io::Read;
 use std::marker::PhantomData;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 
@@ -249,6 +252,17 @@ impl<'input, Endian> Into<&'input [u8]> for EndianBuf<'input, Endian>
 {
     fn into(self) -> &'input [u8] {
         self.buf
+    }
+}
+
+impl<'input, Endian> Read for EndianBuf<'input, Endian>
+    where Endian: Endianity
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let len = cmp::min(buf.len(), self.buf.len());
+        buf[..len].copy_from_slice(&self.buf[..len]);
+        self.buf = &self.buf[len..];
+        Ok(len)
     }
 }
 

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -1,7 +1,6 @@
 //! Types for compile-time endianity.
 
 use byteorder;
-use parser::{Error, Result};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
@@ -134,19 +133,6 @@ impl<'input, Endian> EndianBuf<'input, Endian>
     pub fn split_at(&self, idx: usize) -> (EndianBuf<'input, Endian>, EndianBuf<'input, Endian>) {
         (self.range_to(..idx), self.range_from(idx..))
     }
-
-    /// The same as `split_at`, but returns a `Result` rather than panicking
-    /// when the index is out of bounds.
-    #[inline]
-    pub fn try_split_at(&self,
-                        idx: usize)
-                        -> Result<(EndianBuf<'input, Endian>, EndianBuf<'input, Endian>)> {
-        if idx > self.len() {
-            Err(Error::BadLength)
-        } else {
-            Ok(self.split_at(idx))
-        }
-    }
 }
 
 /// # Range Methods
@@ -242,7 +228,6 @@ impl<'input, Endian> Into<&'input [u8]> for EndianBuf<'input, Endian>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parser::Error;
 
     #[test]
     fn test_endian_buf_split_at() {
@@ -258,20 +243,5 @@ mod tests {
         let buf = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
         let eb = EndianBuf::<NativeEndian>::new(&buf);
         eb.split_at(30);
-    }
-
-    #[test]
-    fn test_endian_buf_try_split_at() {
-        let buf = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
-        let eb = EndianBuf::<NativeEndian>::new(&buf);
-        assert_eq!(eb.try_split_at(3),
-                   Ok((EndianBuf::new(&buf[..3]), EndianBuf::new(&buf[3..]))));
-    }
-
-    #[test]
-    fn test_endian_buf_try_split_at_out_of_bounds() {
-        let buf = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
-        let eb = EndianBuf::<NativeEndian>::new(&buf);
-        assert_eq!(Err(Error::BadLength), eb.try_split_at(30));
     }
 }

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -154,6 +154,16 @@ impl<'input, Endian> EndianBuf<'input, Endian>
     pub fn find(&self, byte: u8) -> Option<usize> {
         self.buf.iter().position(|ch| *ch == byte)
     }
+
+    /// Return the offset of the start of the buffer relative to the start
+    /// of the given buffer.
+    pub fn offset_from(&self, base: EndianBuf<'input, Endian>) -> usize {
+        let base_ptr = base.buf.as_ptr() as *const u8 as usize;
+        let ptr = self.buf.as_ptr() as *const u8 as usize;
+        debug_assert!(base_ptr <= ptr);
+        debug_assert!(ptr + self.buf.len() <= base_ptr + base.buf.len());
+        ptr - base_ptr
+    }
 }
 
 /// # Range Methods

--- a/src/line.rs
+++ b/src/line.rs
@@ -712,11 +712,9 @@ impl<'input, Endian> OpcodesIter<'input, Endian>
     where Endian: Endianity
 {
     fn remove_trailing(&self, other: &OpcodesIter<'input, Endian>) -> OpcodesIter<'input, Endian> {
-        debug_assert!(other.input.len() < self.input.len());
-        debug_assert!(other.input.as_ptr() > self.input.as_ptr());
-        debug_assert!(other.input.as_ptr() <=
-                      unsafe { self.input.as_ptr().offset(self.input.len() as isize) });
-        OpcodesIter { input: self.input.split_at(self.input.len() - other.input.len()).0 }
+        let offset = other.input.offset_from(self.input);
+        debug_assert!(offset <= self.input.len());
+        OpcodesIter { input: self.input.range_to(..offset) }
     }
 }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -3,7 +3,6 @@ use endianity::{Endianity, EndianBuf};
 use parser;
 use std::ffi;
 use std::fmt;
-use std::marker::PhantomData;
 use Section;
 
 /// An offset into the `.debug_line` section.
@@ -37,7 +36,7 @@ impl<'input, Endian> DebugLine<'input, Endian>
     /// let debug_line = DebugLine::<LittleEndian>::new(read_debug_line_section_somehow());
     /// ```
     pub fn new(debug_line_section: &'input [u8]) -> DebugLine<'input, Endian> {
-        DebugLine { debug_line_section: EndianBuf(debug_line_section, PhantomData) }
+        DebugLine { debug_line_section: EndianBuf::new(debug_line_section) }
     }
 
     /// Parse the line number program whose header is at the given `offset` in the
@@ -1223,7 +1222,7 @@ impl<'input, Endian> LineNumberProgramHeader<'input, Endian>
                     line_base: line_base,
                     line_range: line_range,
                     opcode_base: opcode_base,
-                    standard_opcode_lengths: standard_opcode_lengths.0,
+                    standard_opcode_lengths: standard_opcode_lengths.buf(),
                     include_directories: include_directories,
                     file_names: file_names,
                     format: format,

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -2,7 +2,6 @@ use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
 use parser::{Error, Result, parse_u16, take};
 use ranges::Range;
-use std::marker::PhantomData;
 use Section;
 
 /// An offset into the `.debug_loc` section.
@@ -36,7 +35,7 @@ impl<'input, Endian> DebugLoc<'input, Endian>
     /// let debug_loc = DebugLoc::<LittleEndian>::new(read_debug_loc_section_somehow());
     /// ```
     pub fn new(debug_loc_section: &'input [u8]) -> DebugLoc<'input, Endian> {
-        DebugLoc { debug_loc_section: EndianBuf(debug_loc_section, PhantomData) }
+        DebugLoc { debug_loc_section: EndianBuf::new(debug_loc_section) }
     }
 
     /// Iterate over the `LocationListEntry`s starting at the given offset.

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -23,18 +23,18 @@ pub trait LookupParser<'input, Endian>
     /// The type of the produced entry.
     type Entry;
 
-    /// Parse a header from `input`. Returns a tuple of `input` sliced beyond this header and
-    /// all of its entries, `input` sliced to contain just the entries corresponding to this
-    /// header (without the header itself), and the parsed representation of the header itself.
+    /// Parse a header from `input`. Returns a tuple of `input` sliced to contain just the entries
+    /// corresponding to this header (without the header itself), and the parsed representation of
+    /// the header itself.
     #[allow(type_complexity)]
-    fn parse_header(input: EndianBuf<Endian>)
-                    -> Result<(EndianBuf<Endian>, EndianBuf<Endian>, Rc<Self::Header>)>;
+    fn parse_header(input: &mut EndianBuf<'input, Endian>)
+                    -> Result<(EndianBuf<'input, Endian>, Rc<Self::Header>)>;
 
-    /// Parse a single entry from `input`. Returns a tuple of the amount of `input` remaining
-    /// and either a parsed representation of the entry or None if `input` is exhausted.
-    fn parse_entry(input: EndianBuf<'input, Endian>,
+    /// Parse a single entry from `input`. Returns either a parsed representation of the entry
+    /// or None if `input` is exhausted.
+    fn parse_entry(input: &mut EndianBuf<'input, Endian>,
                    header: &Rc<Self::Header>)
-                   -> Result<(EndianBuf<'input, Endian>, Option<Self::Entry>)>;
+                   -> Result<Option<Self::Entry>>;
 }
 
 #[allow(missing_docs)]
@@ -99,17 +99,15 @@ impl<'input, Endian, Parser> LookupEntryIter<'input, Endian, Parser>
                 Ok(None)
             } else {
                 // Parse the next header.
-                let (input, set, header) = Parser::parse_header(self.remaining_input)?;
-                self.remaining_input = input;
+                let (set, header) = Parser::parse_header(&mut self.remaining_input)?;
                 self.current_set = set;
                 self.current_header = Some(header);
                 // Header is parsed, go parse the first entry.
                 self.next()
             }
         } else {
-            let (remaining_set, entry) =
-                Parser::parse_entry(self.current_set, self.current_header.as_ref().unwrap())?;
-            self.current_set = remaining_set;
+            let entry = Parser::parse_entry(&mut self.current_set,
+                                            self.current_header.as_ref().unwrap())?;
             match entry {
                 None => self.next(),
                 Some(entry) => Ok(Some(entry)),
@@ -147,9 +145,7 @@ pub trait NamesOrTypesSwitch<'input, Endian>
 
     fn new_entry(offset: u64, name: &'input ffi::CStr, header: &Rc<Self::Header>) -> Self::Entry;
 
-    fn parse_offset(input: EndianBuf<Endian>,
-                    format: Format)
-                    -> Result<(EndianBuf<Endian>, Self::Offset)>;
+    fn parse_offset(input: &mut EndianBuf<Endian>, format: Format) -> Result<Self::Offset>;
 
     fn format_from(header: &Self::Header) -> Format;
 }
@@ -173,17 +169,17 @@ impl<'input, Endian, Switch> LookupParser<'input, Endian> for PubStuffParser<'in
     /// Parse an pubthings set header. Returns a tuple of the remaining pubthings sets, the
     /// pubthings to be parsed for this set, and the newly created PubThingHeader struct.
     #[allow(type_complexity)]
-    fn parse_header(input: EndianBuf<Endian>)
-                    -> Result<(EndianBuf<Endian>, EndianBuf<Endian>, Rc<Self::Header>)> {
-        let (rest, (set_length, format)) = parse_initial_length(input.into())?;
-        let (rest, version) = parse_u16(rest.into())?;
+    fn parse_header(input: &mut EndianBuf<'input, Endian>)
+                    -> Result<(EndianBuf<'input, Endian>, Rc<Self::Header>)> {
+        let (set_length, format) = parse_initial_length(input)?;
+        let version = parse_u16(input)?;
 
         if version != 2 {
             return Err(Error::UnknownVersion);
         }
 
-        let (rest, info_offset) = Switch::parse_offset(rest.into(), format)?;
-        let (rest, info_length) = parse_word(rest.into(), format)?;
+        let info_offset = Switch::parse_offset(input, format)?;
+        let info_length = parse_word(input, format)?;
 
         let header_length = match format {
             Format::Dwarf32 => 10,
@@ -192,23 +188,24 @@ impl<'input, Endian, Switch> LookupParser<'input, Endian> for PubStuffParser<'in
         let dividing_line: usize = set_length
             .checked_sub(header_length)
             .ok_or(Error::BadLength)? as usize;
+        let rest = input.range_to(..dividing_line);
+        *input = input.range_from(dividing_line..);
 
-        Ok((rest.range_from(dividing_line..),
-            rest.range_to(..dividing_line),
-            Switch::new_header(format, set_length, version, info_offset, info_length)))
+        Ok((rest, Switch::new_header(format, set_length, version, info_offset, info_length)))
     }
 
     /// Parse a single pubthing. Return `None` for the null pubthing, `Some` for an actual pubthing.
-    fn parse_entry(input: EndianBuf<'input, Endian>,
+    fn parse_entry(input: &mut EndianBuf<'input, Endian>,
                    header: &Rc<Self::Header>)
-                   -> Result<(EndianBuf<'input, Endian>, Option<Self::Entry>)> {
-        let (rest, offset) = parse_word(input.into(), Switch::format_from(header))?;
+                   -> Result<Option<Self::Entry>> {
+        let offset = parse_word(input, Switch::format_from(header))?;
 
         if offset == 0 {
-            Ok((EndianBuf::new(&[]), None))
+            *input = EndianBuf::new(&[]);
+            Ok(None)
         } else {
-            let (rest, name) = parse_null_terminated_string(rest)?;
-            Ok((rest, Some(Switch::new_entry(offset, name, header))))
+            let name = parse_null_terminated_string(input)?;
+            Ok(Some(Switch::new_entry(offset, name, header)))
         }
     }
 }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -54,7 +54,7 @@ impl<'input, Endian, Parser> DebugLookup<'input, Endian, Parser>
     #[allow(missing_docs)]
     pub fn new(input_buffer: &'input [u8]) -> DebugLookup<'input, Endian, Parser> {
         DebugLookup {
-            input_buffer: EndianBuf(input_buffer, PhantomData),
+            input_buffer: EndianBuf::new(input_buffer),
             phantom: PhantomData,
         }
     }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -207,9 +207,8 @@ impl<'input, Endian, Switch> LookupParser<'input, Endian> for PubStuffParser<'in
         if offset == 0 {
             Ok((EndianBuf::new(&[]), None))
         } else {
-            let (rest, name) = parse_null_terminated_string(rest.into())?;
-
-            Ok((EndianBuf::new(rest), Some(Switch::new_entry(offset, name, header))))
+            let (rest, name) = parse_null_terminated_string(rest)?;
+            Ok((rest, Some(Switch::new_entry(offset, name, header))))
         }
     }
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,8 +1,8 @@
 //! Functions for parsing and evaluating DWARF expressions.
 
 use constants;
-use parser::{Error, Format, parse_u8e, parse_i8e, parse_u16, parse_i16, parse_u32, parse_i32,
-             parse_u64, parse_i64, parse_unsigned_lebe, parse_signed_lebe, parse_offset,
+use parser::{Error, Format, parse_u8, parse_i8, parse_u16, parse_i16, parse_u32, parse_i32,
+             parse_u64, parse_i64, parse_unsigned_leb, parse_signed_leb, parse_offset,
              parse_address, parse_length_uleb_value};
 use endianity::{Endianity, EndianBuf};
 use unit::{UnitOffset, DebugInfoOffset};
@@ -292,7 +292,7 @@ impl<'input, Endian> Operation<'input, Endian>
                  -> Result<(EndianBuf<'input, Endian>, Operation<'input, Endian>), Error>
         where Endian: Endianity
     {
-        let (bytes, opcode) = parse_u8e(bytes)?;
+        let (bytes, opcode) = parse_u8(bytes)?;
         let name = constants::DwOp(opcode);
         match name {
             constants::DW_OP_addr => {
@@ -307,11 +307,11 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_const1u => {
-                let (newbytes, value) = parse_u8e(bytes)?;
+                let (newbytes, value) = parse_u8(bytes)?;
                 Ok((newbytes, Operation::Literal { value: value as u64 }))
             }
             constants::DW_OP_const1s => {
-                let (newbytes, value) = parse_i8e(bytes)?;
+                let (newbytes, value) = parse_i8(bytes)?;
                 Ok((newbytes, Operation::Literal { value: value as u64 }))
             }
             constants::DW_OP_const2u => {
@@ -339,18 +339,18 @@ impl<'input, Endian> Operation<'input, Endian>
                 Ok((newbytes, Operation::Literal { value: value as u64 }))
             }
             constants::DW_OP_constu => {
-                let (newbytes, value) = parse_unsigned_lebe(bytes)?;
+                let (newbytes, value) = parse_unsigned_leb(bytes)?;
                 Ok((newbytes, Operation::Literal { value: value }))
             }
             constants::DW_OP_consts => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes, Operation::Literal { value: value as u64 }))
             }
             constants::DW_OP_dup => Ok((bytes, Operation::Pick { index: 0 })),
             constants::DW_OP_drop => Ok((bytes, Operation::Drop)),
             constants::DW_OP_over => Ok((bytes, Operation::Pick { index: 1 })),
             constants::DW_OP_pick => {
-                let (newbytes, value) = parse_u8e(bytes)?;
+                let (newbytes, value) = parse_u8(bytes)?;
                 Ok((newbytes, Operation::Pick { index: value }))
             }
             constants::DW_OP_swap => Ok((bytes, Operation::Swap)),
@@ -373,7 +373,7 @@ impl<'input, Endian> Operation<'input, Endian>
             constants::DW_OP_or => Ok((bytes, Operation::Or)),
             constants::DW_OP_plus => Ok((bytes, Operation::Plus)),
             constants::DW_OP_plus_uconst => {
-                let (newbytes, value) = parse_unsigned_lebe(bytes)?;
+                let (newbytes, value) = parse_unsigned_leb(bytes)?;
                 Ok((newbytes, Operation::PlusConstant { value: value }))
             }
             constants::DW_OP_shl => Ok((bytes, Operation::Shl)),
@@ -459,7 +459,7 @@ impl<'input, Endian> Operation<'input, Endian>
             constants::DW_OP_reg30 => Ok((bytes, Operation::Register { register: 30 })),
             constants::DW_OP_reg31 => Ok((bytes, Operation::Register { register: 31 })),
             constants::DW_OP_breg0 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 0,
@@ -467,7 +467,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg1 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 1,
@@ -475,7 +475,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg2 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 2,
@@ -483,7 +483,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg3 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 3,
@@ -491,7 +491,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg4 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 4,
@@ -499,7 +499,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg5 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 5,
@@ -507,7 +507,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg6 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 6,
@@ -515,7 +515,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg7 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 7,
@@ -523,7 +523,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg8 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 8,
@@ -531,7 +531,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg9 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 9,
@@ -539,7 +539,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg10 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 10,
@@ -547,7 +547,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg11 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 11,
@@ -555,7 +555,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg12 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 12,
@@ -563,7 +563,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg13 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 13,
@@ -571,7 +571,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg14 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 14,
@@ -579,7 +579,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg15 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 15,
@@ -587,7 +587,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg16 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 16,
@@ -595,7 +595,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg17 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 17,
@@ -603,7 +603,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg18 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 18,
@@ -611,7 +611,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg19 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 19,
@@ -619,7 +619,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg20 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 20,
@@ -627,7 +627,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg21 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 21,
@@ -635,7 +635,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg22 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 22,
@@ -643,7 +643,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg23 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 23,
@@ -651,7 +651,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg24 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 24,
@@ -659,7 +659,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg25 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 25,
@@ -667,7 +667,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg26 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 26,
@@ -675,7 +675,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg27 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 27,
@@ -683,7 +683,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg28 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 28,
@@ -691,7 +691,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg29 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 29,
@@ -699,7 +699,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg30 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 30,
@@ -707,7 +707,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_breg31 => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: 31,
@@ -715,16 +715,16 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_regx => {
-                let (newbytes, value) = parse_unsigned_lebe(bytes)?;
+                let (newbytes, value) = parse_unsigned_leb(bytes)?;
                 Ok((newbytes, Operation::Register { register: value }))
             }
             constants::DW_OP_fbreg => {
-                let (newbytes, value) = parse_signed_lebe(bytes)?;
+                let (newbytes, value) = parse_signed_leb(bytes)?;
                 Ok((newbytes, Operation::FrameOffset { offset: value }))
             }
             constants::DW_OP_bregx => {
-                let (newbytes, regno) = parse_unsigned_lebe(bytes)?;
-                let (newbytes, offset) = parse_signed_lebe(newbytes)?;
+                let (newbytes, regno) = parse_unsigned_leb(bytes)?;
+                let (newbytes, offset) = parse_signed_leb(newbytes)?;
                 Ok((newbytes,
                     Operation::RegisterOffset {
                         register: regno,
@@ -732,7 +732,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_piece => {
-                let (newbytes, size) = parse_unsigned_lebe(bytes)?;
+                let (newbytes, size) = parse_unsigned_leb(bytes)?;
                 Ok((newbytes,
                     Operation::Piece {
                         size_in_bits: 8 * size,
@@ -740,7 +740,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_deref_size => {
-                let (newbytes, size) = parse_u8e(bytes)?;
+                let (newbytes, size) = parse_u8(bytes)?;
                 Ok((newbytes,
                     Operation::Deref {
                         size: size,
@@ -748,7 +748,7 @@ impl<'input, Endian> Operation<'input, Endian>
                     }))
             }
             constants::DW_OP_xderef_size => {
-                let (newbytes, size) = parse_u8e(bytes)?;
+                let (newbytes, size) = parse_u8(bytes)?;
                 Ok((newbytes,
                     Operation::Deref {
                         size: size,
@@ -776,8 +776,8 @@ impl<'input, Endian> Operation<'input, Endian>
             constants::DW_OP_GNU_push_tls_address => Ok((bytes, Operation::TLS)),
             constants::DW_OP_call_frame_cfa => Ok((bytes, Operation::CallFrameCFA)),
             constants::DW_OP_bit_piece => {
-                let (newbytes, size) = parse_unsigned_lebe(bytes)?;
-                let (newbytes, offset) = parse_unsigned_lebe(newbytes)?;
+                let (newbytes, size) = parse_unsigned_leb(bytes)?;
+                let (newbytes, offset) = parse_unsigned_leb(newbytes)?;
                 Ok((newbytes,
                     Operation::Piece {
                         size_in_bits: size,
@@ -792,7 +792,7 @@ impl<'input, Endian> Operation<'input, Endian>
             constants::DW_OP_implicit_pointer |
             constants::DW_OP_GNU_implicit_pointer => {
                 let (newbytes, value) = parse_offset(bytes, format)?;
-                let (newbytes, byte_offset) = parse_signed_lebe(newbytes)?;
+                let (newbytes, byte_offset) = parse_signed_leb(newbytes)?;
                 Ok((newbytes,
                     Operation::ImplicitPointer {
                         value: DebugInfoOffset(value),

--- a/src/op.rs
+++ b/src/op.rs
@@ -285,524 +285,481 @@ impl<'input, Endian> Operation<'input, Endian>
     /// `bytes` points to a the operation to decode.  It should point into
     /// the same array as `bytecode`, which should be the entire
     /// expression.
-    pub fn parse(bytes: EndianBuf<'input, Endian>,
+    pub fn parse(bytes: &mut EndianBuf<'input, Endian>,
                  bytecode: EndianBuf<'input, Endian>,
                  address_size: u8,
                  format: Format)
-                 -> Result<(EndianBuf<'input, Endian>, Operation<'input, Endian>), Error>
+                 -> Result<Operation<'input, Endian>, Error>
         where Endian: Endianity
     {
-        let (bytes, opcode) = parse_u8(bytes)?;
+        let opcode = parse_u8(bytes)?;
         let name = constants::DwOp(opcode);
         match name {
             constants::DW_OP_addr => {
-                let (newbytes, value) = parse_address(bytes, address_size)?;
-                Ok((newbytes, Operation::Literal { value: value }))
+                let value = parse_address(bytes, address_size)?;
+                Ok(Operation::Literal { value: value })
             }
             constants::DW_OP_deref => {
-                Ok((bytes,
-                    Operation::Deref {
-                        size: address_size,
-                        space: false,
-                    }))
+                Ok(Operation::Deref {
+                       size: address_size,
+                       space: false,
+                   })
             }
             constants::DW_OP_const1u => {
-                let (newbytes, value) = parse_u8(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_u8(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_const1s => {
-                let (newbytes, value) = parse_i8(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_i8(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_const2u => {
-                let (newbytes, value) = parse_u16(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_u16(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_const2s => {
-                let (newbytes, value) = parse_i16(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_i16(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_const4u => {
-                let (newbytes, value) = parse_u32(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_u32(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_const4s => {
-                let (newbytes, value) = parse_i32(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_i32(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_const8u => {
-                let (newbytes, value) = parse_u64(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value }))
+                let value = parse_u64(bytes)?;
+                Ok(Operation::Literal { value: value })
             }
             constants::DW_OP_const8s => {
-                let (newbytes, value) = parse_i64(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_i64(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
             constants::DW_OP_constu => {
-                let (newbytes, value) = parse_unsigned_leb(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value }))
+                let value = parse_unsigned_leb(bytes)?;
+                Ok(Operation::Literal { value: value })
             }
             constants::DW_OP_consts => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes, Operation::Literal { value: value as u64 }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::Literal { value: value as u64 })
             }
-            constants::DW_OP_dup => Ok((bytes, Operation::Pick { index: 0 })),
-            constants::DW_OP_drop => Ok((bytes, Operation::Drop)),
-            constants::DW_OP_over => Ok((bytes, Operation::Pick { index: 1 })),
+            constants::DW_OP_dup => Ok(Operation::Pick { index: 0 }),
+            constants::DW_OP_drop => Ok(Operation::Drop),
+            constants::DW_OP_over => Ok(Operation::Pick { index: 1 }),
             constants::DW_OP_pick => {
-                let (newbytes, value) = parse_u8(bytes)?;
-                Ok((newbytes, Operation::Pick { index: value }))
+                let value = parse_u8(bytes)?;
+                Ok(Operation::Pick { index: value })
             }
-            constants::DW_OP_swap => Ok((bytes, Operation::Swap)),
-            constants::DW_OP_rot => Ok((bytes, Operation::Rot)),
+            constants::DW_OP_swap => Ok(Operation::Swap),
+            constants::DW_OP_rot => Ok(Operation::Rot),
             constants::DW_OP_xderef => {
-                Ok((bytes,
-                    Operation::Deref {
-                        size: address_size,
-                        space: true,
-                    }))
+                Ok(Operation::Deref {
+                       size: address_size,
+                       space: true,
+                   })
             }
-            constants::DW_OP_abs => Ok((bytes, Operation::Abs)),
-            constants::DW_OP_and => Ok((bytes, Operation::And)),
-            constants::DW_OP_div => Ok((bytes, Operation::Div)),
-            constants::DW_OP_minus => Ok((bytes, Operation::Minus)),
-            constants::DW_OP_mod => Ok((bytes, Operation::Mod)),
-            constants::DW_OP_mul => Ok((bytes, Operation::Mul)),
-            constants::DW_OP_neg => Ok((bytes, Operation::Neg)),
-            constants::DW_OP_not => Ok((bytes, Operation::Not)),
-            constants::DW_OP_or => Ok((bytes, Operation::Or)),
-            constants::DW_OP_plus => Ok((bytes, Operation::Plus)),
+            constants::DW_OP_abs => Ok(Operation::Abs),
+            constants::DW_OP_and => Ok(Operation::And),
+            constants::DW_OP_div => Ok(Operation::Div),
+            constants::DW_OP_minus => Ok(Operation::Minus),
+            constants::DW_OP_mod => Ok(Operation::Mod),
+            constants::DW_OP_mul => Ok(Operation::Mul),
+            constants::DW_OP_neg => Ok(Operation::Neg),
+            constants::DW_OP_not => Ok(Operation::Not),
+            constants::DW_OP_or => Ok(Operation::Or),
+            constants::DW_OP_plus => Ok(Operation::Plus),
             constants::DW_OP_plus_uconst => {
-                let (newbytes, value) = parse_unsigned_leb(bytes)?;
-                Ok((newbytes, Operation::PlusConstant { value: value }))
+                let value = parse_unsigned_leb(bytes)?;
+                Ok(Operation::PlusConstant { value: value })
             }
-            constants::DW_OP_shl => Ok((bytes, Operation::Shl)),
-            constants::DW_OP_shr => Ok((bytes, Operation::Shr)),
-            constants::DW_OP_shra => Ok((bytes, Operation::Shra)),
-            constants::DW_OP_xor => Ok((bytes, Operation::Xor)),
+            constants::DW_OP_shl => Ok(Operation::Shl),
+            constants::DW_OP_shr => Ok(Operation::Shr),
+            constants::DW_OP_shra => Ok(Operation::Shra),
+            constants::DW_OP_xor => Ok(Operation::Xor),
             constants::DW_OP_bra => {
-                let (newbytes, value) = parse_i16(bytes)?;
-                Ok((newbytes, Operation::Bra { target: compute_pc(newbytes, bytecode, value)? }))
+                let value = parse_i16(bytes)?;
+                Ok(Operation::Bra { target: compute_pc(*bytes, bytecode, value)? })
             }
-            constants::DW_OP_eq => Ok((bytes, Operation::Eq)),
-            constants::DW_OP_ge => Ok((bytes, Operation::Ge)),
-            constants::DW_OP_gt => Ok((bytes, Operation::Gt)),
-            constants::DW_OP_le => Ok((bytes, Operation::Le)),
-            constants::DW_OP_lt => Ok((bytes, Operation::Lt)),
-            constants::DW_OP_ne => Ok((bytes, Operation::Ne)),
+            constants::DW_OP_eq => Ok(Operation::Eq),
+            constants::DW_OP_ge => Ok(Operation::Ge),
+            constants::DW_OP_gt => Ok(Operation::Gt),
+            constants::DW_OP_le => Ok(Operation::Le),
+            constants::DW_OP_lt => Ok(Operation::Lt),
+            constants::DW_OP_ne => Ok(Operation::Ne),
             constants::DW_OP_skip => {
-                let (newbytes, value) = parse_i16(bytes)?;
-                Ok((newbytes, Operation::Skip { target: compute_pc(newbytes, bytecode, value)? }))
+                let value = parse_i16(bytes)?;
+                Ok(Operation::Skip { target: compute_pc(*bytes, bytecode, value)? })
             }
-            constants::DW_OP_lit0 => Ok((bytes, Operation::Literal { value: 0 })),
-            constants::DW_OP_lit1 => Ok((bytes, Operation::Literal { value: 1 })),
-            constants::DW_OP_lit2 => Ok((bytes, Operation::Literal { value: 2 })),
-            constants::DW_OP_lit3 => Ok((bytes, Operation::Literal { value: 3 })),
-            constants::DW_OP_lit4 => Ok((bytes, Operation::Literal { value: 4 })),
-            constants::DW_OP_lit5 => Ok((bytes, Operation::Literal { value: 5 })),
-            constants::DW_OP_lit6 => Ok((bytes, Operation::Literal { value: 6 })),
-            constants::DW_OP_lit7 => Ok((bytes, Operation::Literal { value: 7 })),
-            constants::DW_OP_lit8 => Ok((bytes, Operation::Literal { value: 8 })),
-            constants::DW_OP_lit9 => Ok((bytes, Operation::Literal { value: 9 })),
-            constants::DW_OP_lit10 => Ok((bytes, Operation::Literal { value: 10 })),
-            constants::DW_OP_lit11 => Ok((bytes, Operation::Literal { value: 11 })),
-            constants::DW_OP_lit12 => Ok((bytes, Operation::Literal { value: 12 })),
-            constants::DW_OP_lit13 => Ok((bytes, Operation::Literal { value: 13 })),
-            constants::DW_OP_lit14 => Ok((bytes, Operation::Literal { value: 14 })),
-            constants::DW_OP_lit15 => Ok((bytes, Operation::Literal { value: 15 })),
-            constants::DW_OP_lit16 => Ok((bytes, Operation::Literal { value: 16 })),
-            constants::DW_OP_lit17 => Ok((bytes, Operation::Literal { value: 17 })),
-            constants::DW_OP_lit18 => Ok((bytes, Operation::Literal { value: 18 })),
-            constants::DW_OP_lit19 => Ok((bytes, Operation::Literal { value: 19 })),
-            constants::DW_OP_lit20 => Ok((bytes, Operation::Literal { value: 20 })),
-            constants::DW_OP_lit21 => Ok((bytes, Operation::Literal { value: 21 })),
-            constants::DW_OP_lit22 => Ok((bytes, Operation::Literal { value: 22 })),
-            constants::DW_OP_lit23 => Ok((bytes, Operation::Literal { value: 23 })),
-            constants::DW_OP_lit24 => Ok((bytes, Operation::Literal { value: 24 })),
-            constants::DW_OP_lit25 => Ok((bytes, Operation::Literal { value: 25 })),
-            constants::DW_OP_lit26 => Ok((bytes, Operation::Literal { value: 26 })),
-            constants::DW_OP_lit27 => Ok((bytes, Operation::Literal { value: 27 })),
-            constants::DW_OP_lit28 => Ok((bytes, Operation::Literal { value: 28 })),
-            constants::DW_OP_lit29 => Ok((bytes, Operation::Literal { value: 29 })),
-            constants::DW_OP_lit30 => Ok((bytes, Operation::Literal { value: 30 })),
-            constants::DW_OP_lit31 => Ok((bytes, Operation::Literal { value: 31 })),
-            constants::DW_OP_reg0 => Ok((bytes, Operation::Register { register: 0 })),
-            constants::DW_OP_reg1 => Ok((bytes, Operation::Register { register: 1 })),
-            constants::DW_OP_reg2 => Ok((bytes, Operation::Register { register: 2 })),
-            constants::DW_OP_reg3 => Ok((bytes, Operation::Register { register: 3 })),
-            constants::DW_OP_reg4 => Ok((bytes, Operation::Register { register: 4 })),
-            constants::DW_OP_reg5 => Ok((bytes, Operation::Register { register: 5 })),
-            constants::DW_OP_reg6 => Ok((bytes, Operation::Register { register: 6 })),
-            constants::DW_OP_reg7 => Ok((bytes, Operation::Register { register: 7 })),
-            constants::DW_OP_reg8 => Ok((bytes, Operation::Register { register: 8 })),
-            constants::DW_OP_reg9 => Ok((bytes, Operation::Register { register: 9 })),
-            constants::DW_OP_reg10 => Ok((bytes, Operation::Register { register: 10 })),
-            constants::DW_OP_reg11 => Ok((bytes, Operation::Register { register: 11 })),
-            constants::DW_OP_reg12 => Ok((bytes, Operation::Register { register: 12 })),
-            constants::DW_OP_reg13 => Ok((bytes, Operation::Register { register: 13 })),
-            constants::DW_OP_reg14 => Ok((bytes, Operation::Register { register: 14 })),
-            constants::DW_OP_reg15 => Ok((bytes, Operation::Register { register: 15 })),
-            constants::DW_OP_reg16 => Ok((bytes, Operation::Register { register: 16 })),
-            constants::DW_OP_reg17 => Ok((bytes, Operation::Register { register: 17 })),
-            constants::DW_OP_reg18 => Ok((bytes, Operation::Register { register: 18 })),
-            constants::DW_OP_reg19 => Ok((bytes, Operation::Register { register: 19 })),
-            constants::DW_OP_reg20 => Ok((bytes, Operation::Register { register: 20 })),
-            constants::DW_OP_reg21 => Ok((bytes, Operation::Register { register: 21 })),
-            constants::DW_OP_reg22 => Ok((bytes, Operation::Register { register: 22 })),
-            constants::DW_OP_reg23 => Ok((bytes, Operation::Register { register: 23 })),
-            constants::DW_OP_reg24 => Ok((bytes, Operation::Register { register: 24 })),
-            constants::DW_OP_reg25 => Ok((bytes, Operation::Register { register: 25 })),
-            constants::DW_OP_reg26 => Ok((bytes, Operation::Register { register: 26 })),
-            constants::DW_OP_reg27 => Ok((bytes, Operation::Register { register: 27 })),
-            constants::DW_OP_reg28 => Ok((bytes, Operation::Register { register: 28 })),
-            constants::DW_OP_reg29 => Ok((bytes, Operation::Register { register: 29 })),
-            constants::DW_OP_reg30 => Ok((bytes, Operation::Register { register: 30 })),
-            constants::DW_OP_reg31 => Ok((bytes, Operation::Register { register: 31 })),
+            constants::DW_OP_lit0 => Ok(Operation::Literal { value: 0 }),
+            constants::DW_OP_lit1 => Ok(Operation::Literal { value: 1 }),
+            constants::DW_OP_lit2 => Ok(Operation::Literal { value: 2 }),
+            constants::DW_OP_lit3 => Ok(Operation::Literal { value: 3 }),
+            constants::DW_OP_lit4 => Ok(Operation::Literal { value: 4 }),
+            constants::DW_OP_lit5 => Ok(Operation::Literal { value: 5 }),
+            constants::DW_OP_lit6 => Ok(Operation::Literal { value: 6 }),
+            constants::DW_OP_lit7 => Ok(Operation::Literal { value: 7 }),
+            constants::DW_OP_lit8 => Ok(Operation::Literal { value: 8 }),
+            constants::DW_OP_lit9 => Ok(Operation::Literal { value: 9 }),
+            constants::DW_OP_lit10 => Ok(Operation::Literal { value: 10 }),
+            constants::DW_OP_lit11 => Ok(Operation::Literal { value: 11 }),
+            constants::DW_OP_lit12 => Ok(Operation::Literal { value: 12 }),
+            constants::DW_OP_lit13 => Ok(Operation::Literal { value: 13 }),
+            constants::DW_OP_lit14 => Ok(Operation::Literal { value: 14 }),
+            constants::DW_OP_lit15 => Ok(Operation::Literal { value: 15 }),
+            constants::DW_OP_lit16 => Ok(Operation::Literal { value: 16 }),
+            constants::DW_OP_lit17 => Ok(Operation::Literal { value: 17 }),
+            constants::DW_OP_lit18 => Ok(Operation::Literal { value: 18 }),
+            constants::DW_OP_lit19 => Ok(Operation::Literal { value: 19 }),
+            constants::DW_OP_lit20 => Ok(Operation::Literal { value: 20 }),
+            constants::DW_OP_lit21 => Ok(Operation::Literal { value: 21 }),
+            constants::DW_OP_lit22 => Ok(Operation::Literal { value: 22 }),
+            constants::DW_OP_lit23 => Ok(Operation::Literal { value: 23 }),
+            constants::DW_OP_lit24 => Ok(Operation::Literal { value: 24 }),
+            constants::DW_OP_lit25 => Ok(Operation::Literal { value: 25 }),
+            constants::DW_OP_lit26 => Ok(Operation::Literal { value: 26 }),
+            constants::DW_OP_lit27 => Ok(Operation::Literal { value: 27 }),
+            constants::DW_OP_lit28 => Ok(Operation::Literal { value: 28 }),
+            constants::DW_OP_lit29 => Ok(Operation::Literal { value: 29 }),
+            constants::DW_OP_lit30 => Ok(Operation::Literal { value: 30 }),
+            constants::DW_OP_lit31 => Ok(Operation::Literal { value: 31 }),
+            constants::DW_OP_reg0 => Ok(Operation::Register { register: 0 }),
+            constants::DW_OP_reg1 => Ok(Operation::Register { register: 1 }),
+            constants::DW_OP_reg2 => Ok(Operation::Register { register: 2 }),
+            constants::DW_OP_reg3 => Ok(Operation::Register { register: 3 }),
+            constants::DW_OP_reg4 => Ok(Operation::Register { register: 4 }),
+            constants::DW_OP_reg5 => Ok(Operation::Register { register: 5 }),
+            constants::DW_OP_reg6 => Ok(Operation::Register { register: 6 }),
+            constants::DW_OP_reg7 => Ok(Operation::Register { register: 7 }),
+            constants::DW_OP_reg8 => Ok(Operation::Register { register: 8 }),
+            constants::DW_OP_reg9 => Ok(Operation::Register { register: 9 }),
+            constants::DW_OP_reg10 => Ok(Operation::Register { register: 10 }),
+            constants::DW_OP_reg11 => Ok(Operation::Register { register: 11 }),
+            constants::DW_OP_reg12 => Ok(Operation::Register { register: 12 }),
+            constants::DW_OP_reg13 => Ok(Operation::Register { register: 13 }),
+            constants::DW_OP_reg14 => Ok(Operation::Register { register: 14 }),
+            constants::DW_OP_reg15 => Ok(Operation::Register { register: 15 }),
+            constants::DW_OP_reg16 => Ok(Operation::Register { register: 16 }),
+            constants::DW_OP_reg17 => Ok(Operation::Register { register: 17 }),
+            constants::DW_OP_reg18 => Ok(Operation::Register { register: 18 }),
+            constants::DW_OP_reg19 => Ok(Operation::Register { register: 19 }),
+            constants::DW_OP_reg20 => Ok(Operation::Register { register: 20 }),
+            constants::DW_OP_reg21 => Ok(Operation::Register { register: 21 }),
+            constants::DW_OP_reg22 => Ok(Operation::Register { register: 22 }),
+            constants::DW_OP_reg23 => Ok(Operation::Register { register: 23 }),
+            constants::DW_OP_reg24 => Ok(Operation::Register { register: 24 }),
+            constants::DW_OP_reg25 => Ok(Operation::Register { register: 25 }),
+            constants::DW_OP_reg26 => Ok(Operation::Register { register: 26 }),
+            constants::DW_OP_reg27 => Ok(Operation::Register { register: 27 }),
+            constants::DW_OP_reg28 => Ok(Operation::Register { register: 28 }),
+            constants::DW_OP_reg29 => Ok(Operation::Register { register: 29 }),
+            constants::DW_OP_reg30 => Ok(Operation::Register { register: 30 }),
+            constants::DW_OP_reg31 => Ok(Operation::Register { register: 31 }),
             constants::DW_OP_breg0 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 0,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 0,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg1 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 1,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 1,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg2 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 2,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 2,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg3 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 3,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 3,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg4 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 4,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 4,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg5 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 5,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 5,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg6 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 6,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 6,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg7 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 7,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 7,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg8 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 8,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 8,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg9 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 9,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 9,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg10 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 10,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 10,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg11 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 11,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 11,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg12 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 12,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 12,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg13 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 13,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 13,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg14 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 14,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 14,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg15 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 15,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 15,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg16 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 16,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 16,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg17 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 17,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 17,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg18 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 18,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 18,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg19 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 19,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 19,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg20 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 20,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 20,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg21 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 21,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 21,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg22 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 22,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 22,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg23 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 23,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 23,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg24 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 24,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 24,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg25 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 25,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 25,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg26 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 26,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 26,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg27 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 27,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 27,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg28 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 28,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 28,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg29 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 29,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 29,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg30 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 30,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 30,
+                       offset: value,
+                   })
             }
             constants::DW_OP_breg31 => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: 31,
-                        offset: value,
-                    }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: 31,
+                       offset: value,
+                   })
             }
             constants::DW_OP_regx => {
-                let (newbytes, value) = parse_unsigned_leb(bytes)?;
-                Ok((newbytes, Operation::Register { register: value }))
+                let value = parse_unsigned_leb(bytes)?;
+                Ok(Operation::Register { register: value })
             }
             constants::DW_OP_fbreg => {
-                let (newbytes, value) = parse_signed_leb(bytes)?;
-                Ok((newbytes, Operation::FrameOffset { offset: value }))
+                let value = parse_signed_leb(bytes)?;
+                Ok(Operation::FrameOffset { offset: value })
             }
             constants::DW_OP_bregx => {
-                let (newbytes, regno) = parse_unsigned_leb(bytes)?;
-                let (newbytes, offset) = parse_signed_leb(newbytes)?;
-                Ok((newbytes,
-                    Operation::RegisterOffset {
-                        register: regno,
-                        offset: offset,
-                    }))
+                let regno = parse_unsigned_leb(bytes)?;
+                let offset = parse_signed_leb(bytes)?;
+                Ok(Operation::RegisterOffset {
+                       register: regno,
+                       offset: offset,
+                   })
             }
             constants::DW_OP_piece => {
-                let (newbytes, size) = parse_unsigned_leb(bytes)?;
-                Ok((newbytes,
-                    Operation::Piece {
-                        size_in_bits: 8 * size,
-                        bit_offset: None,
-                    }))
+                let size = parse_unsigned_leb(bytes)?;
+                Ok(Operation::Piece {
+                       size_in_bits: 8 * size,
+                       bit_offset: None,
+                   })
             }
             constants::DW_OP_deref_size => {
-                let (newbytes, size) = parse_u8(bytes)?;
-                Ok((newbytes,
-                    Operation::Deref {
-                        size: size,
-                        space: false,
-                    }))
+                let size = parse_u8(bytes)?;
+                Ok(Operation::Deref {
+                       size: size,
+                       space: false,
+                   })
             }
             constants::DW_OP_xderef_size => {
-                let (newbytes, size) = parse_u8(bytes)?;
-                Ok((newbytes,
-                    Operation::Deref {
-                        size: size,
-                        space: true,
-                    }))
+                let size = parse_u8(bytes)?;
+                Ok(Operation::Deref {
+                       size: size,
+                       space: true,
+                   })
             }
-            constants::DW_OP_nop => Ok((bytes, Operation::Nop)),
-            constants::DW_OP_push_object_address => Ok((bytes, Operation::PushObjectAddress)),
+            constants::DW_OP_nop => Ok(Operation::Nop),
+            constants::DW_OP_push_object_address => Ok(Operation::PushObjectAddress),
             constants::DW_OP_call2 => {
-                let (newbytes, value) = parse_u16(bytes)?;
-                Ok((newbytes,
-                    Operation::Call { offset: DieReference::UnitRef(UnitOffset(value as usize)) }))
+                let value = parse_u16(bytes)?;
+                Ok(Operation::Call { offset: DieReference::UnitRef(UnitOffset(value as usize)) })
             }
             constants::DW_OP_call4 => {
-                let (newbytes, value) = parse_u32(bytes)?;
-                Ok((newbytes,
-                    Operation::Call { offset: DieReference::UnitRef(UnitOffset(value as usize)) }))
+                let value = parse_u32(bytes)?;
+                Ok(Operation::Call { offset: DieReference::UnitRef(UnitOffset(value as usize)) })
             }
             constants::DW_OP_call_ref => {
-                let (newbytes, value) = parse_offset(bytes, format)?;
-                Ok((newbytes,
-                    Operation::Call { offset: DieReference::DebugInfoRef(DebugInfoOffset(value)) }))
+                let value = parse_offset(bytes, format)?;
+                Ok(Operation::Call { offset: DieReference::DebugInfoRef(DebugInfoOffset(value)) })
             }
             constants::DW_OP_form_tls_address |
-            constants::DW_OP_GNU_push_tls_address => Ok((bytes, Operation::TLS)),
-            constants::DW_OP_call_frame_cfa => Ok((bytes, Operation::CallFrameCFA)),
+            constants::DW_OP_GNU_push_tls_address => Ok(Operation::TLS),
+            constants::DW_OP_call_frame_cfa => Ok(Operation::CallFrameCFA),
             constants::DW_OP_bit_piece => {
-                let (newbytes, size) = parse_unsigned_leb(bytes)?;
-                let (newbytes, offset) = parse_unsigned_leb(newbytes)?;
-                Ok((newbytes,
-                    Operation::Piece {
-                        size_in_bits: size,
-                        bit_offset: Some(offset),
-                    }))
+                let size = parse_unsigned_leb(bytes)?;
+                let offset = parse_unsigned_leb(bytes)?;
+                Ok(Operation::Piece {
+                       size_in_bits: size,
+                       bit_offset: Some(offset),
+                   })
             }
             constants::DW_OP_implicit_value => {
-                let (newbytes, data) = parse_length_uleb_value(bytes)?;
-                Ok((newbytes, Operation::ImplicitValue { data: data.into() }))
+                let data = parse_length_uleb_value(bytes)?;
+                Ok(Operation::ImplicitValue { data: data.into() })
             }
-            constants::DW_OP_stack_value => Ok((bytes, Operation::StackValue)),
+            constants::DW_OP_stack_value => Ok(Operation::StackValue),
             constants::DW_OP_implicit_pointer |
             constants::DW_OP_GNU_implicit_pointer => {
-                let (newbytes, value) = parse_offset(bytes, format)?;
-                let (newbytes, byte_offset) = parse_signed_leb(newbytes)?;
-                Ok((newbytes,
-                    Operation::ImplicitPointer {
-                        value: DebugInfoOffset(value),
-                        byte_offset: byte_offset,
-                    }))
+                let value = parse_offset(bytes, format)?;
+                let byte_offset = parse_signed_leb(bytes)?;
+                Ok(Operation::ImplicitPointer {
+                       value: DebugInfoOffset(value),
+                       byte_offset: byte_offset,
+                   })
             }
             constants::DW_OP_entry_value |
             constants::DW_OP_GNU_entry_value => {
-                let (newbytes, expression) = parse_length_uleb_value(bytes)?;
-                Ok((newbytes, Operation::EntryValue { expression: expression }))
+                let expression = parse_length_uleb_value(bytes)?;
+                Ok(Operation::EntryValue { expression: expression })
             }
 
             _ => Err(Error::InvalidExpression(name)),
@@ -1558,9 +1515,8 @@ impl<'input, Endian> Evaluation<'input, Endian>
                 }
             }
 
-            let (newpc, operation) =
-                Operation::parse(self.pc, self.bytecode, self.address_size, self.format)?;
-            self.pc = newpc;
+            let operation =
+                Operation::parse(&mut self.pc, self.bytecode, self.address_size, self.format)?;
 
             let op_result = self.evaluate_one_operation(&operation)?;
             match op_result {
@@ -1585,12 +1541,10 @@ impl<'input, Endian> Evaluation<'input, Endian>
                                 current_location = Location::Address { address: self.pop()? };
                             }
                         } else if !eof {
-                            let (newpc, operation) = Operation::parse(self.pc,
-                                                                      self.bytecode,
-                                                                      self.address_size,
-                                                                      self.format)?;
-                            self.pc = newpc;
-                            pieceop = operation;
+                            pieceop = Operation::parse(&mut self.pc,
+                                                       self.bytecode,
+                                                       self.address_size,
+                                                       self.format)?;
                         }
                         match pieceop {
                             _ if eof => {
@@ -1716,9 +1670,10 @@ mod tests {
                              address_size: u8,
                              format: Format) {
         let buf = EndianBuf::<LittleEndian>::new(input);
-        let value = Operation::parse(buf, buf, address_size, format);
+        let mut pc = buf;
+        let value = Operation::parse(&mut pc, buf, address_size, format);
         match value {
-            Ok((pc, val)) => {
+            Ok(val) => {
                 assert_eq!(val, *expect);
                 assert_eq!(pc.len(), 0);
             }
@@ -1728,7 +1683,8 @@ mod tests {
 
     fn check_op_parse_failure(input: &[u8], expect: Error, address_size: u8, format: Format) {
         let buf = EndianBuf::<LittleEndian>::new(input);
-        match Operation::parse(buf, buf, address_size, format) {
+        let mut pc = buf;
+        match Operation::parse(&mut pc, buf, address_size, format) {
             Err(x) => {
                 assert_eq!(x, expect);
             }
@@ -2920,8 +2876,8 @@ mod tests {
         check_eval_with_args(&program, Ok(&result), 8, Format::Dwarf64,
                              None, None, None, |eval, result| {
                                  let entry_value = match result {
-                                     EvaluationResult::RequiresEntryValue(expression) => {
-                                         parse_u64(expression).map(|(_, value)| value)?
+                                     EvaluationResult::RequiresEntryValue(mut expression) => {
+                                         parse_u64(&mut expression)?
                                      },
                                      _ => panic!(),
                                  };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -258,115 +258,131 @@ pub type Result<T> = result::Result<T, Error>;
 /// Parse a `u8` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u8<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u8)>
+pub fn parse_u8<Endian>(input: &mut EndianBuf<Endian>) -> Result<u8>
     where Endian: Endianity
 {
     if input.is_empty() {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(1..), input[0]))
+        let val = input[0];
+        *input = input.range_from(1..);
+        Ok(val)
     }
 }
 
 /// Parse a `i8` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i8<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i8)>
+pub fn parse_i8<Endian>(input: &mut EndianBuf<Endian>) -> Result<i8>
     where Endian: Endianity
 {
     if input.is_empty() {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(1..), input[0] as i8))
+        let val = input[0] as i8;
+        *input = input.range_from(1..);
+        Ok(val)
     }
 }
 
 /// Parse a `u16` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u16<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u16)>
+pub fn parse_u16<Endian>(input: &mut EndianBuf<Endian>) -> Result<u16>
     where Endian: Endianity
 {
     if input.len() < 2 {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(2..), Endian::read_u16(&input)))
+        let val = Endian::read_u16(&input);
+        *input = input.range_from(2..);
+        Ok(val)
     }
 }
 
 /// Parse a `i16` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i16<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i16)>
+pub fn parse_i16<Endian>(input: &mut EndianBuf<Endian>) -> Result<i16>
     where Endian: Endianity
 {
     if input.len() < 2 {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(2..), Endian::read_i16(&input)))
+        let val = Endian::read_i16(&input);
+        *input = input.range_from(2..);
+        Ok(val)
     }
 }
 
 /// Parse a `u32` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u32<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u32)>
+pub fn parse_u32<Endian>(input: &mut EndianBuf<Endian>) -> Result<u32>
     where Endian: Endianity
 {
     if input.len() < 4 {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(4..), Endian::read_u32(&input)))
+        let val = Endian::read_u32(&input);
+        *input = input.range_from(4..);
+        Ok(val)
     }
 }
 
 /// Parse a `i32` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i32<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i32)>
+pub fn parse_i32<Endian>(input: &mut EndianBuf<Endian>) -> Result<i32>
     where Endian: Endianity
 {
     if input.len() < 4 {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(4..), Endian::read_i32(&input)))
+        let val = Endian::read_i32(&input);
+        *input = input.range_from(4..);
+        Ok(val)
     }
 }
 
 /// Parse a `u64` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u64<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u64)>
+pub fn parse_u64<Endian>(input: &mut EndianBuf<Endian>) -> Result<u64>
     where Endian: Endianity
 {
     if input.len() < 8 {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(8..), Endian::read_u64(&input)))
+        let val = Endian::read_u64(&input);
+        *input = input.range_from(8..);
+        Ok(val)
     }
 }
 
 /// Parse a `i64` from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_i64<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i64)>
+pub fn parse_i64<Endian>(input: &mut EndianBuf<Endian>) -> Result<i64>
     where Endian: Endianity
 {
     if input.len() < 8 {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(8..), Endian::read_i64(&input)))
+        let val = Endian::read_i64(&input);
+        *input = input.range_from(8..);
+        Ok(val)
     }
 }
 
 /// Parse an unsigned LEB128 encoded integer.
 #[doc(hidden)]
 #[inline]
-pub fn parse_unsigned_leb<Endian>(mut input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u64)>
+pub fn parse_unsigned_leb<Endian>(input: &mut EndianBuf<Endian>) -> Result<u64>
     where Endian: Endianity
 {
     match leb128::read::unsigned(&mut input.0) {
-        Ok(val) => Ok((input, val)),
+        Ok(val) => Ok(val),
         Err(leb128::read::Error::IoError(ref e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
             Err(Error::UnexpectedEof)
         }
@@ -377,22 +393,20 @@ pub fn parse_unsigned_leb<Endian>(mut input: EndianBuf<Endian>) -> Result<(Endia
 /// Parse an unsigned LEB128 encoded integer return it as a `u8`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_unsigned_leb_as_u8<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u8)>
+pub fn parse_unsigned_leb_as_u8<Endian>(input: &mut EndianBuf<Endian>) -> Result<u8>
     where Endian: Endianity
 {
-    let (input, value) = parse_unsigned_leb(input)?;
-    let value = u64_to_u8(value)?;
-    Ok((input, value))
+    parse_unsigned_leb(input).and_then(u64_to_u8)
 }
 
 /// Parse a signed LEB128 encoded integer.
 #[doc(hidden)]
 #[inline]
-pub fn parse_signed_leb<Endian>(mut input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, i64)>
+pub fn parse_signed_leb<Endian>(input: &mut EndianBuf<Endian>) -> Result<i64>
     where Endian: Endianity
 {
     match leb128::read::signed(&mut input.0) {
-        Ok(val) => Ok((input, val)),
+        Ok(val) => Ok(val),
         Err(leb128::read::Error::IoError(ref e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
             Err(Error::UnexpectedEof)
         }
@@ -403,14 +417,10 @@ pub fn parse_signed_leb<Endian>(mut input: EndianBuf<Endian>) -> Result<(EndianB
 /// Parse a `u32` from the input and return it as a `u64`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u32_as_u64<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u64)>
+pub fn parse_u32_as_u64<Endian>(input: &mut EndianBuf<Endian>) -> Result<u64>
     where Endian: Endianity
 {
-    if input.len() < 4 {
-        Err(Error::UnexpectedEof)
-    } else {
-        Ok((input.range_from(4..), Endian::read_u32(&input) as u64))
-    }
+    parse_u32(input).map(|v| v as u64)
 }
 
 /// Convert a `u64` to a `usize` and return it.
@@ -440,31 +450,25 @@ pub fn u64_to_u8(x: u64) -> Result<u8> {
 /// Parse a `u64` from the input, and return it as a `usize`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_u64_as_offset<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, usize)>
+pub fn parse_u64_as_offset<Endian>(input: &mut EndianBuf<Endian>) -> Result<usize>
     where Endian: Endianity
 {
-    let (rest, offset) = parse_u64(input)?;
-    let offset = u64_to_offset(offset)?;
-    Ok((rest, offset))
+    parse_u64(input).and_then(u64_to_offset)
 }
 
 /// Parse an unsigned LEB128 encoded integer from the input, and return it as a `usize`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_uleb_as_offset<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, usize)>
+pub fn parse_uleb_as_offset<Endian>(input: &mut EndianBuf<Endian>) -> Result<usize>
     where Endian: Endianity
 {
-    let (rest, offset) = parse_unsigned_leb(input)?;
-    let offset = u64_to_offset(offset)?;
-    Ok((rest, offset))
+    parse_unsigned_leb(input).and_then(u64_to_offset)
 }
 
 /// Parse a word-sized integer according to the DWARF format, and return it as a `u64`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_word<Endian>(input: EndianBuf<Endian>,
-                          format: Format)
-                          -> Result<(EndianBuf<Endian>, u64)>
+pub fn parse_word<Endian>(input: &mut EndianBuf<Endian>, format: Format) -> Result<u64>
     where Endian: Endianity
 {
     match format {
@@ -476,56 +480,49 @@ pub fn parse_word<Endian>(input: EndianBuf<Endian>,
 /// Parse a word-sized integer according to the DWARF format, and return it as a `usize`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_offset<Endian>(input: EndianBuf<Endian>,
-                            format: Format)
-                            -> Result<(EndianBuf<Endian>, usize)>
+pub fn parse_offset<Endian>(input: &mut EndianBuf<Endian>, format: Format) -> Result<usize>
     where Endian: Endianity
 {
-    let (rest, offset) = parse_word(input, format)?;
-    let offset = u64_to_offset(offset)?;
-    Ok((rest, offset))
+    parse_word(input, format).and_then(u64_to_offset)
 }
 
 /// Parse an address-sized integer, and return it as a `u64`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_address<Endian>(input: EndianBuf<Endian>,
-                             address_size: u8)
-                             -> Result<(EndianBuf<Endian>, u64)>
+pub fn parse_address<Endian>(input: &mut EndianBuf<Endian>, address_size: u8) -> Result<u64>
     where Endian: Endianity
 {
     if input.len() < address_size as usize {
         Err(Error::UnexpectedEof)
     } else {
         let address = match address_size {
-            8 => Endian::read_u64(&input),
-            4 => Endian::read_u32(&input) as u64,
-            2 => Endian::read_u16(&input) as u64,
+            8 => Endian::read_u64(&input.0),
+            4 => Endian::read_u32(&input.0) as u64,
+            2 => Endian::read_u16(&input.0) as u64,
             1 => input[0] as u64,
             otherwise => return Err(Error::UnsupportedAddressSize(otherwise)),
         };
-        Ok((input.range_from(address_size as usize..), address))
+        *input = input.range_from(address_size as usize..);
+        Ok(address)
     }
 }
 
 /// Parse an address-sized integer, and return it as a `usize`.
 #[doc(hidden)]
 #[inline]
-pub fn parse_address_as_offset<Endian>(input: EndianBuf<Endian>,
+pub fn parse_address_as_offset<Endian>(input: &mut EndianBuf<Endian>,
                                        address_size: u8)
-                                       -> Result<(EndianBuf<Endian>, usize)>
+                                       -> Result<usize>
     where Endian: Endianity
 {
-    let (rest, offset) = parse_address(input, address_size)?;
-    let offset = u64_to_offset(offset)?;
-    Ok((rest, offset))
+    parse_address(input, address_size).and_then(u64_to_offset)
 }
 
 /// Parse a null-terminated slice from the input.
 #[doc(hidden)]
 #[inline]
-pub fn parse_null_terminated_string<Endian>(input: EndianBuf<Endian>)
-                                            -> Result<(EndianBuf<Endian>, &ffi::CStr)>
+pub fn parse_null_terminated_string<'input, Endian>(input: &mut EndianBuf<'input, Endian>)
+                                                    -> Result<&'input ffi::CStr>
     where Endian: Endianity
 {
     let null_idx = input.0.iter().position(|ch| *ch == 0);
@@ -537,7 +534,8 @@ pub fn parse_null_terminated_string<Endian>(input: EndianBuf<Endian>)
             // therefore there can't be any interior null bytes in this slice.
             ffi::CStr::from_bytes_with_nul_unchecked(&input.0[0..idx + 1])
         };
-        Ok((input.range_from(idx + 1..), cstr))
+        *input = input.range_from(idx + 1..);
+        Ok(cstr)
     } else {
         Err(Error::UnexpectedEof)
     }
@@ -546,15 +544,14 @@ pub fn parse_null_terminated_string<Endian>(input: EndianBuf<Endian>)
 /// Parse a `DW_EH_PE_*` pointer encoding.
 #[doc(hidden)]
 #[inline]
-pub fn parse_pointer_encoding<Endian>(input: EndianBuf<Endian>)
-                                      -> Result<(EndianBuf<Endian>, constants::DwEhPe)>
+pub fn parse_pointer_encoding<Endian>(input: &mut EndianBuf<Endian>) -> Result<constants::DwEhPe>
     where Endian: Endianity
 {
-    let (rest, eh_pe) = parse_u8(input)?;
+    let eh_pe = parse_u8(input)?;
     let eh_pe = constants::DwEhPe(eh_pe);
 
     if eh_pe.is_valid_encoding() {
-        Ok((rest, eh_pe))
+        Ok(eh_pe)
     } else {
         Err(Error::UnknownPointerEncoding)
     }
@@ -600,19 +597,18 @@ impl Pointer {
     }
 }
 
-pub fn parse_encoded_pointer<'bases, 'input, Endian>
-    (encoding: constants::DwEhPe,
-     bases: &'bases BaseAddresses,
-     address_size: u8,
-     section: EndianBuf<'input, Endian>,
-     input: EndianBuf<'input, Endian>)
-     -> Result<(EndianBuf<'input, Endian>, Pointer)>
+pub fn parse_encoded_pointer<'bases, 'input, Endian>(encoding: constants::DwEhPe,
+                                                     bases: &'bases BaseAddresses,
+                                                     address_size: u8,
+                                                     section: EndianBuf<'input, Endian>,
+                                                     input: &mut EndianBuf<'input, Endian>)
+                                                     -> Result<Pointer>
     where Endian: Endianity
 {
     fn parse_data<Endian>(encoding: constants::DwEhPe,
                           address_size: u8,
-                          input: EndianBuf<Endian>)
-                          -> Result<(EndianBuf<Endian>, u64)>
+                          input: &mut EndianBuf<Endian>)
+                          -> Result<u64>
         where Endian: Endianity
     {
         // We should never be called with an invalid encoding: parse_encoded_pointer
@@ -621,47 +617,20 @@ pub fn parse_encoded_pointer<'bases, 'input, Endian>
 
         match encoding.format() {
             // Unsigned variants.
-            constants::DW_EH_PE_absptr => {
-                let (rest, a) = parse_address(input, address_size)?;
-                Ok((rest, a))
-            }
-            constants::DW_EH_PE_uleb128 => {
-                let (rest, a) = parse_unsigned_leb(input)?;
-                Ok((rest, a))
-            }
-            constants::DW_EH_PE_udata2 => {
-                let (rest, a) = parse_u16(input)?;
-                Ok((rest, a as u64))
-            }
-            constants::DW_EH_PE_udata4 => {
-                let (rest, a) = parse_u32(input)?;
-                Ok((rest, a as u64))
-            }
-            constants::DW_EH_PE_udata8 => {
-                let (rest, a) = parse_u64(input)?;
-                Ok((rest, a))
-            }
+            constants::DW_EH_PE_absptr => parse_address(input, address_size),
+            constants::DW_EH_PE_uleb128 => parse_unsigned_leb(input),
+            constants::DW_EH_PE_udata2 => parse_u16(input).map(|a| a as u64),
+            constants::DW_EH_PE_udata4 => parse_u32(input).map(|a| a as u64),
+            constants::DW_EH_PE_udata8 => parse_u64(input),
 
             // Signed variants. Here we sign extend the values (happens by
             // default when casting a signed integer to a larger range integer
             // in Rust), return them as u64, and rely on wrapping addition to do
             // the right thing when adding these offsets to their bases.
-            constants::DW_EH_PE_sleb128 => {
-                let (rest, a) = parse_signed_leb(input)?;
-                Ok((rest, a as u64))
-            }
-            constants::DW_EH_PE_sdata2 => {
-                let (rest, a) = parse_i16(input)?;
-                Ok((rest, a as u64))
-            }
-            constants::DW_EH_PE_sdata4 => {
-                let (rest, a) = parse_i32(input)?;
-                Ok((rest, a as u64))
-            }
-            constants::DW_EH_PE_sdata8 => {
-                let (rest, a) = parse_i64(input)?;
-                Ok((rest, a as u64))
-            }
+            constants::DW_EH_PE_sleb128 => parse_signed_leb(input).map(|a| a as u64),
+            constants::DW_EH_PE_sdata2 => parse_i16(input).map(|a| a as u64),
+            constants::DW_EH_PE_sdata4 => parse_i32(input).map(|a| a as u64),
+            constants::DW_EH_PE_sdata8 => parse_i64(input).map(|a| a as u64),
 
             // That was all of the valid encoding formats.
             _ => unreachable!(),
@@ -673,37 +642,37 @@ pub fn parse_encoded_pointer<'bases, 'input, Endian>
     }
 
     if encoding == constants::DW_EH_PE_omit {
-        return Ok((input, Pointer::Direct(0)));
+        return Ok(Pointer::Direct(0));
     }
 
     match encoding.application() {
         constants::DW_EH_PE_absptr => {
-            let (rest, addr) = parse_data(encoding, address_size, input)?;
-            Ok((rest, Pointer::new(encoding, addr.into())))
+            let addr = parse_data(encoding, address_size, input)?;
+            Ok(Pointer::new(encoding, addr.into()))
         }
         constants::DW_EH_PE_pcrel => {
             if let Some(cfi) = bases.cfi {
-                let (rest, offset) = parse_data(encoding, address_size, input)?;
                 let offset_from_section = input.as_ptr() as usize - section.as_ptr() as usize;
+                let offset = parse_data(encoding, address_size, input)?;
                 let p = cfi.wrapping_add(offset_from_section as u64)
                     .wrapping_add(offset);
-                Ok((rest, Pointer::new(encoding, p)))
+                Ok(Pointer::new(encoding, p))
             } else {
                 Err(Error::CfiRelativePointerButCfiBaseIsUndefined)
             }
         }
         constants::DW_EH_PE_textrel => {
             if let Some(text) = bases.text {
-                let (rest, offset) = parse_data(encoding, address_size, input)?;
-                Ok((rest, Pointer::new(encoding, text.wrapping_add(offset))))
+                let offset = parse_data(encoding, address_size, input)?;
+                Ok(Pointer::new(encoding, text.wrapping_add(offset)))
             } else {
                 Err(Error::TextRelativePointerButTextBaseIsUndefined)
             }
         }
         constants::DW_EH_PE_datarel => {
             if let Some(data) = bases.data {
-                let (rest, offset) = parse_data(encoding, address_size, input)?;
-                Ok((rest, Pointer::new(encoding, data.wrapping_add(offset))))
+                let offset = parse_data(encoding, address_size, input)?;
+                Ok(Pointer::new(encoding, data.wrapping_add(offset)))
             } else {
                 Err(Error::DataRelativePointerButDataBaseIsUndefined)
             }
@@ -711,8 +680,8 @@ pub fn parse_encoded_pointer<'bases, 'input, Endian>
         constants::DW_EH_PE_funcrel => {
             let func = bases.func.borrow();
             if let Some(func) = *func {
-                let (rest, offset) = parse_data(encoding, address_size, input)?;
-                Ok((rest, Pointer::new(encoding, func.wrapping_add(offset))))
+                let offset = parse_data(encoding, address_size, input)?;
+                Ok(Pointer::new(encoding, func.wrapping_add(offset)))
             } else {
                 Err(Error::FuncRelativePointerInBadContext)
             }
@@ -741,23 +710,22 @@ const DWARF_64_INITIAL_UNIT_LENGTH: u64 = 0xffffffff;
 
 /// Parse the compilation unit header's length.
 #[doc(hidden)]
-pub fn parse_initial_length<Endian>(input: EndianBuf<Endian>)
-                                    -> Result<(EndianBuf<Endian>, (u64, Format))>
+pub fn parse_initial_length<Endian>(input: &mut EndianBuf<Endian>) -> Result<(u64, Format)>
     where Endian: Endianity
 {
-    let (rest, val) = parse_u32_as_u64(input)?;
+    let val = parse_u32_as_u64(input)?;
     if val < MAX_DWARF_32_UNIT_LENGTH {
-        Ok((rest, (val, Format::Dwarf32)))
+        Ok((val, Format::Dwarf32))
     } else if val == DWARF_64_INITIAL_UNIT_LENGTH {
-        let (rest, val) = parse_u64(rest)?;
-        Ok((rest, (val, Format::Dwarf64)))
+        let val = parse_u64(input)?;
+        Ok((val, Format::Dwarf64))
     } else {
         Err(Error::UnknownReservedLength)
     }
 }
 
 /// Parse the size of addresses (in bytes) on the target architecture.
-pub fn parse_address_size<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf<Endian>, u8)>
+pub fn parse_address_size<Endian>(input: &mut EndianBuf<Endian>) -> Result<u8>
     where Endian: Endianity
 {
     parse_u8(input)
@@ -765,15 +733,17 @@ pub fn parse_address_size<Endian>(input: EndianBuf<Endian>) -> Result<(EndianBuf
 
 /// Take a slice of size `bytes` from the input.
 #[inline]
-pub fn take<Endian>(bytes: usize,
-                    input: EndianBuf<Endian>)
-                    -> Result<(EndianBuf<Endian>, EndianBuf<Endian>)>
+pub fn take<'input, Endian>(bytes: usize,
+                            input: &mut EndianBuf<'input, Endian>)
+                            -> Result<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     if input.len() < bytes {
         Err(Error::UnexpectedEof)
     } else {
-        Ok((input.range_from(bytes..), input.range_to(..bytes)))
+        let val = input.range_to(..bytes);
+        *input = input.range_from(bytes..);
+        Ok(val)
     }
 }
 
@@ -781,12 +751,12 @@ pub fn take<Endian>(bytes: usize,
 /// that many bytes from the input.  These bytes are returned as the
 /// second element of the result tuple.
 #[doc(hidden)]
-pub fn parse_length_uleb_value<Endian>(input: EndianBuf<Endian>)
-                                       -> Result<(EndianBuf<Endian>, EndianBuf<Endian>)>
+pub fn parse_length_uleb_value<'input, Endian>(input: &mut EndianBuf<'input, Endian>)
+                                               -> Result<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
-    let (rest, len) = parse_unsigned_leb(input)?;
-    take(len as usize, rest)
+    let len = parse_unsigned_leb(input)?;
+    take(len as usize, input)
 }
 
 #[cfg(test)]
@@ -806,9 +776,10 @@ mod tests {
         let section = Section::with_endian(Endian::Little).L32(0x78563412);
         let buf = section.get_contents().unwrap();
 
-        match parse_initial_length(EndianBuf::<LittleEndian>::new(&buf)) {
-            Ok((rest, (length, format))) => {
-                assert_eq!(rest.len(), 0);
+        let input = &mut EndianBuf::<LittleEndian>::new(&buf);
+        match parse_initial_length(input) {
+            Ok((length, format)) => {
+                assert_eq!(input.len(), 0);
                 assert_eq!(format, Format::Dwarf32);
                 assert_eq!(0x78563412, length);
             }
@@ -825,9 +796,10 @@ mod tests {
             .L64(0xffdebc9a78563412);
         let buf = section.get_contents().unwrap();
 
-        match parse_initial_length(EndianBuf::<LittleEndian>::new(&buf)) {
-            Ok((rest, (length, format))) => {
-                assert_eq!(rest.len(), 0);
+        let input = &mut EndianBuf::<LittleEndian>::new(&buf);
+        match parse_initial_length(input) {
+            Ok((length, format)) => {
+                assert_eq!(input.len(), 0);
                 assert_eq!(format, Format::Dwarf64);
                 assert_eq!(0xffdebc9a78563412, length);
             }
@@ -840,7 +812,7 @@ mod tests {
         let section = Section::with_endian(Endian::Little).L32(0xfffffffe);
         let buf = section.get_contents().unwrap();
 
-        match parse_initial_length(EndianBuf::<LittleEndian>::new(&buf)) {
+        match parse_initial_length(&mut EndianBuf::<LittleEndian>::new(&buf)) {
             Err(Error::UnknownReservedLength) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
@@ -850,7 +822,7 @@ mod tests {
     fn test_parse_initial_length_incomplete() {
         let buf = [0xff, 0xff, 0xff]; // Need at least 4 bytes.
 
-        match parse_initial_length(EndianBuf::<LittleEndian>::new(&buf)) {
+        match parse_initial_length(&mut EndianBuf::<LittleEndian>::new(&buf)) {
             Err(Error::UnexpectedEof) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
@@ -865,7 +837,7 @@ mod tests {
             .L32(0x78563412);
         let buf = section.get_contents().unwrap();
 
-        match parse_initial_length(EndianBuf::<LittleEndian>::new(&buf)) {
+        match parse_initial_length(&mut EndianBuf::<LittleEndian>::new(&buf)) {
             Err(Error::UnexpectedEof) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
@@ -876,9 +848,10 @@ mod tests {
         let section = Section::with_endian(Endian::Little).L32(0x01234567);
         let buf = section.get_contents().unwrap();
 
-        match parse_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf32) {
-            Ok((rest, val)) => {
-                assert_eq!(rest.len(), 0);
+        let input = &mut EndianBuf::<LittleEndian>::new(&buf);
+        match parse_offset(input, Format::Dwarf32) {
+            Ok(val) => {
+                assert_eq!(input.len(), 0);
                 assert_eq!(val, 0x01234567);
             }
             otherwise => panic!("Unexpected result: {:?}", otherwise),
@@ -890,9 +863,10 @@ mod tests {
         let section = Section::with_endian(Endian::Little).L64(0x01234567);
         let buf = section.get_contents().unwrap();
 
-        match parse_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf64) {
-            Ok((rest, val)) => {
-                assert_eq!(rest.len(), 0);
+        let input = &mut EndianBuf::<LittleEndian>::new(&buf);
+        match parse_offset(input, Format::Dwarf64) {
+            Ok(val) => {
+                assert_eq!(input.len(), 0);
                 assert_eq!(val, 0x01234567);
             }
             otherwise => panic!("Unexpected result: {:?}", otherwise),
@@ -905,9 +879,10 @@ mod tests {
         let section = Section::with_endian(Endian::Little).L64(0x0123456789abcdef);
         let buf = section.get_contents().unwrap();
 
-        match parse_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf64) {
-            Ok((rest, val)) => {
-                assert_eq!(rest.len(), 0);
+        let input = &mut EndianBuf::<LittleEndian>::new(&buf);
+        match parse_offset(input, Format::Dwarf64) {
+            Ok(val) => {
+                assert_eq!(input.len(), 0);
                 assert_eq!(val, 0x0123456789abcdef);
             }
             otherwise => panic!("Unexpected result: {:?}", otherwise),
@@ -930,8 +905,8 @@ mod tests {
     fn test_parse_address_size_ok() {
         let buf = [0x04];
 
-        match parse_address_size(EndianBuf::<LittleEndian>::new(&buf)) {
-            Ok((_, val)) => assert_eq!(val, 4),
+        match parse_address_size(&mut EndianBuf::<LittleEndian>::new(&buf)) {
+            Ok(val) => assert_eq!(val, 4),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }
@@ -942,9 +917,9 @@ mod tests {
         let expected = constants::DwEhPe(constants::DW_EH_PE_uleb128.0 |
                                          constants::DW_EH_PE_pcrel.0);
         let input = [expected.0, 1, 2, 3, 4];
-        let input = EndianBuf::<NativeEndian>::new(&input);
-        assert_eq!(Ok((EndianBuf::new(&[1, 2, 3, 4]), expected)),
-                   parse_pointer_encoding(input));
+        let input = &mut EndianBuf::<NativeEndian>::new(&input);
+        assert_eq!(parse_pointer_encoding(input), Ok(expected));
+        assert_eq!(*input, EndianBuf::new(&[1, 2, 3, 4]));
     }
 
     #[test]
@@ -953,7 +928,7 @@ mod tests {
         let expected = constants::DwEhPe((constants::DW_EH_PE_sdata8.0 + 1) |
                                          constants::DW_EH_PE_pcrel.0);
         let input = [expected.0, 1, 2, 3, 4];
-        let input = EndianBuf::<NativeEndian>::new(&input);
+        let input = &mut EndianBuf::<NativeEndian>::new(&input);
         assert_eq!(Err(Error::UnknownPointerEncoding),
                    parse_pointer_encoding(input));
     }
@@ -970,9 +945,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0xf00df00d))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0xf00df00d)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -990,13 +967,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input.range_from(0x10..);
 
-        assert_eq!(parse_encoded_pointer(encoding,
-                                         &bases,
-                                         address_size,
-                                         input,
-                                         input.range_from(0x10..)),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x111))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x111)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1008,8 +983,9 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
                    Err(Error::CfiRelativePointerButCfiBaseIsUndefined));
     }
 
@@ -1027,9 +1003,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x11))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x11)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1041,8 +1019,9 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
                    Err(Error::TextRelativePointerButTextBaseIsUndefined));
     }
 
@@ -1060,9 +1039,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x11))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x11)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1074,8 +1055,9 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
                    Err(Error::DataRelativePointerButDataBaseIsUndefined));
     }
 
@@ -1094,9 +1076,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x11))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x11)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1108,8 +1092,9 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
                    Err(Error::FuncRelativePointerInBadContext));
     }
 
@@ -1126,9 +1111,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x123456))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x123456)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1144,9 +1131,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x1234))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x1234)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1162,9 +1151,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x12345678))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x12345678)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1180,9 +1171,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x1234567812345678))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x1234567812345678)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1198,9 +1191,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(0x11110000))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(0x11110000)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1217,9 +1212,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(expected as u64))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(expected as u64)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1236,9 +1233,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(expected as u64))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(expected as u64)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1255,9 +1254,11 @@ mod tests {
             .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&expected_rest), Pointer::Direct(expected as u64))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Direct(expected as u64)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 
     #[test]
@@ -1269,9 +1270,11 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((input, Pointer::default())));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::default()));
+        assert_eq!(rest, input);
     }
 
     #[test]
@@ -1283,8 +1286,9 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
                    Err(Error::UnknownPointerEncoding));
     }
 
@@ -1299,14 +1303,15 @@ mod tests {
         let input = Section::with_endian(Endian::Little).L32(0x1);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
                    Err(Error::UnsupportedPointerEncoding));
     }
 
     #[test]
     fn test_parse_encoded_pointer_indirect() {
-        let rest = [1, 2, 3, 4];
+        let expected_rest = [1, 2, 3, 4];
 
         let encoding = constants::DW_EH_PE_indirect;
         let bases = BaseAddresses::default();
@@ -1314,11 +1319,13 @@ mod tests {
 
         let input = Section::with_endian(Endian::Little)
             .L32(0x12345678)
-            .append_bytes(&rest);
+            .append_bytes(&expected_rest);
         let input = input.get_contents().unwrap();
         let input = EndianBuf::<LittleEndian>::new(&input);
+        let mut rest = input;
 
-        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, input),
-                   Ok((EndianBuf::new(&rest), Pointer::Indirect(0x12345678))));
+        assert_eq!(parse_encoded_pointer(encoding, &bases, address_size, input, &mut rest),
+                   Ok(Pointer::Indirect(0x12345678)));
+        assert_eq!(rest, EndianBuf::new(&expected_rest));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -381,12 +381,8 @@ pub fn parse_i64<Endian>(input: &mut EndianBuf<Endian>) -> Result<i64>
 pub fn parse_unsigned_leb<Endian>(input: &mut EndianBuf<Endian>) -> Result<u64>
     where Endian: Endianity
 {
-    let mut buf = input.buf();
-    match leb128::read::unsigned(&mut buf) {
-        Ok(val) => {
-            *input = EndianBuf::new(buf);
-            Ok(val)
-        }
+    match leb128::read::unsigned(input) {
+        Ok(val) => Ok(val),
         Err(leb128::read::Error::IoError(ref e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
             Err(Error::UnexpectedEof)
         }
@@ -409,12 +405,8 @@ pub fn parse_unsigned_leb_as_u8<Endian>(input: &mut EndianBuf<Endian>) -> Result
 pub fn parse_signed_leb<Endian>(input: &mut EndianBuf<Endian>) -> Result<i64>
     where Endian: Endianity
 {
-    let mut buf = input.buf();
-    match leb128::read::signed(&mut buf) {
-        Ok(val) => {
-            *input = EndianBuf::new(buf);
-            Ok(val)
-        }
+    match leb128::read::signed(input) {
+        Ok(val) => Ok(val),
         Err(leb128::read::Error::IoError(ref e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
             Err(Error::UnexpectedEof)
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -644,7 +644,7 @@ pub fn parse_encoded_pointer<'bases, 'input, Endian>(encoding: constants::DwEhPe
         }
         constants::DW_EH_PE_pcrel => {
             if let Some(cfi) = bases.cfi {
-                let offset_from_section = input.as_ptr() as usize - section.as_ptr() as usize;
+                let offset_from_section = input.offset_from(section);
                 let offset = parse_data(encoding, address_size, input)?;
                 let p = cfi.wrapping_add(offset_from_section as u64)
                     .wrapping_add(offset);

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -77,9 +77,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for NamesSwitch<'input, 
         }
     }
 
-    fn parse_offset(input: EndianBuf<Endian>,
-                    format: Format)
-                    -> Result<(EndianBuf<Endian>, Self::Offset)> {
+    fn parse_offset(input: &mut EndianBuf<Endian>, format: Format) -> Result<Self::Offset> {
         parse_debug_info_offset(input, format)
     }
 

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -76,9 +76,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
         }
     }
 
-    fn parse_offset(input: EndianBuf<Endian>,
-                    format: Format)
-                    -> Result<(EndianBuf<Endian>, Self::Offset)> {
+    fn parse_offset(input: &mut EndianBuf<Endian>, format: Format) -> Result<Self::Offset> {
         parse_debug_types_offset(input, format)
     }
 

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -126,11 +126,9 @@ impl<'input, Endian> RawRangesIter<'input, Endian>
             return Ok(None);
         }
 
-        let (rest, range) = Range::parse(self.input, self.address_size)?;
+        let range = Range::parse(&mut self.input, self.address_size)?;
         if range.is_end() {
             self.input = EndianBuf::new(&[]);
-        } else {
-            self.input = rest;
         }
 
         Ok(Some(range))
@@ -259,18 +257,16 @@ impl Range {
     /// Parse an address range entry from `.debug_ranges` or `.debug_loc`.
     #[doc(hidden)]
     #[inline]
-    pub fn parse<Endian>(input: EndianBuf<Endian>,
-                         address_size: u8)
-                         -> Result<(EndianBuf<Endian>, Range)>
+    pub fn parse<Endian>(input: &mut EndianBuf<Endian>, address_size: u8) -> Result<Range>
         where Endian: Endianity
     {
-        let (rest, begin) = parse_address(input, address_size)?;
-        let (rest, end) = parse_address(rest, address_size)?;
+        let begin = parse_address(input, address_size)?;
+        let end = parse_address(input, address_size)?;
         let range = Range {
             begin: begin,
             end: end,
         };
-        Ok((rest, range))
+        Ok(range)
     }
 }
 

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,7 +1,6 @@
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
 use parser::{Error, Result, parse_address};
-use std::marker::PhantomData;
 use Section;
 
 /// An offset into the `.debug_ranges` section.
@@ -35,7 +34,7 @@ impl<'input, Endian> DebugRanges<'input, Endian>
     /// let debug_ranges = DebugRanges::<LittleEndian>::new(read_debug_ranges_section_somehow());
     /// ```
     pub fn new(debug_ranges_section: &'input [u8]) -> DebugRanges<'input, Endian> {
-        DebugRanges { debug_ranges_section: EndianBuf(debug_ranges_section, PhantomData) }
+        DebugRanges { debug_ranges_section: EndianBuf::new(debug_ranges_section) }
     }
 
     /// Iterate over the `Range` list entries starting at the given offset.

--- a/src/str.rs
+++ b/src/str.rs
@@ -54,9 +54,8 @@ impl<'input, Endian> DebugStr<'input, Endian>
         if self.debug_str_section.len() < offset.0 {
             return Err(Error::UnexpectedEof);
         }
-        let buf = self.debug_str_section.range_from(offset.0..);
-        let result = parse_null_terminated_string(buf);
-        result.map(|(_, cstr)| cstr)
+        let buf = &mut self.debug_str_section.range_from(offset.0..);
+        parse_null_terminated_string(buf)
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,7 +1,6 @@
 use endianity::{Endianity, EndianBuf};
 use parser::{parse_null_terminated_string, Error, Result};
 use std::ffi;
-use std::marker::PhantomData;
 use Section;
 
 /// An offset into the `.debug_str` section.
@@ -35,7 +34,7 @@ impl<'input, Endian> DebugStr<'input, Endian>
     /// let debug_str = DebugStr::<LittleEndian>::new(read_debug_str_section_somehow());
     /// ```
     pub fn new(debug_str_section: &'input [u8]) -> DebugStr<'input, Endian> {
-        DebugStr { debug_str_section: EndianBuf(debug_str_section, PhantomData) }
+        DebugStr { debug_str_section: EndianBuf::new(debug_str_section) }
     }
 
     /// Lookup a string from the `.debug_str` section by DebugStrOffset.

--- a/src/str.rs
+++ b/src/str.rs
@@ -55,7 +55,7 @@ impl<'input, Endian> DebugStr<'input, Endian>
             return Err(Error::UnexpectedEof);
         }
         let buf = self.debug_str_section.range_from(offset.0..);
-        let result = parse_null_terminated_string(buf.0);
+        let result = parse_null_terminated_string(buf);
         result.map(|(_, cstr)| cstr)
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -656,11 +656,7 @@ fn parse_unit_header<'input, Endian>(input: &mut EndianBuf<'input, Endian>)
     where Endian: Endianity
 {
     let (unit_length, format) = parse_initial_length(input)?;
-    if unit_length as usize > input.len() {
-        return Err(Error::UnexpectedEof);
-    }
-    let rest = &mut input.range_to(..unit_length as usize);
-    *input = input.range_from(unit_length as usize..);
+    let rest = &mut take(unit_length as usize, input)?;
 
     let version = parse_version(rest)?;
     let offset = parse_debug_abbrev_offset(rest, format)?;

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -15,7 +15,6 @@ use ranges::DebugRangesOffset;
 use std::cell::Cell;
 use std::convert::AsMut;
 use std::ffi;
-use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Range, RangeFrom, RangeTo};
 use std::{u8, u16};
@@ -121,7 +120,7 @@ impl<'input, Endian> DebugInfo<'input, Endian>
     /// let debug_info = DebugInfo::<LittleEndian>::new(read_debug_info_section_somehow());
     /// ```
     pub fn new(debug_info_section: &'input [u8]) -> DebugInfo<'input, Endian> {
-        DebugInfo { debug_info_section: EndianBuf(debug_info_section, PhantomData) }
+        DebugInfo { debug_info_section: EndianBuf::new(debug_info_section) }
     }
 
     /// Iterate the compilation- and partial-units in this
@@ -1837,7 +1836,7 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
 
     /// Return the offset in bytes of the given array from the start of the compilation unit
     fn get_offset(&self, input: EndianBuf<'input, Endian>) -> UnitOffset {
-        let ptr = input.0.as_ptr() as *const u8 as usize;
+        let ptr = input.buf().as_ptr() as *const u8 as usize;
         let start_ptr = self.unit.entries_buf.as_ptr() as *const u8 as usize;
         let offset = ptr - start_ptr + self.unit.header_size();
         UnitOffset(offset)
@@ -2426,7 +2425,7 @@ impl<'input, Endian> DebugTypes<'input, Endian>
     /// let debug_types = DebugTypes::<LittleEndian>::new(read_debug_types_section_somehow());
     /// ```
     pub fn new(debug_types_section: &'input [u8]) -> DebugTypes<'input, Endian> {
-        DebugTypes { debug_types_section: EndianBuf(debug_types_section, PhantomData) }
+        DebugTypes { debug_types_section: EndianBuf::new(debug_types_section) }
     }
 
     /// Iterate the type-units in this `.debug_types` section.

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1836,10 +1836,7 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
 
     /// Return the offset in bytes of the given array from the start of the compilation unit
     fn get_offset(&self, input: EndianBuf<'input, Endian>) -> UnitOffset {
-        let ptr = input.buf().as_ptr() as *const u8 as usize;
-        let start_ptr = self.unit.entries_buf.as_ptr() as *const u8 as usize;
-        let offset = ptr - start_ptr + self.unit.header_size();
-        UnitOffset(offset)
+        UnitOffset(self.unit.header_size() + input.offset_from(self.unit.entries_buf))
     }
 
     /// Move the cursor to the next DIE in the tree.


### PR DESCRIPTION
I'm not sure that this PR is ready to merge yet, but I'd like feedback on the direction it is taking. My goal is to define a `Reader` trait, implement that trait for `EndianBuf`, and gradually replace all usage of `EndianBuf` with the `Reader` trait instead.

This PR takes two steps:
- use `EndianBuf` everywhere, instead of `&[u8]`. We were already using it in most places, but this extends it to things like `parse_u8`. There are likely still some places I have missed.
- reduce the amount of cloning of `EndianBuf`. This is achieved by changing parsing functions to take `&mut EndianBuf`, instead of returning a copy and leaving the input unmodified. The motivation is that while cloning `EndianBuf` is cheap, this may not be true for other implementations of `Reader`.

One reason I'm asking for feedback is that I suspect @fitzgen likes the current immutable input for parsing, so this may be a controversial change.