### PR TITLE
Parse DW_OP_GNU_parameter_ref, add plumbing for evaluating it.

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1156,6 +1156,7 @@ dw!(DwOp(u8) {
     DW_OP_GNU_push_tls_address = 0xe0,
     DW_OP_GNU_implicit_pointer = 0xf2,
     DW_OP_GNU_entry_value = 0xf3,
+    DW_OP_GNU_parameter_ref = 0xfa,
 });
 
 /// Pointer encoding used by `.eh_frame`. The four lower bits describe the


### PR DESCRIPTION
`DW_OP_GNU_parameter_ref` is a DWARF extension that allows finding the value of parameters or variables that were optimized out of a function but may vary at the caller.  See https://gcc.gnu.org/ml/gcc-patches/2011-06/msg00649.html for an example.  There, the optimizer will remove both `y` and `z` from the generated assembly.  Because `z` is constant, the debug info can note it has a value of 3.  But `y` varies, so a `DW_OP_GNU_parameter_ref` is emitted.  The Gimli consumer is responsible for determining the caller, finding the right `DW_TAG_GNU_call_site`, and looking up the `DW_TAG_GNU_call_parameter`'s value to continue with the evaluation.

The parsing semantics of the operand are the same as `DW_OP_call4`s.