### PR TITLE
Convert dwarfdump to use Reader

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -38,7 +38,7 @@ fn bench_parsing_debug_abbrev(b: &mut test::Bencher) {
 
     b.iter(|| {
                let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
-               test::black_box(unit.abbreviations(debug_abbrev)
+               test::black_box(unit.abbreviations(&debug_abbrev)
                                    .expect("Should parse abbreviations"));
            });
 }
@@ -55,7 +55,7 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
 
         let mut iter = debug_info.units();
         while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-            let abbrevs = unit.abbreviations(debug_abbrev)
+            let abbrevs = unit.abbreviations(&debug_abbrev)
                 .expect("Should parse abbreviations");
 
             let mut cursor = unit.entries(&abbrevs);
@@ -81,7 +81,7 @@ fn bench_parsing_debug_info_tree(b: &mut test::Bencher) {
 
         let mut iter = debug_info.units();
         while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-            let abbrevs = unit.abbreviations(debug_abbrev)
+            let abbrevs = unit.abbreviations(&debug_abbrev)
                 .expect("Should parse abbreviations");
 
             let mut tree = unit.entries_tree(&abbrevs, None)
@@ -201,7 +201,7 @@ fn bench_parsing_debug_loc(b: &mut test::Bencher) {
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -255,7 +255,7 @@ fn bench_parsing_debug_ranges(b: &mut test::Bencher) {
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -428,7 +428,7 @@ mod cfi {
             .expect("fold over instructions OK")
     }
 
-    fn get_fde_with_longest_cfi_instructions<R: Reader>(eh_frame: EhFrame<R>)
+    fn get_fde_with_longest_cfi_instructions<R: Reader>(eh_frame: &EhFrame<R>)
                                                         -> FrameDescriptionEntry<R, EhFrame<R>> {
         let bases = BaseAddresses::default().set_cfi(0).set_data(0).set_text(0);
 
@@ -464,7 +464,7 @@ mod cfi {
     fn parse_longest_fde_instructions(b: &mut test::Bencher) {
         let eh_frame = read_section("eh_frame");
         let eh_frame = EhFrame::<EndianBuf<LittleEndian>>::new(&eh_frame);
-        let fde = get_fde_with_longest_cfi_instructions(eh_frame);
+        let fde = get_fde_with_longest_cfi_instructions(&eh_frame);
 
         b.iter(|| {
                    let mut instrs = fde.instructions();
@@ -478,7 +478,7 @@ mod cfi {
     fn eval_longest_fde_instructions_new_ctx_everytime(b: &mut test::Bencher) {
         let eh_frame = read_section("eh_frame");
         let eh_frame = EhFrame::<EndianBuf<LittleEndian>>::new(&eh_frame);
-        let fde = get_fde_with_longest_cfi_instructions(eh_frame);
+        let fde = get_fde_with_longest_cfi_instructions(&eh_frame);
 
         b.iter(|| {
             let mut ctx = UninitializedUnwindContext::new()
@@ -496,7 +496,7 @@ mod cfi {
     fn eval_longest_fde_instructions_same_ctx(b: &mut test::Bencher) {
         let eh_frame = read_section("eh_frame");
         let eh_frame = EhFrame::<EndianBuf<LittleEndian>>::new(&eh_frame);
-        let fde = get_fde_with_longest_cfi_instructions(eh_frame);
+        let fde = get_fde_with_longest_cfi_instructions(&eh_frame);
 
         let mut ctx = Some(UninitializedUnwindContext::new());
 

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -108,25 +108,25 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
     where Endian: gimli::Endianity
 {
     let debug_abbrev = file.get_section(".debug_abbrev").unwrap_or(&[]);
-    let debug_abbrev = gimli::DebugAbbrev::<gimli::EndianBuf<Endian>>::new(debug_abbrev);
+    let debug_abbrev = &gimli::DebugAbbrev::<gimli::EndianBuf<Endian>>::new(debug_abbrev);
     let debug_aranges = file.get_section(".debug_aranges").unwrap_or(&[]);
-    let debug_aranges = gimli::DebugAranges::<gimli::EndianBuf<Endian>>::new(debug_aranges);
+    let debug_aranges = &gimli::DebugAranges::<gimli::EndianBuf<Endian>>::new(debug_aranges);
     let debug_info = file.get_section(".debug_info").unwrap_or(&[]);
-    let debug_info = gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
+    let debug_info = &gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
     let debug_line = file.get_section(".debug_line").unwrap_or(&[]);
-    let debug_line = gimli::DebugLine::<gimli::EndianBuf<Endian>>::new(debug_line);
+    let debug_line = &gimli::DebugLine::<gimli::EndianBuf<Endian>>::new(debug_line);
     let debug_loc = file.get_section(".debug_loc").unwrap_or(&[]);
-    let debug_loc = gimli::DebugLoc::<gimli::EndianBuf<Endian>>::new(debug_loc);
+    let debug_loc = &gimli::DebugLoc::<gimli::EndianBuf<Endian>>::new(debug_loc);
     let debug_pubnames = file.get_section(".debug_pubnames").unwrap_or(&[]);
-    let debug_pubnames = gimli::DebugPubNames::<gimli::EndianBuf<Endian>>::new(debug_pubnames);
+    let debug_pubnames = &gimli::DebugPubNames::<gimli::EndianBuf<Endian>>::new(debug_pubnames);
     let debug_pubtypes = file.get_section(".debug_pubtypes").unwrap_or(&[]);
-    let debug_pubtypes = gimli::DebugPubTypes::<gimli::EndianBuf<Endian>>::new(debug_pubtypes);
+    let debug_pubtypes = &gimli::DebugPubTypes::<gimli::EndianBuf<Endian>>::new(debug_pubtypes);
     let debug_ranges = file.get_section(".debug_ranges").unwrap_or(&[]);
-    let debug_ranges = gimli::DebugRanges::<gimli::EndianBuf<Endian>>::new(debug_ranges);
+    let debug_ranges = &gimli::DebugRanges::<gimli::EndianBuf<Endian>>::new(debug_ranges);
     let debug_str = file.get_section(".debug_str").unwrap_or(&[]);
-    let debug_str = gimli::DebugStr::<gimli::EndianBuf<Endian>>::new(debug_str);
+    let debug_str = &gimli::DebugStr::<gimli::EndianBuf<Endian>>::new(debug_str);
     let debug_types = file.get_section(".debug_types").unwrap_or(&[]);
-    let debug_types = gimli::DebugTypes::<gimli::EndianBuf<Endian>>::new(debug_types);
+    let debug_types = &gimli::DebugTypes::<gimli::EndianBuf<Endian>>::new(debug_types);
 
     if flags.info {
         dump_info(debug_info,
@@ -159,15 +159,13 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
     }
 }
 
-fn dump_info<Endian>(debug_info: gimli::DebugInfo<gimli::EndianBuf<Endian>>,
-                     debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
-                     debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                     debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
-                     debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
-                     debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
-                     flags: &Flags)
-    where Endian: gimli::Endianity
-{
+fn dump_info<R: gimli::Reader>(debug_info: &gimli::DebugInfo<R>,
+                               debug_abbrev: &gimli::DebugAbbrev<R>,
+                               debug_line: &gimli::DebugLine<R>,
+                               debug_loc: &gimli::DebugLoc<R>,
+                               debug_ranges: &gimli::DebugRanges<R>,
+                               debug_str: &gimli::DebugStr<R>,
+                               flags: &Flags) {
     println!("\n.debug_info");
 
     let mut iter = debug_info.units();
@@ -187,15 +185,13 @@ fn dump_info<Endian>(debug_info: gimli::DebugInfo<gimli::EndianBuf<Endian>>,
     }
 }
 
-fn dump_types<Endian>(debug_types: gimli::DebugTypes<gimli::EndianBuf<Endian>>,
-                      debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
-                      debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                      debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
-                      debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
-                      debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
-                      flags: &Flags)
-    where Endian: gimli::Endianity
-{
+fn dump_types<R: gimli::Reader>(debug_types: &gimli::DebugTypes<R>,
+                                debug_abbrev: &gimli::DebugAbbrev<R>,
+                                debug_line: &gimli::DebugLine<R>,
+                                debug_loc: &gimli::DebugLoc<R>,
+                                debug_ranges: &gimli::DebugRanges<R>,
+                                debug_str: &gimli::DebugStr<R>,
+                                flags: &Flags) {
     println!("\n.debug_types");
 
     let mut iter = debug_types.units();
@@ -205,7 +201,7 @@ fn dump_types<Endian>(debug_types: gimli::DebugTypes<gimli::EndianBuf<Endian>>,
 
         println!("\nCU_HEADER:");
         print!("  signature        = ");
-        dump_type_signature::<Endian>(unit.type_signature());
+        dump_type_signature::<R::Endian>(unit.type_signature());
         println!("");
         println!("  typeoffset       = 0x{:08x} {}",
                  unit.type_offset().0,
@@ -224,29 +220,25 @@ fn dump_types<Endian>(debug_types: gimli::DebugTypes<gimli::EndianBuf<Endian>>,
 }
 
 // TODO: most of this should be moved to the main library.
-struct Unit<'input, Endian>
-    where Endian: gimli::Endianity
-{
+struct Unit<R: gimli::Reader> {
     format: gimli::Format,
     address_size: u8,
     base_address: u64,
-    line_program: Option<gimli::IncompleteLineNumberProgram<gimli::EndianBuf<'input, Endian>>>,
-    comp_dir: Option<gimli::EndianBuf<'input, Endian>>,
-    comp_name: Option<gimli::EndianBuf<'input, Endian>>,
+    line_program: Option<gimli::IncompleteLineNumberProgram<R>>,
+    comp_dir: Option<R>,
+    comp_name: Option<R>,
 }
 
 #[allow(too_many_arguments)]
-fn dump_entries<Endian>(offset: usize,
-                        mut entries: gimli::EntriesCursor<gimli::EndianBuf<Endian>>,
-                        address_size: u8,
-                        format: gimli::Format,
-                        debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                        debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
-                        debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
-                        debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>,
-                        flags: &Flags)
-    where Endian: gimli::Endianity
-{
+fn dump_entries<R: gimli::Reader>(offset: usize,
+                                  mut entries: gimli::EntriesCursor<R>,
+                                  address_size: u8,
+                                  format: gimli::Format,
+                                  debug_line: &gimli::DebugLine<R>,
+                                  debug_loc: &gimli::DebugLoc<R>,
+                                  debug_ranges: &gimli::DebugRanges<R>,
+                                  debug_str: &gimli::DebugStr<R>,
+                                  flags: &Flags) {
     let mut unit = Unit {
         format: format,
         address_size: address_size,
@@ -286,17 +278,20 @@ fn dump_entries<Endian>(offset: usize,
             unit.comp_dir = entry
                 .attr(gimli::DW_AT_comp_dir)
                 .expect("Should parse comp_dir")
-                .and_then(|attr| attr.string_value(&debug_str));
+                .and_then(|attr| attr.string_value(debug_str));
             unit.comp_name = entry
                 .attr(gimli::DW_AT_name)
                 .expect("Should parse name")
-                .and_then(|attr| attr.string_value(&debug_str));
+                .and_then(|attr| attr.string_value(debug_str));
             unit.line_program = match entry
                       .attr_value(gimli::DW_AT_stmt_list)
                       .expect("Should parse stmt_list") {
                 Some(gimli::AttributeValue::DebugLineRef(offset)) => {
                     debug_line
-                        .program(offset, unit.address_size, unit.comp_dir, unit.comp_name)
+                        .program(offset,
+                                 unit.address_size,
+                                 unit.comp_dir.clone(),
+                                 unit.comp_name.clone())
                         .ok()
                 }
                 _ => None,
@@ -309,26 +304,24 @@ fn dump_entries<Endian>(offset: usize,
             if flags.raw {
                 println!("{:?}", attr.raw_value());
             } else {
-                dump_attr_value(attr, &unit, debug_loc, debug_ranges, debug_str);
+                dump_attr_value(&attr, &unit, debug_loc, debug_ranges, debug_str);
             }
         }
     }
 }
 
-fn dump_attr_value<Endian>(attr: gimli::Attribute<gimli::EndianBuf<Endian>>,
-                           unit: &Unit<Endian>,
-                           debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
-                           debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
-                           debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>)
-    where Endian: gimli::Endianity
-{
+fn dump_attr_value<R: gimli::Reader>(attr: &gimli::Attribute<R>,
+                                     unit: &Unit<R>,
+                                     debug_loc: &gimli::DebugLoc<R>,
+                                     debug_ranges: &gimli::DebugRanges<R>,
+                                     debug_str: &gimli::DebugStr<R>) {
     let value = attr.value();
     match value {
         gimli::AttributeValue::Addr(address) => {
             println!("0x{:08x}", address);
         }
         gimli::AttributeValue::Block(data) => {
-            for byte in data.buf() {
+            for byte in data.to_slice().iter() {
                 print!("{:02x}", byte);
             }
             println!("");
@@ -388,10 +381,10 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<gimli::EndianBuf<Endian>>,
                 }
             };
         }
-        gimli::AttributeValue::Exprloc(data) => {
+        gimli::AttributeValue::Exprloc(ref data) => {
             if let gimli::AttributeValue::Exprloc(_) = attr.raw_value() {
                 print!("len 0x{:04x}: ", data.len());
-                for byte in data.buf() {
+                for byte in data.to_slice().iter() {
                     print!("{:02x}", byte);
                 }
                 print!(": ");
@@ -429,7 +422,7 @@ fn dump_attr_value<Endian>(attr: gimli::Attribute<gimli::EndianBuf<Endian>>,
             dump_range_list(debug_ranges, offset, unit);
         }
         gimli::AttributeValue::DebugTypesRef(signature) => {
-            dump_type_signature::<Endian>(signature);
+            dump_type_signature::<R::Endian>(signature);
             println!(" <type signature>");
         }
         gimli::AttributeValue::DebugStrRef(offset) => {
@@ -498,9 +491,7 @@ fn dump_type_signature<Endian>(signature: gimli::DebugTypeSignature)
     }
 }
 
-fn dump_file_index<Endian>(file: u64, unit: &Unit<Endian>)
-    where Endian: gimli::Endianity
-{
+fn dump_file_index<R: gimli::Reader>(file: u64, unit: &Unit<R>) {
     if file == 0 {
         return;
     }
@@ -513,7 +504,7 @@ fn dump_file_index<Endian>(file: u64, unit: &Unit<Endian>)
     if let Some(directory) = file.directory(header) {
         let directory = directory.to_string_lossy();
         if !directory.starts_with('/') {
-            if let Some(comp_dir) = unit.comp_dir {
+            if let Some(ref comp_dir) = unit.comp_dir {
                 print!("{}/", comp_dir.to_string_lossy());
             }
         }
@@ -522,21 +513,20 @@ fn dump_file_index<Endian>(file: u64, unit: &Unit<Endian>)
     print!("{}", file.path_name().to_string_lossy());
 }
 
-fn dump_exprloc<Endian>(data: gimli::EndianBuf<Endian>, unit: &Unit<Endian>)
-    where Endian: gimli::Endianity
-{
-    let mut pc = data;
+fn dump_exprloc<R: gimli::Reader>(data: &R, unit: &Unit<R>) {
+    let mut pc = data.clone();
     let mut space = false;
     while pc.len() != 0 {
-        let dwop = gimli::DwOp(pc[0]);
-        match gimli::Operation::parse(&mut pc, &data, unit.address_size, unit.format) {
+        let mut op_pc = pc.clone();
+        let dwop = gimli::DwOp(op_pc.read_u8().expect("Should read from non-empty reader"));
+        match gimli::Operation::parse(&mut pc, data, unit.address_size, unit.format) {
             Ok(op) => {
                 if space {
                     print!(" ");
                 } else {
                     space = true;
                 }
-                dump_op(dwop, op, pc.buf());
+                dump_op(dwop, op, &pc);
             }
             Err(gimli::Error::InvalidExpression(op)) => {
                 writeln!(&mut std::io::stderr(),
@@ -550,9 +540,7 @@ fn dump_exprloc<Endian>(data: gimli::EndianBuf<Endian>, unit: &Unit<Endian>)
     }
 }
 
-fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<gimli::EndianBuf<Endian>>, newpc: &[u8])
-    where Endian: gimli::Endianity
-{
+fn dump_op<R: gimli::Reader>(dwop: gimli::DwOp, op: gimli::Operation<R>, newpc: &R) {
     print!("{}", dwop);
     match op {
         gimli::Operation::Deref { size, .. } => {
@@ -632,9 +620,9 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<gimli::EndianBuf<Endi
             print!(" 0x{:08x} offset 0x{:08x}", size_in_bits, bit_offset);
         }
         gimli::Operation::ImplicitValue { data } => {
-            let data = data.buf();
+            let data = data.to_slice();
             print!(" 0x{:08x} contents 0x", data.len());
-            for byte in data {
+            for byte in data.iter() {
                 print!("{:02x}", byte);
             }
         }
@@ -643,7 +631,7 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<gimli::EndianBuf<Endi
         }
         gimli::Operation::EntryValue { expression } => {
             print!(" 0x{:08x} contents 0x", expression.len());
-            for byte in expression.buf() {
+            for byte in expression.to_slice().iter() {
                 print!("{:02x}", byte);
             }
         }
@@ -651,11 +639,9 @@ fn dump_op<Endian>(dwop: gimli::DwOp, op: gimli::Operation<gimli::EndianBuf<Endi
     }
 }
 
-fn dump_loc_list<Endian>(debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
-                         offset: gimli::DebugLocOffset,
-                         unit: &Unit<Endian>)
-    where Endian: gimli::Endianity
-{
+fn dump_loc_list<R: gimli::Reader>(debug_loc: &gimli::DebugLoc<R>,
+                                   offset: gimli::DebugLocOffset,
+                                   unit: &Unit<R>) {
     let locations = debug_loc
         .raw_locations(offset, unit.address_size)
         .expect("Should have valid loc offset");
@@ -697,17 +683,15 @@ fn dump_loc_list<Endian>(debug_loc: gimli::DebugLoc<gimli::EndianBuf<Endian>>,
                    range.begin,
                    location.range.end,
                    range.end);
-            dump_exprloc(location.data, unit);
+            dump_exprloc(&location.data, unit);
             println!("");
         }
     }
 }
 
-fn dump_range_list<Endian>(debug_ranges: gimli::DebugRanges<gimli::EndianBuf<Endian>>,
-                           offset: gimli::DebugRangesOffset,
-                           unit: &Unit<Endian>)
-    where Endian: gimli::Endianity
-{
+fn dump_range_list<R: gimli::Reader>(debug_ranges: &gimli::DebugRanges<R>,
+                                     offset: gimli::DebugRangesOffset,
+                                     unit: &Unit<R>) {
     let ranges = debug_ranges
         .raw_ranges(offset, unit.address_size)
         .expect("Should have valid range offset");
@@ -730,12 +714,10 @@ fn dump_range_list<Endian>(debug_ranges: gimli::DebugRanges<gimli::EndianBuf<End
     }
 }
 
-fn dump_line<Endian>(debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
-                     debug_info: gimli::DebugInfo<gimli::EndianBuf<Endian>>,
-                     debug_abbrev: gimli::DebugAbbrev<gimli::EndianBuf<Endian>>,
-                     debug_str: gimli::DebugStr<gimli::EndianBuf<Endian>>)
-    where Endian: gimli::Endianity
-{
+fn dump_line<R: gimli::Reader>(debug_line: &gimli::DebugLine<R>,
+                               debug_info: &gimli::DebugInfo<R>,
+                               debug_abbrev: &gimli::DebugAbbrev<R>,
+                               debug_str: &gimli::DebugStr<R>) {
     println!("\n.debug_line");
 
     let mut iter = debug_info.units();
@@ -754,10 +736,10 @@ fn dump_line<Endian>(debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
         };
         let comp_dir = root.attr(gimli::DW_AT_comp_dir)
             .expect("Should parse comp_dir")
-            .and_then(|attr| attr.string_value(&debug_str));
+            .and_then(|attr| attr.string_value(debug_str));
         let comp_name = root.attr(gimli::DW_AT_name)
             .expect("Should parse name")
-            .and_then(|attr| attr.string_value(&debug_str));
+            .and_then(|attr| attr.string_value(debug_str));
 
         let program = debug_line.program(offset, unit.address_size(), comp_dir, comp_name);
         if let Ok(program) = program {
@@ -784,7 +766,11 @@ fn dump_line<Endian>(debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
 
                 println!("");
                 println!("Opcodes:");
-                for (i, length) in header.standard_opcode_lengths().iter().enumerate() {
+                for (i, length) in header
+                        .standard_opcode_lengths()
+                        .to_slice()
+                        .iter()
+                        .enumerate() {
                     println!("  Opcode {} as {} args", i + 1, length);
                 }
 
@@ -867,10 +853,8 @@ fn dump_line<Endian>(debug_line: gimli::DebugLine<gimli::EndianBuf<Endian>>,
     }
 }
 
-fn dump_pubnames<Endian>(debug_pubnames: gimli::DebugPubNames<gimli::EndianBuf<Endian>>,
-                         debug_info: gimli::DebugInfo<gimli::EndianBuf<Endian>>)
-    where Endian: gimli::Endianity
-{
+fn dump_pubnames<R: gimli::Reader>(debug_pubnames: &gimli::DebugPubNames<R>,
+                                   debug_info: &gimli::DebugInfo<R>) {
     println!("\n.debug_pubnames");
 
     let mut cu_offset;
@@ -897,10 +881,8 @@ fn dump_pubnames<Endian>(debug_pubnames: gimli::DebugPubNames<gimli::EndianBuf<E
     }
 }
 
-fn dump_pubtypes<Endian>(debug_pubtypes: gimli::DebugPubTypes<gimli::EndianBuf<Endian>>,
-                         debug_info: gimli::DebugInfo<gimli::EndianBuf<Endian>>)
-    where Endian: gimli::Endianity
-{
+fn dump_pubtypes<R: gimli::Reader>(debug_pubtypes: &gimli::DebugPubTypes<R>,
+                                   debug_info: &gimli::DebugInfo<R>) {
     println!("\n.debug_pubtypes");
 
     let mut cu_offset;
@@ -927,10 +909,8 @@ fn dump_pubtypes<Endian>(debug_pubtypes: gimli::DebugPubTypes<gimli::EndianBuf<E
     }
 }
 
-fn dump_aranges<Endian>(debug_aranges: gimli::DebugAranges<gimli::EndianBuf<Endian>>,
-                        debug_info: gimli::DebugInfo<gimli::EndianBuf<Endian>>)
-    where Endian: gimli::Endianity
-{
+fn dump_aranges<R: gimli::Reader>(debug_aranges: &gimli::DebugAranges<R>,
+                                  debug_info: &gimli::DebugInfo<R>) {
     println!("\n.debug_aranges");
 
     let mut cu_die_offset = gimli::DebugInfoOffset(0);

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -758,12 +758,12 @@ impl Default for Augmentation {
 }
 
 impl Augmentation {
-    fn parse<'aug, 'bases, R, Section>(augmentation_str: &mut R,
-                                       bases: &'bases BaseAddresses,
-                                       address_size: u8,
-                                       section: Section,
-                                       input: &mut R)
-                                       -> Result<Augmentation>
+    fn parse<'bases, R, Section>(augmentation_str: &mut R,
+                                 bases: &'bases BaseAddresses,
+                                 address_size: u8,
+                                 section: Section,
+                                 input: &mut R)
+                                 -> Result<Augmentation>
         where R: Reader,
               Section: UnwindSection<R>
     {
@@ -931,12 +931,12 @@ impl<R, Section> CommonInformationEntry<R, Section>
         Ok(Some(entry))
     }
 
-    fn parse_rest<'bases>(length: u64,
-                          format: Format,
-                          bases: &'bases BaseAddresses,
-                          section: Section,
-                          mut rest: R)
-                          -> Result<CommonInformationEntry<R, Section>> {
+    fn parse_rest(length: u64,
+                  format: Format,
+                  bases: &BaseAddresses,
+                  section: Section,
+                  mut rest: R)
+                  -> Result<CommonInformationEntry<R, Section>> {
         let version = rest.read_u8()?;
         if !Section::compatible_version(version) {
             return Err(Error::UnknownVersion);
@@ -1169,7 +1169,7 @@ impl<R, Section> FrameDescriptionEntry<R, Section>
     }
 
     /// Get a reference to this FDE's CIE.
-    pub fn cie<'me>(&'me self) -> &'me CommonInformationEntry<R, Section> {
+    pub fn cie(&self) -> &CommonInformationEntry<R, Section> {
         &self.cie
     }
 
@@ -1299,6 +1299,15 @@ impl<R, Section> UninitializedUnwindContext<R, Section>
     /// Construct a new call frame unwinding context.
     pub fn new() -> UninitializedUnwindContext<R, Section> {
         UninitializedUnwindContext(Box::new(UnwindContext::new()))
+    }
+}
+
+impl<R, Section> Default for UninitializedUnwindContext<R, Section>
+    where R: Reader,
+          Section: UnwindSection<R>
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1865,7 +1874,7 @@ impl<R: Reader> RegisterRuleMap<R> {
         self.rules.clear();
     }
 
-    fn iter<'me>(&'me self) -> RegisterRuleIter<'me, R> {
+    fn iter(&self) -> RegisterRuleIter<R> {
         RegisterRuleIter(self.rules.iter())
     }
 }
@@ -2042,7 +2051,7 @@ impl<R: Reader> UnwindTableRow<R> {
     /// }
     /// # }
     /// ```
-    pub fn registers<'me>(&'me self) -> RegisterRuleIter<'me, R> {
+    pub fn registers(&self) -> RegisterRuleIter<R> {
         self.registers.iter()
     }
 }

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -379,37 +379,37 @@ impl<'input, Endian> Reader for EndianBuf<'input, Endian>
     #[inline]
     fn read_u16(&mut self) -> Result<u16> {
         let slice = self.read_slice(2)?;
-        Ok(Endian::read_u16(&slice))
+        Ok(Endian::read_u16(slice))
     }
 
     #[inline]
     fn read_i16(&mut self) -> Result<i16> {
         let slice = self.read_slice(2)?;
-        Ok(Endian::read_i16(&slice))
+        Ok(Endian::read_i16(slice))
     }
 
     #[inline]
     fn read_u32(&mut self) -> Result<u32> {
         let slice = self.read_slice(4)?;
-        Ok(Endian::read_u32(&slice))
+        Ok(Endian::read_u32(slice))
     }
 
     #[inline]
     fn read_i32(&mut self) -> Result<i32> {
         let slice = self.read_slice(4)?;
-        Ok(Endian::read_i32(&slice))
+        Ok(Endian::read_i32(slice))
     }
 
     #[inline]
     fn read_u64(&mut self) -> Result<u64> {
         let slice = self.read_slice(8)?;
-        Ok(Endian::read_u64(&slice))
+        Ok(Endian::read_u64(slice))
     }
 
     #[inline]
     fn read_i64(&mut self) -> Result<i64> {
         let slice = self.read_slice(8)?;
-        Ok(Endian::read_i64(&slice))
+        Ok(Endian::read_i64(slice))
     }
 }
 

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -9,6 +9,7 @@ use std::io::Read;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
+use std::str;
 use parser::{Error, Result};
 use reader::Reader;
 
@@ -351,6 +352,24 @@ impl<'input, Endian> Reader for EndianBuf<'input, Endian>
     fn split(&mut self, len: usize) -> Result<Self> {
         let slice = self.read_slice(len)?;
         Ok(EndianBuf::new(slice))
+    }
+
+    #[inline]
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::from(self.buf)
+    }
+
+    #[inline]
+    fn to_string(&self) -> Result<Cow<str>> {
+        match str::from_utf8(self.buf) {
+            Ok(s) => Ok(Cow::from(s)),
+            _ => Err(Error::BadUtf8),
+        }
+    }
+
+    #[inline]
+    fn to_string_lossy(&self) -> Cow<str> {
+        String::from_utf8_lossy(self.buf)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! let mut iter = debug_info.units();
 //! while let Some(unit) = try!(iter.next()) {
 //!     // Parse the abbreviations for this compilation unit.
-//!     let abbrevs = try!(unit.abbreviations(debug_abbrev));
+//!     let abbrevs = try!(unit.abbreviations(&debug_abbrev));
 //!
 //!     // Iterate over all of this compilation unit's entries.
 //!     let mut entries = unit.entries(&abbrevs);

--- a/src/line.rs
+++ b/src/line.rs
@@ -107,13 +107,13 @@ impl<'input, Endian> From<&'input [u8]> for DebugLine<EndianBuf<'input, Endian>>
 /// never need to use or see this trait.
 pub trait LineNumberProgram<R: Reader> {
     /// Get a reference to the held `LineNumberProgramHeader`.
-    fn header<'a>(&'a self) -> &'a LineNumberProgramHeader<R>;
+    fn header(&self) -> &LineNumberProgramHeader<R>;
     /// Add a file to the file table if necessary.
     fn add_file(&mut self, file: FileEntry<R>);
 }
 
 impl<R: Reader> LineNumberProgram<R> for IncompleteLineNumberProgram<R> {
-    fn header<'a>(&'a self) -> &'a LineNumberProgramHeader<R> {
+    fn header(&self) -> &LineNumberProgramHeader<R> {
         &self.header
     }
     fn add_file(&mut self, file: FileEntry<R>) {
@@ -122,7 +122,7 @@ impl<R: Reader> LineNumberProgram<R> for IncompleteLineNumberProgram<R> {
 }
 
 impl<'program, R: Reader> LineNumberProgram<R> for &'program CompleteLineNumberProgram<R> {
-    fn header<'a>(&'a self) -> &'a LineNumberProgramHeader<R> {
+    fn header(&self) -> &LineNumberProgramHeader<R> {
         &self.header
     }
     fn add_file(&mut self, _: FileEntry<R>) {
@@ -721,7 +721,7 @@ impl<R: Reader> OpcodesIter<R> {
             return Ok(None);
         }
 
-        Opcode::parse(header, &mut self.input).map(|opcode| Some(opcode))
+        Opcode::parse(header, &mut self.input).map(Some)
     }
 }
 
@@ -1056,7 +1056,7 @@ impl<R: Reader> LineNumberProgramHeader<R> {
             self.comp_dir.clone()
         } else {
             let directory = directory as usize - 1;
-            self.include_directories.get(directory).map(|d| d.clone())
+            self.include_directories.get(directory).cloned()
         }
     }
 
@@ -1197,7 +1197,7 @@ impl<R: Reader> LineNumberProgramHeader<R> {
             comp_dir: comp_dir,
             comp_name: comp_name,
         };
-        return Ok(header);
+        Ok(header)
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::io;
 use std::io::Read;
@@ -46,6 +47,32 @@ pub trait Reader: Debug + Clone + Read {
     /// A new reader is returned that can be used to read the next
     /// `len` bytes, and `self` is advanced so that it reads the remainder.
     fn split(&mut self, len: usize) -> Result<Self>;
+
+    /// Return all remaining data as a clone-on-write slice.
+    ///
+    /// The slice will be borrowed where possible, but some readers may
+    /// always return an owned vector.
+    ///
+    /// Does not advance the reader.
+    fn to_slice(&self) -> Cow<[u8]>;
+
+    /// Convert all remaining data to a clone-on-write string.
+    ///
+    /// The string will be borrowed where possible, but some readers may
+    /// always return an owned string.
+    ///
+    /// Does not advance the reader.
+    ///
+    /// Returns an error if the data contains invalid characters.
+    fn to_string(&self) -> Result<Cow<str>>;
+
+    /// Convert all remaining data to a clone-on-write string, including invalid characters.
+    ///
+    /// The string will be borrowed where possible, but some readers may
+    /// always return an owned string.
+    ///
+    /// Does not advance the reader.
+    fn to_string_lossy(&self) -> Cow<str>;
 
     /// Read a u8 array.
     fn read_u8_array<A>(&mut self) -> Result<A> where A: Sized + Default + AsMut<[u8]>;

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -368,9 +368,9 @@ impl<R: Reader> CompilationUnitHeader<R> {
     ///
     /// # let read_debug_abbrev_section_somehow = || &abbrev_buf;
     /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
-    /// let abbrevs_for_unit = unit.abbreviations(debug_abbrev).unwrap();
+    /// let abbrevs_for_unit = unit.abbreviations(&debug_abbrev).unwrap();
     /// ```
-    pub fn abbreviations(&self, debug_abbrev: DebugAbbrev<R>) -> Result<Abbreviations> {
+    pub fn abbreviations(&self, debug_abbrev: &DebugAbbrev<R>) -> Result<Abbreviations> {
         self.header.abbreviations(debug_abbrev)
     }
 
@@ -612,7 +612,7 @@ impl<R: Reader> UnitHeader<R> {
     }
 
     /// Parse this unit's abbreviations.
-    pub fn abbreviations(&self, debug_abbrev: DebugAbbrev<R>) -> Result<Abbreviations> {
+    pub fn abbreviations(&self, debug_abbrev: &DebugAbbrev<R>) -> Result<Abbreviations> {
         debug_abbrev.abbreviations(self.debug_abbrev_offset())
     }
 }
@@ -698,7 +698,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// # ];
     /// # let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
     /// # let unit = debug_info.units().next().unwrap().unwrap();
-    /// # let abbrevs = unit.abbreviations(debug_abbrev).unwrap();
+    /// # let abbrevs = unit.abbreviations(&debug_abbrev).unwrap();
     /// # let mut cursor = unit.entries(&abbrevs);
     /// # let (_, entry) = cursor.next_dfs().unwrap().unwrap();
     /// # let mut get_some_entry = || entry;
@@ -784,7 +784,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// # ];
     /// # let read_debug_abbrev_section_somehow = || &abbrev_buf;
     /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
-    /// let abbrevs = unit.abbreviations(debug_abbrev).unwrap();
+    /// let abbrevs = unit.abbreviations(&debug_abbrev).unwrap();
     ///
     /// // Get the first entry from that compilation unit.
     ///
@@ -1899,7 +1899,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// # let get_some_unit = || debug_info.units().next().unwrap().unwrap();
     ///
     /// let unit = get_some_unit();
-    /// # let get_abbrevs_for_unit = |_| unit.abbreviations(debug_abbrev).unwrap();
+    /// # let get_abbrevs_for_unit = |_| unit.abbreviations(&debug_abbrev).unwrap();
     /// let abbrevs = get_abbrevs_for_unit(&unit);
     ///
     /// let mut first_entry_with_no_children = None;
@@ -2024,7 +2024,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// # let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
     /// #
     /// let unit = get_some_unit();
-    /// # let get_abbrevs_for_unit = |_| unit.abbreviations(debug_abbrev).unwrap();
+    /// # let get_abbrevs_for_unit = |_| unit.abbreviations(&debug_abbrev).unwrap();
     /// let abbrevs = get_abbrevs_for_unit(&unit);
     ///
     /// let mut cursor = unit.entries(&abbrevs);
@@ -2119,7 +2119,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
 /// # let get_some_unit = || debug_info.units().next().unwrap().unwrap();
 /// let unit = get_some_unit();
 /// # let debug_abbrev = gimli::DebugAbbrev::<gimli::EndianBuf<gimli::LittleEndian>>::new(&[]);
-/// # let get_abbrevs_for_unit = |_| unit.abbreviations(debug_abbrev).unwrap();
+/// # let get_abbrevs_for_unit = |_| unit.abbreviations(&debug_abbrev).unwrap();
 /// let abbrevs = get_abbrevs_for_unit(&unit);
 ///
 /// let mut tree = try!(unit.entries_tree(&abbrevs, None));
@@ -2594,9 +2594,9 @@ impl<R: Reader> TypeUnitHeader<R> {
     ///
     /// # let read_debug_abbrev_section_somehow = || &abbrev_buf;
     /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
-    /// let abbrevs_for_unit = unit.abbreviations(debug_abbrev).unwrap();
+    /// let abbrevs_for_unit = unit.abbreviations(&debug_abbrev).unwrap();
     /// ```
-    pub fn abbreviations(&self, debug_abbrev: DebugAbbrev<R>) -> Result<Abbreviations> {
+    pub fn abbreviations(&self, debug_abbrev: &DebugAbbrev<R>) -> Result<Abbreviations> {
         self.header.abbreviations(debug_abbrev)
     }
 }
@@ -3805,7 +3805,7 @@ mod tests {
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -3839,7 +3839,7 @@ mod tests {
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -3882,7 +3882,7 @@ mod tests {
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -3915,7 +3915,7 @@ mod tests {
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -3952,7 +3952,7 @@ mod tests {
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -4115,7 +4115,7 @@ mod tests {
         let abbrev_buf = entries_cursor_sibling_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -4154,7 +4154,7 @@ mod tests {
         let abbrev_buf = entries_cursor_sibling_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -4175,7 +4175,7 @@ mod tests {
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
         let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
 
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries_at_offset(&abbrevs, UnitOffset(unit.header_size()))
@@ -4298,7 +4298,7 @@ mod tests {
             .next()
             .expect("Should parse unit")
             .expect("and it should be some");
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
         let mut tree = unit.entries_tree(&abbrevs, None)
             .expect("Should have entries tree");

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -401,18 +401,14 @@ fn parse_version<R: Reader>(input: &mut R) -> Result<u16> {
 fn parse_debug_abbrev_offset<R: Reader>(input: &mut R,
                                         format: Format)
                                         -> Result<DebugAbbrevOffset> {
-    input
-        .read_offset(format)
-        .map(|offset| DebugAbbrevOffset(offset))
+    input.read_offset(format).map(DebugAbbrevOffset)
 }
 
 /// Parse the `debug_info_offset` in the arange header.
 pub fn parse_debug_info_offset<R: Reader>(input: &mut R,
                                           format: Format)
                                           -> Result<DebugInfoOffset> {
-    input
-        .read_offset(format)
-        .map(|offset| DebugInfoOffset(offset))
+    input.read_offset(format).map(DebugInfoOffset)
 }
 
 /// The common fields for the headers of compilation units and
@@ -2292,14 +2288,12 @@ impl<'abbrev, 'unit, 'tree, R: Reader> EntriesTreeIter<'abbrev, 'unit, 'tree, R>
 /// Parse a type unit header's unique type signature. Callers should handle
 /// unique-ness checking.
 fn parse_type_signature<R: Reader>(input: &mut R) -> Result<DebugTypeSignature> {
-    input
-        .read_u64()
-        .map(|signature| DebugTypeSignature(signature))
+    input.read_u64().map(DebugTypeSignature)
 }
 
 /// Parse a type unit header's type offset.
 fn parse_type_offset<R: Reader>(input: &mut R, format: Format) -> Result<UnitOffset> {
-    input.read_offset(format).map(|offset| UnitOffset(offset))
+    input.read_offset(format).map(UnitOffset)
 }
 
 /// The `DebugTypes` struct represents the DWARF type information

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -35,7 +35,7 @@ fn test_parse_self_debug_info() {
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -65,7 +65,7 @@ fn test_parse_self_debug_line() {
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -137,7 +137,7 @@ fn test_parse_self_debug_loc() {
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);
@@ -185,7 +185,7 @@ fn test_parse_self_debug_ranges() {
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
-        let abbrevs = unit.abbreviations(debug_abbrev)
+        let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
 
         let mut cursor = unit.entries(&abbrevs);


### PR DESCRIPTION
The main change is the addition of `to_slice`, `to_string` and `to_string_lossy` to the `Reader` trait. Note that these functions return values with a lifetime of the `Reader`, not of the underlying data. If required, we could add a lifetime parameter to the trait, but this will propagate through all uses of the trait, so I'm not keen to do that unless there is a need, and I think it would be hard to take advantage of this in a generic way. As it is, you can use `EndianBuf` explicitly if that's what you need.