### PR TITLE
Convert remaining modules to use Reader

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -195,7 +195,7 @@ fn bench_parsing_debug_loc(b: &mut test::Bencher) {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_loc = read_section("debug_loc");
-    let debug_loc = DebugLoc::<LittleEndian>::new(&debug_loc);
+    let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&debug_loc);
 
     let mut offsets = Vec::new();
 
@@ -249,7 +249,7 @@ fn bench_parsing_debug_ranges(b: &mut test::Bencher) {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_ranges = read_section("debug_ranges");
-    let debug_ranges = DebugRanges::<LittleEndian>::new(&debug_ranges);
+    let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&debug_ranges);
 
     let mut offsets = Vec::new();
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -107,7 +107,7 @@ fn parse_debug_info_tree(mut iter: EntriesTreeIter<EndianBuf<LittleEndian>>) {
 #[bench]
 fn bench_parsing_debug_aranges(b: &mut test::Bencher) {
     let debug_aranges = read_section("debug_aranges");
-    let debug_aranges = DebugAranges::<LittleEndian>::new(&debug_aranges);
+    let debug_aranges = DebugAranges::<EndianBuf<LittleEndian>>::new(&debug_aranges);
 
     b.iter(|| {
                let mut aranges = debug_aranges.items();
@@ -120,7 +120,7 @@ fn bench_parsing_debug_aranges(b: &mut test::Bencher) {
 #[bench]
 fn bench_parsing_debug_pubnames(b: &mut test::Bencher) {
     let debug_pubnames = read_section("debug_pubnames");
-    let debug_pubnames = DebugPubNames::<LittleEndian>::new(&debug_pubnames);
+    let debug_pubnames = DebugPubNames::<EndianBuf<LittleEndian>>::new(&debug_pubnames);
 
     b.iter(|| {
                let mut pubnames = debug_pubnames.items();
@@ -133,7 +133,7 @@ fn bench_parsing_debug_pubnames(b: &mut test::Bencher) {
 #[bench]
 fn bench_parsing_debug_pubtypes(b: &mut test::Bencher) {
     let debug_pubtypes = read_section("debug_pubtypes");
-    let debug_pubtypes = DebugPubTypes::<LittleEndian>::new(&debug_pubtypes);
+    let debug_pubtypes = DebugPubTypes::<EndianBuf<LittleEndian>>::new(&debug_pubtypes);
 
     b.iter(|| {
                let mut pubtypes = debug_pubtypes.items();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -152,7 +152,7 @@ const ADDRESS_SIZE: u8 = 8;
 #[bench]
 fn bench_parsing_line_number_program_opcodes(b: &mut test::Bencher) {
     let debug_line = read_section("debug_line");
-    let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
+    let debug_line = DebugLine::<EndianBuf<LittleEndian>>::new(&debug_line);
 
     b.iter(|| {
         let program = debug_line
@@ -170,7 +170,7 @@ fn bench_parsing_line_number_program_opcodes(b: &mut test::Bencher) {
 #[bench]
 fn bench_executing_line_number_programs(b: &mut test::Bencher) {
     let debug_line = read_section("debug_line");
-    let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
+    let debug_line = DebugLine::<EndianBuf<LittleEndian>>::new(&debug_line);
 
     b.iter(|| {
         let program = debug_line

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -112,9 +112,9 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
     let debug_line = file.get_section(".debug_line").unwrap_or(&[]);
     let debug_line = gimli::DebugLine::<gimli::EndianBuf<Endian>>::new(debug_line);
     let debug_loc = file.get_section(".debug_loc").unwrap_or(&[]);
-    let debug_loc = gimli::DebugLoc::<Endian>::new(debug_loc);
+    let debug_loc = gimli::DebugLoc::<gimli::EndianBuf<Endian>>::new(debug_loc);
     let debug_ranges = file.get_section(".debug_ranges").unwrap_or(&[]);
-    let debug_ranges = gimli::DebugRanges::<Endian>::new(debug_ranges);
+    let debug_ranges = gimli::DebugRanges::<gimli::EndianBuf<Endian>>::new(debug_ranges);
     let debug_str = file.get_section(".debug_str").unwrap_or(&[]);
     let debug_str = gimli::DebugStr::<gimli::EndianBuf<Endian>>::new(debug_str);
 
@@ -152,8 +152,8 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
 fn dump_info<Endian>(file: &object::File,
                      debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
                      debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                     debug_loc: gimli::DebugLoc<Endian>,
-                     debug_ranges: gimli::DebugRanges<Endian>,
+                     debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
+                     debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
                      debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
                      flags: &Flags)
     where Endian: gimli::Endianity
@@ -184,8 +184,8 @@ fn dump_info<Endian>(file: &object::File,
 fn dump_types<Endian>(file: &object::File,
                       debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
                       debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                      debug_loc: gimli::DebugLoc<Endian>,
-                      debug_ranges: gimli::DebugRanges<Endian>,
+                      debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
+                      debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
                       debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
                       flags: &Flags)
     where Endian: gimli::Endianity
@@ -239,8 +239,8 @@ fn dump_entries<Endian>(offset: usize,
                         address_size: u8,
                         format: gimli::Format,
                         debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                        debug_loc: gimli::DebugLoc<Endian>,
-                        debug_ranges: gimli::DebugRanges<Endian>,
+                        debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
+                        debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
                         debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
                         flags: &Flags)
     where Endian: gimli::Endianity
@@ -315,8 +315,8 @@ fn dump_entries<Endian>(offset: usize,
 
 fn dump_attr_value<Endian>(attr: gimli::Attribute<gimli::EndianBuf<Endian>>,
                            unit: &Unit<Endian>,
-                           debug_loc: gimli::DebugLoc<Endian>,
-                           debug_ranges: gimli::DebugRanges<Endian>,
+                           debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
+                           debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
                            debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>)
     where Endian: gimli::Endianity
 {
@@ -649,7 +649,7 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<gimli::EndianBuf<Endi
     }
 }
 
-fn dump_loc_list<Endian>(debug_loc: gimli::DebugLoc<Endian>,
+fn dump_loc_list<Endian>(debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
                          offset: gimli::DebugLocOffset,
                          unit: &Unit<Endian>)
     where Endian: gimli::Endianity
@@ -701,7 +701,7 @@ fn dump_loc_list<Endian>(debug_loc: gimli::DebugLoc<Endian>,
     }
 }
 
-fn dump_range_list<Endian>(debug_ranges: gimli::DebugRanges<Endian>,
+fn dump_range_list<Endian>(debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
                            offset: gimli::DebugRangesOffset,
                            unit: &Unit<Endian>)
     where Endian: gimli::Endianity

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -883,7 +883,7 @@ fn dump_pubnames<Endian>(file: &object::File)
     if let (Some(debug_pubnames), Some(debug_info)) = (debug_pubnames, debug_info) {
         println!("\n.debug_pubnames");
 
-        let debug_pubnames = gimli::DebugPubNames::<Endian>::new(debug_pubnames);
+        let debug_pubnames = gimli::DebugPubNames::<gimli::EndianBuf<Endian>>::new(debug_pubnames);
         let debug_info = gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
 
         let mut cu_offset;
@@ -920,7 +920,7 @@ fn dump_pubtypes<Endian>(file: &object::File)
     if let (Some(debug_pubtypes), Some(debug_info)) = (debug_pubtypes, debug_info) {
         println!("\n.debug_pubtypes");
 
-        let debug_pubtypes = gimli::DebugPubNames::<Endian>::new(debug_pubtypes);
+        let debug_pubtypes = gimli::DebugPubNames::<gimli::EndianBuf<Endian>>::new(debug_pubtypes);
         let debug_info = gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
 
         let mut cu_offset;
@@ -958,7 +958,7 @@ fn dump_aranges<Endian>(file: &object::File)
         println!(".debug_aranges");
         println!("");
 
-        let debug_aranges = gimli::DebugAranges::<Endian>::new(debug_aranges);
+        let debug_aranges = gimli::DebugAranges::<gimli::EndianBuf<Endian>>::new(debug_aranges);
         let debug_info = gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
 
         let mut cu_die_offset = gimli::DebugInfoOffset(0);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -527,7 +527,7 @@ fn dump_exprloc<Endian>(data: gimli::EndianBuf<Endian>, unit: &Unit<Endian>)
     let mut space = false;
     while pc.len() != 0 {
         let dwop = gimli::DwOp(pc[0]);
-        match gimli::Operation::parse(&mut pc, data, unit.address_size, unit.format) {
+        match gimli::Operation::parse(&mut pc, &data, unit.address_size, unit.format) {
             Ok(op) => {
                 if space {
                     print!(" ");
@@ -548,7 +548,7 @@ fn dump_exprloc<Endian>(data: gimli::EndianBuf<Endian>, unit: &Unit<Endian>)
     }
 }
 
-fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<Endian>, newpc: &[u8])
+fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<gimli::EndianBuf<Endian>>, newpc: &[u8])
     where Endian: gimli::Endianity
 {
     print!("{}", dwop);
@@ -630,6 +630,7 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<Endian>, newpc: &[u8]
             print!(" 0x{:08x} offset 0x{:08x}", size_in_bits, bit_offset);
         }
         gimli::Operation::ImplicitValue { data } => {
+            let data = data.buf();
             print!(" 0x{:08x} contents 0x", data.len());
             for byte in data {
                 print!("{:02x}", byte);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -110,7 +110,7 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
     let debug_abbrev = file.get_section(".debug_abbrev").unwrap_or(&[]);
     let debug_abbrev = gimli::DebugAbbrev::<gimli::EndianBuf<Endian>>::new(debug_abbrev);
     let debug_line = file.get_section(".debug_line").unwrap_or(&[]);
-    let debug_line = gimli::DebugLine::<Endian>::new(debug_line);
+    let debug_line = gimli::DebugLine::<gimli::EndianBuf<Endian>>::new(debug_line);
     let debug_loc = file.get_section(".debug_loc").unwrap_or(&[]);
     let debug_loc = gimli::DebugLoc::<Endian>::new(debug_loc);
     let debug_ranges = file.get_section(".debug_ranges").unwrap_or(&[]);
@@ -151,7 +151,7 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
 
 fn dump_info<Endian>(file: &object::File,
                      debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
-                     debug_line: gimli::DebugLine<Endian>,
+                     debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
                      debug_loc: gimli::DebugLoc<Endian>,
                      debug_ranges: gimli::DebugRanges<Endian>,
                      debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
@@ -183,7 +183,7 @@ fn dump_info<Endian>(file: &object::File,
 
 fn dump_types<Endian>(file: &object::File,
                       debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
-                      debug_line: gimli::DebugLine<Endian>,
+                      debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
                       debug_loc: gimli::DebugLoc<Endian>,
                       debug_ranges: gimli::DebugRanges<Endian>,
                       debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
@@ -228,7 +228,7 @@ struct Unit<'input, Endian>
     format: gimli::Format,
     address_size: u8,
     base_address: u64,
-    line_program: Option<gimli::IncompleteLineNumberProgram<'input, Endian>>,
+    line_program: Option<gimli::IncompleteLineNumberProgram<gimli::EndianBuf<'input, Endian>>>,
     comp_dir: Option<gimli::EndianBuf<'input, Endian>>,
     comp_name: Option<gimli::EndianBuf<'input, Endian>>,
 }
@@ -238,7 +238,7 @@ fn dump_entries<Endian>(offset: usize,
                         mut entries: gimli::EntriesCursor<gimli::EndianBuf<Endian>>,
                         address_size: u8,
                         format: gimli::Format,
-                        debug_line: gimli::DebugLine<Endian>,
+                        debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
                         debug_loc: gimli::DebugLoc<Endian>,
                         debug_ranges: gimli::DebugRanges<Endian>,
                         debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
@@ -739,7 +739,7 @@ fn dump_line<Endian>(file: &object::File,
         println!(".debug_line");
         println!("");
 
-        let debug_line = gimli::DebugLine::<Endian>::new(debug_line);
+        let debug_line = gimli::DebugLine::<gimli::EndianBuf<Endian>>::new(debug_line);
         let debug_info = gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
         let debug_str = gimli::DebugStr::<gimli::EndianBuf<Endian>>::new(debug_str);
 

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -46,9 +46,8 @@ impl<R: Reader> DebugAbbrev<R> {
     /// Construct a new `DebugAbbrev` instance from the data in the `.debug_abbrev`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_abbrev` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
+    /// It is the caller's responsibility to read the `.debug_abbrev` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
     pub fn from_reader(debug_abbrev_section: R) -> Self {
         DebugAbbrev { debug_abbrev_section }
     }

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -89,9 +89,8 @@ impl<R: Reader> DebugFrame<R> {
     /// Construct a new `DebugFrame` instance from the data in the
     /// `.debug_frame` section.
     ///
-    /// It is the caller's responsibility to read the section and present it as
-    /// a `&[u8]` slice. That means using some ELF loader on Linux, a Mach-O
-    /// loader on OSX, etc.
+    /// It is the caller's responsibility to read the section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
     pub fn from_reader(section: R) -> Self {
         DebugFrame(section)
     }
@@ -153,9 +152,8 @@ impl<R: Reader> EhFrame<R> {
     /// Construct a new `EhFrame` instance from the data in the
     /// `.debug_frame` section.
     ///
-    /// It is the caller's responsibility to read the section and present it as
-    /// a `&[u8]` slice. That means using some ELF loader on Linux, a Mach-O
-    /// loader on OSX, etc.
+    /// It is the caller's responsibility to read the section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
     pub fn from_reader(section: R) -> Self {
         EhFrame(section)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,9 @@
 //!
 //! // Use the `FallibleIterator` trait so its methods are in scope!
 //! use fallible_iterator::FallibleIterator;
-//! use gimli::{DebugAranges, LittleEndian};
+//! use gimli::{DebugAranges, EndianBuf, LittleEndian};
 //!
-//! fn find_sum_of_address_range_lengths(aranges: DebugAranges<LittleEndian>)
+//! fn find_sum_of_address_range_lengths(aranges: DebugAranges<EndianBuf<LittleEndian>>)
 //!     -> gimli::Result<u64>
 //! {
 //!     // `DebugAranges::items` returns a `FallibleIterator`!

--- a/src/line.rs
+++ b/src/line.rs
@@ -42,9 +42,8 @@ impl<R: Reader> DebugLine<R> {
     /// Construct a new `DebugLine` instance from the data in the `.debug_line`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_line` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
+    /// It is the caller's responsibility to read the `.debug_line` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
     pub fn from_reader(debug_line_section: R) -> Self {
         DebugLine { debug_line_section }
     }

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -42,9 +42,8 @@ impl<R: Reader> DebugLoc<R> {
     /// Construct a new `DebugLoc` instance from the data in the `.debug_loc`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_loc` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
+    /// It is the caller's responsibility to read the `.debug_loc` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
     pub fn from_reader(debug_loc_section: R) -> Self {
         DebugLoc { debug_loc_section }
     }

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -1,6 +1,7 @@
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
-use parser::{Error, Result, parse_u16, take};
+use parser::{Error, Result};
+use reader::Reader;
 use ranges::Range;
 use Section;
 
@@ -11,13 +12,11 @@ pub struct DebugLocOffset(pub usize);
 /// The `DebugLoc` struct represents the DWARF strings
 /// found in the `.debug_loc` section.
 #[derive(Debug, Clone, Copy)]
-pub struct DebugLoc<'input, Endian>
-    where Endian: Endianity
-{
-    debug_loc_section: EndianBuf<'input, Endian>,
+pub struct DebugLoc<R: Reader> {
+    debug_loc_section: R,
 }
 
-impl<'input, Endian> DebugLoc<'input, Endian>
+impl<'input, Endian> DebugLoc<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     /// Construct a new `DebugLoc` instance from the data in the `.debug_loc`
@@ -28,14 +27,26 @@ impl<'input, Endian> DebugLoc<'input, Endian>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugLoc, LittleEndian};
+    /// use gimli::{DebugLoc, EndianBuf, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_loc_section_somehow = || &buf;
-    /// let debug_loc = DebugLoc::<LittleEndian>::new(read_debug_loc_section_somehow());
+    /// let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(read_debug_loc_section_somehow());
     /// ```
-    pub fn new(debug_loc_section: &'input [u8]) -> DebugLoc<'input, Endian> {
-        DebugLoc { debug_loc_section: EndianBuf::new(debug_loc_section) }
+    pub fn new(debug_loc_section: &'input [u8]) -> Self {
+        Self::from_reader(EndianBuf::new(debug_loc_section))
+    }
+}
+
+impl<R: Reader> DebugLoc<R> {
+    /// Construct a new `DebugLoc` instance from the data in the `.debug_loc`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_loc` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on OSX, etc.
+    pub fn from_reader(debug_loc_section: R) -> Self {
+        DebugLoc { debug_loc_section }
     }
 
     /// Iterate over the `LocationListEntry`s starting at the given offset.
@@ -51,12 +62,9 @@ impl<'input, Endian> DebugLoc<'input, Endian>
                      offset: DebugLocOffset,
                      address_size: u8,
                      base_address: u64)
-                     -> Result<LocationListIter<'input, Endian>> {
-        if self.debug_loc_section.len() < offset.0 {
-            return Err(Error::UnexpectedEof);
-        }
-
-        let input = self.debug_loc_section.range_from(offset.0..);
+                     -> Result<LocationListIter<R>> {
+        let mut input = self.debug_loc_section.clone();
+        input.skip(offset.0)?;
         Ok(LocationListIter::new(input, address_size, base_address))
     }
 
@@ -72,17 +80,14 @@ impl<'input, Endian> DebugLoc<'input, Endian>
     pub fn raw_locations(&self,
                          offset: DebugLocOffset,
                          address_size: u8)
-                         -> Result<RawLocationListIter<'input, Endian>> {
-        if self.debug_loc_section.len() < offset.0 {
-            return Err(Error::UnexpectedEof);
-        }
-
-        let input = self.debug_loc_section.range_from(offset.0..);
+                         -> Result<RawLocationListIter<R>> {
+        let mut input = self.debug_loc_section.clone();
+        input.skip(offset.0)?;
         Ok(RawLocationListIter::new(input, address_size))
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugLoc<'input, Endian>
+impl<'input, Endian> Section<'input> for DebugLoc<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     fn section_name() -> &'static str {
@@ -90,7 +95,7 @@ impl<'input, Endian> Section<'input> for DebugLoc<'input, Endian>
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugLoc<'input, Endian>
+impl<'input, Endian> From<&'input [u8]> for DebugLoc<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     fn from(v: &'input [u8]) -> Self {
@@ -103,20 +108,14 @@ impl<'input, Endian> From<&'input [u8]> for DebugLoc<'input, Endian>
 /// This iterator does not perform any processing of the location entries,
 /// such as handling base addresses.
 #[derive(Debug)]
-pub struct RawLocationListIter<'input, Endian>
-    where Endian: Endianity
-{
-    input: EndianBuf<'input, Endian>,
+pub struct RawLocationListIter<R: Reader> {
+    input: R,
     address_size: u8,
 }
 
-impl<'input, Endian> RawLocationListIter<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> RawLocationListIter<R> {
     /// Construct a `RawLocationListIter`.
-    pub fn new(input: EndianBuf<'input, Endian>,
-               address_size: u8)
-               -> RawLocationListIter<'input, Endian> {
+    pub fn new(input: R, address_size: u8) -> RawLocationListIter<R> {
         RawLocationListIter {
             input: input,
             address_size: address_size,
@@ -124,24 +123,22 @@ impl<'input, Endian> RawLocationListIter<'input, Endian>
     }
 
     /// Advance the iterator to the next location.
-    pub fn next(&mut self) -> Result<Option<LocationListEntry<'input, Endian>>> {
+    pub fn next(&mut self) -> Result<Option<LocationListEntry<R>>> {
         if self.input.is_empty() {
             return Ok(None);
         }
 
         let location = LocationListEntry::parse(&mut self.input, self.address_size)?;
         if location.range.is_end() {
-            self.input = EndianBuf::new(&[]);
+            self.input.empty();
         }
 
         Ok(Some(location))
     }
 }
 
-impl<'input, Endian> FallibleIterator for RawLocationListIter<'input, Endian>
-    where Endian: Endianity
-{
-    type Item = LocationListEntry<'input, Endian>;
+impl<R: Reader> FallibleIterator for RawLocationListIter<R> {
+    type Item = LocationListEntry<R>;
     type Error = Error;
 
     fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
@@ -155,21 +152,14 @@ impl<'input, Endian> FallibleIterator for RawLocationListIter<'input, Endian>
 /// and list end entries.  Thus, it only returns location entries that are valid
 /// and already adjusted for the base address.
 #[derive(Debug)]
-pub struct LocationListIter<'input, Endian>
-    where Endian: Endianity
-{
-    raw: RawLocationListIter<'input, Endian>,
+pub struct LocationListIter<R: Reader> {
+    raw: RawLocationListIter<R>,
     base_address: u64,
 }
 
-impl<'input, Endian> LocationListIter<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> LocationListIter<R> {
     /// Construct a `LocationListIter`.
-    fn new(input: EndianBuf<'input, Endian>,
-           address_size: u8,
-           base_address: u64)
-           -> LocationListIter<'input, Endian> {
+    fn new(input: R, address_size: u8, base_address: u64) -> LocationListIter<R> {
         LocationListIter {
             raw: RawLocationListIter::new(input, address_size),
             base_address: base_address,
@@ -177,7 +167,7 @@ impl<'input, Endian> LocationListIter<'input, Endian>
     }
 
     /// Advance the iterator to the next location.
-    pub fn next(&mut self) -> Result<Option<LocationListEntry<'input, Endian>>> {
+    pub fn next(&mut self) -> Result<Option<LocationListEntry<R>>> {
         loop {
             let mut location = match self.raw.next()? {
                 Some(location) => location,
@@ -202,7 +192,7 @@ impl<'input, Endian> LocationListIter<'input, Endian>
                 .range
                 .add_base_address(self.base_address, self.raw.address_size);
             if location.range.begin > location.range.end {
-                self.raw.input = EndianBuf::new(&[]);
+                self.raw.input.empty();
                 return Err(Error::InvalidLocationAddressRange);
             }
 
@@ -211,10 +201,8 @@ impl<'input, Endian> LocationListIter<'input, Endian>
     }
 }
 
-impl<'input, Endian> FallibleIterator for LocationListIter<'input, Endian>
-    where Endian: Endianity
-{
-    type Item = LocationListEntry<'input, Endian>;
+impl<R: Reader> FallibleIterator for LocationListIter<R> {
+    type Item = LocationListEntry<R>;
     type Error = Error;
 
     fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
@@ -224,35 +212,29 @@ impl<'input, Endian> FallibleIterator for LocationListIter<'input, Endian>
 
 /// A location list entry from the `.debug_loc` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct LocationListEntry<'input, Endian>
-    where Endian: Endianity
-{
+pub struct LocationListEntry<R: Reader> {
     /// The address range that this location is valid for.
     pub range: Range,
 
     /// The data containing a single location description.
-    pub data: EndianBuf<'input, Endian>,
+    pub data: R,
 }
 
-impl<'input, Endian> LocationListEntry<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> LocationListEntry<R> {
     /// Parse a location list entry from `.debug_loc`.
-    fn parse(input: &mut EndianBuf<'input, Endian>,
-             address_size: u8)
-             -> Result<LocationListEntry<'input, Endian>>
-        where Endian: Endianity
-    {
+    fn parse(input: &mut R, address_size: u8) -> Result<LocationListEntry<R>> {
         let range = Range::parse(input, address_size)?;
         if range.is_end() || range.is_base_address(address_size) {
+            let mut data = input.clone();
+            data.empty();
             let location = LocationListEntry {
                 range: range,
-                data: EndianBuf::new(&[]),
+                data: data,
             };
             Ok(location)
         } else {
-            let len = parse_u16(input)?;
-            let data = take(len as usize, input)?;
+            let len = input.read_u16()?;
+            let data = input.split(len as usize)?;
             let location = LocationListEntry {
                 range: range,
                 data: data,
@@ -300,7 +282,7 @@ mod tests {
             .L32(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_loc = DebugLoc::<LittleEndian>::new(&buf);
+        let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&buf);
         let offset = DebugLocOffset((&first - &start) as usize);
         let mut locations = debug_loc.locations(offset, 4, 0x01000000).unwrap();
 
@@ -392,7 +374,7 @@ mod tests {
             .L64(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_loc = DebugLoc::<LittleEndian>::new(&buf);
+        let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&buf);
         let offset = DebugLocOffset((&first - &start) as usize);
         let mut locations = debug_loc.locations(offset, 8, 0x01000000).unwrap();
 
@@ -465,7 +447,7 @@ mod tests {
             .L32(0x20000).L32(0xff010000).L16(4).L32(2);
 
         let buf = section.get_contents().unwrap();
-        let debug_loc = DebugLoc::<LittleEndian>::new(&buf);
+        let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&buf);
 
         // An invalid location range.
         let mut locations = debug_loc

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,9 +49,6 @@ pub enum Error {
     UnknownReservedLength,
     /// Found an unknown DWARF version.
     UnknownVersion,
-    /// The unit header's claimed length is too short to even hold the header
-    /// itself.
-    UnitHeaderLengthTooShort,
     /// Found a record with an unknown abbreviation code.
     UnknownAbbreviation,
     /// Hit the end of input before it was expected.
@@ -178,10 +175,6 @@ impl error::Error for Error {
             Error::DuplicateArange => "Found a duplicate arange",
             Error::UnknownReservedLength => "Found an unknown reserved length value",
             Error::UnknownVersion => "Found an unknown DWARF version",
-            Error::UnitHeaderLengthTooShort => {
-                "The unit header's claimed length is too short to even hold
-                 the header itself"
-            }
             Error::UnknownAbbreviation => "Found a record with an unknown abbreviation code",
             Error::UnexpectedEof => "Hit the end of input before it was expected",
             Error::UnexpectedNull => "Read a null entry before it was expected.",

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,6 +1,7 @@
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
-use parser::{Error, Result, parse_address};
+use parser::{Error, Result};
+use reader::Reader;
 use Section;
 
 /// An offset into the `.debug_ranges` section.
@@ -10,13 +11,11 @@ pub struct DebugRangesOffset(pub usize);
 /// The `DebugRanges` struct represents the DWARF strings
 /// found in the `.debug_ranges` section.
 #[derive(Debug, Clone, Copy)]
-pub struct DebugRanges<'input, Endian>
-    where Endian: Endianity
-{
-    debug_ranges_section: EndianBuf<'input, Endian>,
+pub struct DebugRanges<R: Reader> {
+    debug_ranges_section: R,
 }
 
-impl<'input, Endian> DebugRanges<'input, Endian>
+impl<'input, Endian> DebugRanges<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     /// Construct a new `DebugRanges` instance from the data in the `.debug_ranges`
@@ -27,14 +26,26 @@ impl<'input, Endian> DebugRanges<'input, Endian>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugRanges, LittleEndian};
+    /// use gimli::{DebugRanges, EndianBuf, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_ranges_section_somehow = || &buf;
-    /// let debug_ranges = DebugRanges::<LittleEndian>::new(read_debug_ranges_section_somehow());
+    /// let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(read_debug_ranges_section_somehow());
     /// ```
-    pub fn new(debug_ranges_section: &'input [u8]) -> DebugRanges<'input, Endian> {
-        DebugRanges { debug_ranges_section: EndianBuf::new(debug_ranges_section) }
+    pub fn new(debug_ranges_section: &'input [u8]) -> Self {
+        Self::from_reader(EndianBuf::new(debug_ranges_section))
+    }
+}
+
+impl<R: Reader> DebugRanges<R> {
+    /// Construct a new `DebugRanges` instance from the data in the `.debug_ranges`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_ranges` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on OSX, etc.
+    pub fn from_reader(debug_ranges_section: R) -> DebugRanges<R> {
+        DebugRanges { debug_ranges_section }
     }
 
     /// Iterate over the `Range` list entries starting at the given offset.
@@ -49,12 +60,9 @@ impl<'input, Endian> DebugRanges<'input, Endian>
                   offset: DebugRangesOffset,
                   address_size: u8,
                   base_address: u64)
-                  -> Result<RangesIter<Endian>> {
-        if self.debug_ranges_section.len() < offset.0 {
-            return Err(Error::UnexpectedEof);
-        }
-
-        let input = self.debug_ranges_section.range_from(offset.0..);
+                  -> Result<RangesIter<R>> {
+        let mut input = self.debug_ranges_section.clone();
+        input.skip(offset.0)?;
         Ok(RangesIter::new(input, address_size, base_address))
     }
 
@@ -70,17 +78,14 @@ impl<'input, Endian> DebugRanges<'input, Endian>
     pub fn raw_ranges(&self,
                       offset: DebugRangesOffset,
                       address_size: u8)
-                      -> Result<RawRangesIter<Endian>> {
-        if self.debug_ranges_section.len() < offset.0 {
-            return Err(Error::UnexpectedEof);
-        }
-
-        let input = self.debug_ranges_section.range_from(offset.0..);
+                      -> Result<RawRangesIter<R>> {
+        let mut input = self.debug_ranges_section.clone();
+        input.skip(offset.0)?;
         Ok(RawRangesIter::new(input, address_size))
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugRanges<'input, Endian>
+impl<'input, Endian> Section<'input> for DebugRanges<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     fn section_name() -> &'static str {
@@ -88,7 +93,7 @@ impl<'input, Endian> Section<'input> for DebugRanges<'input, Endian>
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugRanges<'input, Endian>
+impl<'input, Endian> From<&'input [u8]> for DebugRanges<EndianBuf<'input, Endian>>
     where Endian: Endianity
 {
     fn from(v: &'input [u8]) -> Self {
@@ -101,18 +106,14 @@ impl<'input, Endian> From<&'input [u8]> for DebugRanges<'input, Endian>
 /// This iterator does not perform any processing of the range entries,
 /// such as handling base addresses.
 #[derive(Debug)]
-pub struct RawRangesIter<'input, Endian>
-    where Endian: Endianity
-{
-    input: EndianBuf<'input, Endian>,
+pub struct RawRangesIter<R: Reader> {
+    input: R,
     address_size: u8,
 }
 
-impl<'input, Endian> RawRangesIter<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> RawRangesIter<R> {
     /// Construct a `RawRangesIter`.
-    fn new(input: EndianBuf<'input, Endian>, address_size: u8) -> RawRangesIter<'input, Endian> {
+    fn new(input: R, address_size: u8) -> RawRangesIter<R> {
         RawRangesIter {
             input: input,
             address_size: address_size,
@@ -127,16 +128,14 @@ impl<'input, Endian> RawRangesIter<'input, Endian>
 
         let range = Range::parse(&mut self.input, self.address_size)?;
         if range.is_end() {
-            self.input = EndianBuf::new(&[]);
+            self.input.empty();
         }
 
         Ok(Some(range))
     }
 }
 
-impl<'input, Endian> FallibleIterator for RawRangesIter<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> FallibleIterator for RawRangesIter<R> {
     type Item = Range;
     type Error = Error;
 
@@ -151,21 +150,14 @@ impl<'input, Endian> FallibleIterator for RawRangesIter<'input, Endian>
 /// and range end entries.  Thus, it only returns range entries that are valid
 /// and already adjusted for the base address.
 #[derive(Debug)]
-pub struct RangesIter<'input, Endian>
-    where Endian: Endianity
-{
-    raw: RawRangesIter<'input, Endian>,
+pub struct RangesIter<R: Reader> {
+    raw: RawRangesIter<R>,
     base_address: u64,
 }
 
-impl<'input, Endian> RangesIter<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> RangesIter<R> {
     /// Construct a `RangesIter`.
-    fn new(input: EndianBuf<'input, Endian>,
-           address_size: u8,
-           base_address: u64)
-           -> RangesIter<'input, Endian> {
+    fn new(input: R, address_size: u8, base_address: u64) -> RangesIter<R> {
         RangesIter {
             raw: RawRangesIter::new(input, address_size),
             base_address: base_address,
@@ -196,7 +188,7 @@ impl<'input, Endian> RangesIter<'input, Endian>
 
             range.add_base_address(self.base_address, self.raw.address_size);
             if range.begin > range.end {
-                self.raw.input = EndianBuf::new(&[]);
+                self.raw.input.empty();
                 return Err(Error::InvalidAddressRange);
             }
 
@@ -205,9 +197,7 @@ impl<'input, Endian> RangesIter<'input, Endian>
     }
 }
 
-impl<'input, Endian> FallibleIterator for RangesIter<'input, Endian>
-    where Endian: Endianity
-{
+impl<R: Reader> FallibleIterator for RangesIter<R> {
     type Item = Range;
     type Error = Error;
 
@@ -256,11 +246,9 @@ impl Range {
     /// Parse an address range entry from `.debug_ranges` or `.debug_loc`.
     #[doc(hidden)]
     #[inline]
-    pub fn parse<Endian>(input: &mut EndianBuf<Endian>, address_size: u8) -> Result<Range>
-        where Endian: Endianity
-    {
-        let begin = parse_address(input, address_size)?;
-        let end = parse_address(input, address_size)?;
+    pub fn parse<R: Reader>(input: &mut R, address_size: u8) -> Result<Range> {
+        let begin = input.read_address(address_size)?;
+        let end = input.read_address(address_size)?;
         let range = Range {
             begin: begin,
             end: end,
@@ -338,7 +326,7 @@ mod tests {
             .L32(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_ranges = DebugRanges::<LittleEndian>::new(&buf);
+        let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&buf);
         let offset = DebugRangesOffset((&first - &start) as usize);
         let mut ranges = debug_ranges.ranges(offset, 4, 0x01000000).unwrap();
 
@@ -415,7 +403,7 @@ mod tests {
             .L64(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_ranges = DebugRanges::<LittleEndian>::new(&buf);
+        let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&buf);
         let offset = DebugRangesOffset((&first - &start) as usize);
         let mut ranges = debug_ranges.ranges(offset, 8, 0x01000000).unwrap();
 
@@ -473,7 +461,7 @@ mod tests {
             .L32(0x20000).L32(0xff010000);
 
         let buf = section.get_contents().unwrap();
-        let debug_ranges = DebugRanges::<LittleEndian>::new(&buf);
+        let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&buf);
 
         // An invalid range.
         let mut ranges = debug_ranges

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -41,10 +41,9 @@ impl<R: Reader> DebugRanges<R> {
     /// Construct a new `DebugRanges` instance from the data in the `.debug_ranges`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_ranges` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_ranges_section: R) -> DebugRanges<R> {
+    /// It is the caller's responsibility to read the `.debug_ranges` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
+    pub fn from_reader(debug_ranges_section: R) -> Self {
         DebugRanges { debug_ranges_section }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -11,8 +11,7 @@ use parser::{Error, Result, Format, u64_to_offset};
 /// All read operations advance the section offset of the reader
 /// unless specified otherwise.
 ///
-// TODO: Don't require Copy, Eq
-pub trait Reader: Debug + Clone + Copy + PartialEq + Eq + Read {
+pub trait Reader: Debug + Clone + Read {
     /// The endianity of bytes that are read.
     type Endian: Endianity;
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -40,9 +40,8 @@ impl<R: Reader> DebugStr<R> {
     /// Construct a new `DebugStr` instance from the data in the `.debug_str`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_str` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
+    /// It is the caller's responsibility to read the `.debug_str` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
     pub fn from_reader(debug_str_section: R) -> Self {
         DebugStr { debug_str_section }
     }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -113,10 +113,9 @@ impl<R: Reader> DebugInfo<R> {
     /// Construct a new `DebugInfo` instance from the data in the `.debug_info`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_info` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_info_section: R) -> DebugInfo<R> {
+    /// It is the caller's responsibility to read the `.debug_info` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
+    pub fn from_reader(debug_info_section: R) -> Self {
         DebugInfo { debug_info_section }
     }
 
@@ -2336,10 +2335,9 @@ impl<R: Reader> DebugTypes<R> {
     /// Construct a new `DebugTypes` instance from the data in the `.debug_types`
     /// section.
     ///
-    /// It is the caller's responsibility to read the `.debug_types` section and
-    /// present it as a `&[u8]` slice. That means using some ELF loader on
-    /// Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_types_section: R) -> DebugTypes<R> {
+    /// It is the caller's responsibility to read the `.debug_types` section.
+    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
+    pub fn from_reader(debug_types_section: R) -> Self {
         DebugTypes { debug_types_section }
     }
 

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -58,7 +58,7 @@ fn test_parse_self_debug_line() {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_line = read_section("debug_line");
-    let debug_line = DebugLine::<LittleEndian>::new(&debug_line);
+    let debug_line = DebugLine::<EndianBuf<LittleEndian>>::new(&debug_line);
 
     let debug_str = read_section("debug_str");
     let debug_str = DebugStr::<EndianBuf<LittleEndian>>::new(&debug_str);

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -223,7 +223,7 @@ fn test_parse_self_debug_ranges() {
 #[test]
 fn test_parse_self_debug_aranges() {
     let debug_aranges = read_section("debug_aranges");
-    let debug_aranges = DebugAranges::<LittleEndian>::new(&debug_aranges);
+    let debug_aranges = DebugAranges::<EndianBuf<LittleEndian>>::new(&debug_aranges);
 
     let mut aranges = debug_aranges.items();
     while let Some(_) = aranges.next().expect("Should parse arange OK") {
@@ -240,7 +240,7 @@ fn test_parse_self_debug_pubnames() {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_pubnames = read_section("debug_pubnames");
-    let debug_pubnames = DebugPubNames::<LittleEndian>::new(&debug_pubnames);
+    let debug_pubnames = DebugPubNames::<EndianBuf<LittleEndian>>::new(&debug_pubnames);
 
     let mut units = HashMap::new();
     let mut abbrevs = HashMap::new();
@@ -273,7 +273,7 @@ fn test_parse_self_debug_pubtypes() {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_pubtypes = read_section("debug_pubtypes");
-    let debug_pubtypes = DebugPubTypes::<LittleEndian>::new(&debug_pubtypes);
+    let debug_pubtypes = DebugPubTypes::<EndianBuf<LittleEndian>>::new(&debug_pubtypes);
 
     let mut units = HashMap::new();
     let mut abbrevs = HashMap::new();

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -306,7 +306,7 @@ fn test_parse_self_eh_frame() {
     use gimli::{BaseAddresses, CieOrFde, EhFrame, UnwindSection};
 
     let eh_frame = read_section("eh_frame");
-    let eh_frame = EhFrame::<LittleEndian>::new(&eh_frame);
+    let eh_frame = EhFrame::<EndianBuf<LittleEndian>>::new(&eh_frame);
 
     let bases = BaseAddresses::default().set_cfi(0).set_data(0).set_text(0);
     let mut entries = eh_frame.entries(&bases);

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -133,7 +133,7 @@ fn test_parse_self_debug_loc() {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_loc = read_section("debug_loc");
-    let debug_loc = DebugLoc::<LittleEndian>::new(&debug_loc);
+    let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&debug_loc);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
@@ -181,7 +181,7 @@ fn test_parse_self_debug_ranges() {
     let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
 
     let debug_ranges = read_section("debug_ranges");
-    let debug_ranges = DebugRanges::<LittleEndian>::new(&debug_ranges);
+    let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&debug_ranges);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {


### PR DESCRIPTION
Also avoid `Copy`/`Eq` requirement by using offsets.

Next step after this is to convert dwarfdump to use `Reader`. Probably need to add `to_vec` and `to_string` methods to the `Reader` trait to allow this.