### PR TITLE
Fix pubnames/pubtypes offset handling

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -130,7 +130,7 @@ fn bench_parsing_debug_pubnames(b: &mut test::Bencher) {
 }
 
 #[bench]
-fn bench_parsing_debug_types(b: &mut test::Bencher) {
+fn bench_parsing_debug_pubtypes(b: &mut test::Bencher) {
     let debug_pubtypes = read_section("debug_pubtypes");
     let debug_pubtypes = DebugPubTypes::<LittleEndian>::new(&debug_pubtypes);
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 // The various "Accelerated Access" sections (DWARF standard v4 Section 6.1) all have
 // similar structures. They consist of a header with metadata and an offset into the
-// .debug_info or .debug_types sections for the entire compilation unit, and a series
+// .debug_info section for the entire compilation unit, and a series
 // of following entries that list addresses (for .debug_aranges) or names
 // (for .debug_pubnames and .debug_pubtypes) that are covered.
 //

--- a/src/op.rs
+++ b/src/op.rs
@@ -197,7 +197,7 @@ pub enum Operation<'input, Endian>
     TextRelativeOffset {
         /// The offfset to add.
         offset: u64,
-    }
+    },
 }
 
 #[derive(Debug)]
@@ -1546,7 +1546,9 @@ impl<'input, Endian> Evaluation<'input, Endian>
     {
         match self.state {
             EvaluationState::Error(err) => return Err(err),
-            EvaluationState::Waiting(OperationEvaluationResult::AwaitingParameterRef { .. }) => {
+            EvaluationState::Waiting(OperationEvaluationResult::AwaitingParameterRef {
+                                         ..
+                                     }) => {
                 self.push(parameter_value);
             }
             _ => {
@@ -2033,7 +2035,9 @@ mod tests {
         let format = Format::Dwarf32;
 
         let inputs =
-            [(constants::DW_OP_addr, 0x12345678, Operation::TextRelativeOffset { offset: 0x12345678 }),
+            [(constants::DW_OP_addr,
+              0x12345678,
+              Operation::TextRelativeOffset { offset: 0x12345678 }),
              (constants::DW_OP_const4u, 0x12345678, Operation::Literal { value: 0x12345678 }),
              (constants::DW_OP_const4s,
               (-23i32) as u32,
@@ -2260,9 +2264,7 @@ mod tests {
     #[test]
     fn test_op_parse_gnu_parameter_ref() {
         check_op_parse(|s| s.D8(constants::DW_OP_GNU_parameter_ref.0).D32(0x12345678),
-                       &Operation::ParameterRef {
-                           offset: UnitOffset(0x12345678)
-                       },
+                       &Operation::ParameterRef { offset: UnitOffset(0x12345678) },
                        4,
                        Format::Dwarf32)
     }

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -4,7 +4,6 @@ use parser::{Format, Result};
 use unit::{DebugInfoOffset, UnitOffset, parse_debug_info_offset};
 use std::ffi;
 use std::marker::PhantomData;
-use std::rc::Rc;
 use Section;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -19,9 +18,9 @@ pub struct PubTypesHeader {
 /// A single parsed pubtype.
 #[derive(Debug, Clone)]
 pub struct PubTypesEntry<'input> {
-    offset: UnitOffset,
+    unit_header_offset: DebugInfoOffset,
+    die_offset: UnitOffset,
     name: &'input ffi::CStr,
-    header: Rc<PubTypesHeader>,
 }
 
 impl<'input> PubTypesEntry<'input> {
@@ -33,13 +32,13 @@ impl<'input> PubTypesEntry<'input> {
     /// Returns the offset into the .debug_info section for the header of the compilation unit
     /// which contains the type with this name.
     pub fn unit_header_offset(&self) -> DebugInfoOffset {
-        self.header.info_offset
+        self.unit_header_offset
     }
 
     /// Returns the offset into the compilation unit for the debugging information entry which
     /// the type with this name.
     pub fn die_offset(&self) -> UnitOffset {
-        self.offset
+        self.die_offset
     }
 }
 
@@ -62,24 +61,24 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
                   version: u16,
                   offset: DebugInfoOffset,
                   length: u64)
-                  -> Rc<PubTypesHeader> {
-        Rc::new(PubTypesHeader {
-                    format: format,
-                    length: set_length,
-                    version: version,
-                    info_offset: offset,
-                    info_length: length,
-                })
+                  -> PubTypesHeader {
+        PubTypesHeader {
+            format: format,
+            length: set_length,
+            version: version,
+            info_offset: offset,
+            info_length: length,
+        }
     }
 
     fn new_entry(offset: u64,
                  name: &'input ffi::CStr,
-                 header: &Rc<PubTypesHeader>)
+                 header: &PubTypesHeader)
                  -> PubTypesEntry<'input> {
         PubTypesEntry {
-            offset: UnitOffset(offset as usize),
+            unit_header_offset: header.info_offset,
+            die_offset: UnitOffset(offset as usize),
             name: name,
-            header: header.clone(),
         }
     }
 

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -1,7 +1,7 @@
 use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, Result};
-use unit::{DebugTypesOffset, parse_debug_types_offset};
+use unit::{DebugInfoOffset, UnitOffset, parse_debug_info_offset};
 use std::ffi;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -12,14 +12,14 @@ pub struct PubTypesHeader {
     format: Format,
     length: u64,
     version: u16,
-    types_offset: DebugTypesOffset,
-    types_length: u64,
+    info_offset: DebugInfoOffset,
+    info_length: u64,
 }
 
 /// A single parsed pubtype.
 #[derive(Debug, Clone)]
 pub struct PubTypesEntry<'input> {
-    offset: u64,
+    offset: UnitOffset,
     name: &'input ffi::CStr,
     header: Rc<PubTypesHeader>,
 }
@@ -30,9 +30,16 @@ impl<'input> PubTypesEntry<'input> {
         self.name
     }
 
-    /// Returns the offset into the .debug_types section for this type.
-    pub fn types_offset(&self) -> DebugTypesOffset {
-        self.header.types_offset
+    /// Returns the offset into the .debug_info section for the header of the compilation unit
+    /// which contains the type with this name.
+    pub fn unit_header_offset(&self) -> DebugInfoOffset {
+        self.header.info_offset
+    }
+
+    /// Returns the offset into the compilation unit for the debugging information entry which
+    /// the type with this name.
+    pub fn die_offset(&self) -> UnitOffset {
+        self.offset
     }
 }
 
@@ -48,20 +55,20 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
 {
     type Header = PubTypesHeader;
     type Entry = PubTypesEntry<'input>;
-    type Offset = DebugTypesOffset;
+    type Offset = DebugInfoOffset;
 
     fn new_header(format: Format,
                   set_length: u64,
                   version: u16,
-                  offset: DebugTypesOffset,
+                  offset: DebugInfoOffset,
                   length: u64)
                   -> Rc<PubTypesHeader> {
         Rc::new(PubTypesHeader {
                     format: format,
                     length: set_length,
                     version: version,
-                    types_offset: offset,
-                    types_length: length,
+                    info_offset: offset,
+                    info_length: length,
                 })
     }
 
@@ -70,14 +77,14 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
                  header: &Rc<PubTypesHeader>)
                  -> PubTypesEntry<'input> {
         PubTypesEntry {
-            offset: offset,
+            offset: UnitOffset(offset as usize),
             name: name,
             header: header.clone(),
         }
     }
 
     fn parse_offset(input: &mut EndianBuf<Endian>, format: Format) -> Result<Self::Offset> {
-        parse_debug_types_offset(input, format)
+        parse_debug_info_offset(input, format)
     }
 
     fn format_from(header: &PubTypesHeader) -> Format {
@@ -86,7 +93,7 @@ impl<'input, Endian> NamesOrTypesSwitch<'input, Endian> for TypesSwitch<'input, 
 }
 
 /// The `DebugPubTypes` struct represents the DWARF public types information
-/// found in the `.debug_types` section.
+/// found in the `.debug_info` section.
 ///
 /// Provides:
 ///

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -439,15 +439,6 @@ pub fn parse_debug_info_offset<Endian>(input: &mut EndianBuf<Endian>,
     parse_offset(input, format).map(|offset| DebugInfoOffset(offset))
 }
 
-/// Parse the `debug_types_offset` in the pubtypes header.
-pub fn parse_debug_types_offset<Endian>(input: &mut EndianBuf<Endian>,
-                                        format: Format)
-                                        -> Result<DebugTypesOffset>
-    where Endian: Endianity
-{
-    parse_offset(input, format).map(|offset| DebugTypesOffset(offset))
-}
-
 /// The common fields for the headers of compilation units and
 /// type units.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2915,53 +2906,6 @@ mod tests {
         let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
 
         match parse_debug_info_offset(buf, Format::Dwarf64) {
-            Err(Error::UnexpectedEof) => assert!(true),
-            otherwise => panic!("Unexpected result: {:?}", otherwise),
-        };
-    }
-
-    #[test]
-    fn test_parse_debug_types_offset_32() {
-        let section = Section::with_endian(Endian::Little).L32(0x04030201);
-        let buf = section.get_contents().unwrap();
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
-
-        match parse_debug_types_offset(buf, Format::Dwarf32) {
-            Ok(val) => assert_eq!(val, DebugTypesOffset(0x04030201)),
-            otherwise => panic!("Unexpected result: {:?}", otherwise),
-        };
-    }
-
-    #[test]
-    fn test_parse_debug_types_offset_32_incomplete() {
-        let buf = [0x01, 0x02];
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
-
-        match parse_debug_types_offset(buf, Format::Dwarf32) {
-            Err(Error::UnexpectedEof) => assert!(true),
-            otherwise => panic!("Unexpected result: {:?}", otherwise),
-        };
-    }
-
-    #[test]
-    #[cfg(target_pointer_width = "64")]
-    fn test_parse_debug_types_offset_64() {
-        let section = Section::with_endian(Endian::Little).L64(0x0807060504030201);
-        let buf = section.get_contents().unwrap();
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
-
-        match parse_debug_types_offset(buf, Format::Dwarf64) {
-            Ok(val) => assert_eq!(val, DebugTypesOffset(0x0807060504030201)),
-            otherwise => panic!("Unexpected result: {:?}", otherwise),
-        };
-    }
-
-    #[test]
-    fn test_parse_debug_types_offset_64_incomplete() {
-        let buf = [0x01, 0x02];
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
-
-        match parse_debug_types_offset(buf, Format::Dwarf64) {
             Err(Error::UnexpectedEof) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };


### PR DESCRIPTION
- add die_offset() methods
- pubtypes is still for .debug_info, not .debug_types
- improve parse_self tests
- add dwarfdump support