### PR TITLE
Convert Section trait to use Reader

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -107,26 +107,25 @@ fn main() {
 fn dump_file<Endian>(file: &object::File, flags: &Flags)
     where Endian: gimli::Endianity
 {
-    let debug_abbrev = file.get_section(".debug_abbrev").unwrap_or(&[]);
-    let debug_abbrev = &gimli::DebugAbbrev::<gimli::EndianBuf<Endian>>::new(debug_abbrev);
-    let debug_aranges = file.get_section(".debug_aranges").unwrap_or(&[]);
-    let debug_aranges = &gimli::DebugAranges::<gimli::EndianBuf<Endian>>::new(debug_aranges);
-    let debug_info = file.get_section(".debug_info").unwrap_or(&[]);
-    let debug_info = &gimli::DebugInfo::<gimli::EndianBuf<Endian>>::new(debug_info);
-    let debug_line = file.get_section(".debug_line").unwrap_or(&[]);
-    let debug_line = &gimli::DebugLine::<gimli::EndianBuf<Endian>>::new(debug_line);
-    let debug_loc = file.get_section(".debug_loc").unwrap_or(&[]);
-    let debug_loc = &gimli::DebugLoc::<gimli::EndianBuf<Endian>>::new(debug_loc);
-    let debug_pubnames = file.get_section(".debug_pubnames").unwrap_or(&[]);
-    let debug_pubnames = &gimli::DebugPubNames::<gimli::EndianBuf<Endian>>::new(debug_pubnames);
-    let debug_pubtypes = file.get_section(".debug_pubtypes").unwrap_or(&[]);
-    let debug_pubtypes = &gimli::DebugPubTypes::<gimli::EndianBuf<Endian>>::new(debug_pubtypes);
-    let debug_ranges = file.get_section(".debug_ranges").unwrap_or(&[]);
-    let debug_ranges = &gimli::DebugRanges::<gimli::EndianBuf<Endian>>::new(debug_ranges);
-    let debug_str = file.get_section(".debug_str").unwrap_or(&[]);
-    let debug_str = &gimli::DebugStr::<gimli::EndianBuf<Endian>>::new(debug_str);
-    let debug_types = file.get_section(".debug_types").unwrap_or(&[]);
-    let debug_types = &gimli::DebugTypes::<gimli::EndianBuf<Endian>>::new(debug_types);
+    fn load_section<'input, 'file, S, Endian>(file: &'file object::File<'input>) -> S
+        where S: gimli::Section<gimli::EndianBuf<'input, Endian>>,
+              Endian: gimli::Endianity,
+              'file: 'input
+    {
+        let data = file.get_section(S::section_name()).unwrap_or(&[]);
+        S::from(gimli::EndianBuf::new(data))
+    }
+
+    let debug_abbrev: &gimli::DebugAbbrev<_> = &load_section::<_, Endian>(file);
+    let debug_aranges: &gimli::DebugAranges<_> = &load_section(file);
+    let debug_info: &gimli::DebugInfo<_> = &load_section(file);
+    let debug_line: &gimli::DebugLine<_> = &load_section(file);
+    let debug_loc: &gimli::DebugLoc<_> = &load_section(file);
+    let debug_pubnames: &gimli::DebugPubNames<_> = &load_section(file);
+    let debug_pubtypes: &gimli::DebugPubTypes<_> = &load_section(file);
+    let debug_ranges: &gimli::DebugRanges<_> = &load_section(file);
+    let debug_str: &gimli::DebugStr<_> = &load_section(file);
+    let debug_types: &gimli::DebugTypes<_> = &load_section(file);
 
     if flags.info {
         dump_info(debug_info,

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -38,20 +38,11 @@ impl<'input, Endian> DebugAbbrev<EndianBuf<'input, Endian>>
     /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
     /// ```
     pub fn new(debug_abbrev_section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(debug_abbrev_section))
+        Self::from(EndianBuf::new(debug_abbrev_section))
     }
 }
 
 impl<R: Reader> DebugAbbrev<R> {
-    /// Construct a new `DebugAbbrev` instance from the data in the `.debug_abbrev`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_abbrev` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_abbrev_section: R) -> Self {
-        DebugAbbrev { debug_abbrev_section }
-    }
-
     /// Parse the abbreviations at the given `offset` within this
     /// `.debug_abbrev` section.
     ///
@@ -63,19 +54,15 @@ impl<R: Reader> DebugAbbrev<R> {
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugAbbrev<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugAbbrev<R> {
     fn section_name() -> &'static str {
         ".debug_abbrev"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugAbbrev<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugAbbrev<R> {
+    fn from(debug_abbrev_section: R) -> Self {
+        DebugAbbrev { debug_abbrev_section }
     }
 }
 

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -1,4 +1,3 @@
-use endianity::{Endianity, EndianBuf};
 use lookup::{LookupParser, LookupEntryIter, DebugLookup};
 use parser::{parse_initial_length, Error, Format, Result};
 use reader::Reader;
@@ -187,11 +186,6 @@ impl<R: Reader> LookupParser<R> for ArangeParser<R> {
 ///   let debug_aranges = DebugAranges::<EndianBuf<LittleEndian>>::new(read_debug_aranges_section());
 ///   ```
 ///
-/// * `from_reader(input: R) -> DebugAranges<R>`
-///
-///   Construct a new `DebugAranges` instance from the data in the `.debug_aranges`
-///   section.
-///
 /// * `items(&self) -> ArangeEntryIter<R>`
 ///
 ///   Iterate the aranges in the `.debug_aranges` section.
@@ -210,19 +204,9 @@ impl<R: Reader> LookupParser<R> for ArangeParser<R> {
 ///   ```
 pub type DebugAranges<R> = DebugLookup<R, ArangeParser<R>>;
 
-impl<'input, Endian> Section<'input> for DebugAranges<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugAranges<R> {
     fn section_name() -> &'static str {
         ".debug_aranges"
-    }
-}
-
-impl<'input, Endian> From<&'input [u8]> for DebugAranges<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
     }
 }
 

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -81,34 +81,19 @@ impl<'input, Endian> DebugFrame<EndianBuf<'input, Endian>>
     /// let debug_frame = DebugFrame::<EndianBuf<NativeEndian>>::new(read_debug_frame_section_somehow());
     /// ```
     pub fn new(section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(section))
+        Self::from(EndianBuf::new(section))
     }
 }
 
-impl<R: Reader> DebugFrame<R> {
-    /// Construct a new `DebugFrame` instance from the data in the
-    /// `.debug_frame` section.
-    ///
-    /// It is the caller's responsibility to read the section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(section: R) -> Self {
-        DebugFrame(section)
-    }
-}
-
-impl<'input, Endian> Section<'input> for DebugFrame<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugFrame<R> {
     fn section_name() -> &'static str {
         ".debug_frame"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugFrame<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugFrame<R> {
+    fn from(section: R) -> Self {
+        DebugFrame(section)
     }
 }
 
@@ -144,34 +129,19 @@ impl<'input, Endian> EhFrame<EndianBuf<'input, Endian>>
     /// let debug_frame = EhFrame::<EndianBuf<NativeEndian>>::new(read_debug_frame_section_somehow());
     /// ```
     pub fn new(section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(section))
+        Self::from(EndianBuf::new(section))
     }
 }
 
-impl<R: Reader> EhFrame<R> {
-    /// Construct a new `EhFrame` instance from the data in the
-    /// `.debug_frame` section.
-    ///
-    /// It is the caller's responsibility to read the section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(section: R) -> Self {
-        EhFrame(section)
-    }
-}
-
-impl<'input, Endian> Section<'input> for EhFrame<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for EhFrame<R> {
     fn section_name() -> &'static str {
         ".eh_frame"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for EhFrame<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for EhFrame<R> {
+    fn from(section: R) -> Self {
+        EhFrame(section)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,20 +224,21 @@ pub use unit::{AttrsIter, Attribute, AttributeValue};
 /// used like:
 ///
 /// ```
-/// use gimli::{DebugInfo, EndianBuf, LittleEndian, Section};
+/// use gimli::{DebugInfo, EndianBuf, LittleEndian, Reader, Section};
 ///
-/// fn load_section<'a, S, F>(loader: F) -> S
-///   where S: Section<'a>, F: FnOnce(&'static str) -> &'a [u8]
+/// fn load_section<R, S, F>(loader: F) -> S
+///   where R: Reader, S: Section<R>, F: FnOnce(&'static str) -> R
 /// {
 ///   let data = loader(S::section_name());
 ///   S::from(data)
 /// }
 ///
 /// let buf = [0x00, 0x01, 0x02, 0x03];
+/// let reader = EndianBuf::<LittleEndian>::new(&buf);
 ///
-/// let debug_info: DebugInfo<EndianBuf<LittleEndian>> = load_section(|_: &'static str| &buf);
+/// let debug_info: DebugInfo<_> = load_section(|_: &'static str| reader);
 /// ```
-pub trait Section<'input>: From<&'input [u8]> {
+pub trait Section<R: Reader>: From<R> {
     /// Returns the ELF section name for this type.
     fn section_name() -> &'static str;
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -34,20 +34,11 @@ impl<'input, Endian> DebugLine<EndianBuf<'input, Endian>>
     /// let debug_line = DebugLine::<EndianBuf<LittleEndian>>::new(read_debug_line_section_somehow());
     /// ```
     pub fn new(debug_line_section: &'input [u8]) -> DebugLine<EndianBuf<'input, Endian>> {
-        Self::from_reader(EndianBuf::new(debug_line_section))
+        Self::from(EndianBuf::new(debug_line_section))
     }
 }
 
 impl<R: Reader> DebugLine<R> {
-    /// Construct a new `DebugLine` instance from the data in the `.debug_line`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_line` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_line_section: R) -> Self {
-        DebugLine { debug_line_section }
-    }
-
     /// Parse the line number program whose header is at the given `offset` in the
     /// `.debug_line` section.
     ///
@@ -86,19 +77,15 @@ impl<R: Reader> DebugLine<R> {
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugLine<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugLine<R> {
     fn section_name() -> &'static str {
         ".debug_line"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugLine<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugLine<R> {
+    fn from(debug_line_section: R) -> Self {
+        DebugLine { debug_line_section }
     }
 }
 

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -34,20 +34,11 @@ impl<'input, Endian> DebugLoc<EndianBuf<'input, Endian>>
     /// let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(read_debug_loc_section_somehow());
     /// ```
     pub fn new(debug_loc_section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(debug_loc_section))
+        Self::from(EndianBuf::new(debug_loc_section))
     }
 }
 
 impl<R: Reader> DebugLoc<R> {
-    /// Construct a new `DebugLoc` instance from the data in the `.debug_loc`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_loc` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_loc_section: R) -> Self {
-        DebugLoc { debug_loc_section }
-    }
-
     /// Iterate over the `LocationListEntry`s starting at the given offset.
     ///
     /// The `address_size` must be match the compilation unit for this location list.
@@ -86,19 +77,15 @@ impl<R: Reader> DebugLoc<R> {
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugLoc<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugLoc<R> {
     fn section_name() -> &'static str {
         ".debug_loc"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugLoc<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugLoc<R> {
+    fn from(debug_loc_section: R) -> Self {
+        DebugLoc { debug_loc_section }
     }
 }
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -46,7 +46,19 @@ impl<'input, Endian, Parser> DebugLookup<EndianBuf<'input, Endian>, Parser>
 {
     #[allow(missing_docs)]
     pub fn new(input_buffer: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(input_buffer))
+        Self::from(EndianBuf::new(input_buffer))
+    }
+}
+
+impl<R, Parser> From<R> for DebugLookup<R, Parser>
+    where R: Reader,
+          Parser: LookupParser<R>
+{
+    fn from(input_buffer: R) -> Self {
+        DebugLookup {
+            input_buffer: input_buffer,
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -54,14 +66,6 @@ impl<R, Parser> DebugLookup<R, Parser>
     where R: Reader,
           Parser: LookupParser<R>
 {
-    #[allow(missing_docs)]
-    pub fn from_reader(input_buffer: R) -> Self {
-        DebugLookup {
-            input_buffer: input_buffer,
-            phantom: PhantomData,
-        }
-    }
-
     #[allow(missing_docs)]
     pub fn items(&self) -> LookupEntryIter<R, Parser> {
         let mut current_set = self.input_buffer.clone();

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -1,4 +1,3 @@
-use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, Result};
 use reader::Reader;
@@ -108,11 +107,6 @@ impl<R: Reader> NamesOrTypesSwitch<R> for NamesSwitch<R> {
 ///       DebugPubNames::<EndianBuf<LittleEndian>>::new(read_debug_pubnames_section_somehow());
 ///   ```
 ///
-/// * `from_reader(input: R) -> DebugPubNames<R>`
-///
-///   Construct a new `DebugPubNames` instance from the data in the `.debug_pubnames`
-///   section.
-///
 /// * `items(&self) -> PubNamesEntryIter<R>`
 ///
 ///   Iterate the pubnames in the `.debug_pubnames` section.
@@ -133,19 +127,9 @@ impl<R: Reader> NamesOrTypesSwitch<R> for NamesSwitch<R> {
 pub type DebugPubNames<R> = DebugLookup<R, PubStuffParser<R, NamesSwitch<R>>>;
 
 
-impl<'input, Endian> Section<'input> for DebugPubNames<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugPubNames<R> {
     fn section_name() -> &'static str {
         ".debug_pubnames"
-    }
-}
-
-impl<'input, Endian> From<&'input [u8]> for DebugPubNames<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
     }
 }
 

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -1,4 +1,3 @@
-use endianity::{Endianity, EndianBuf};
 use lookup::{PubStuffParser, LookupEntryIter, DebugLookup, NamesOrTypesSwitch};
 use parser::{Format, Result};
 use reader::Reader;
@@ -106,11 +105,6 @@ impl<R: Reader> NamesOrTypesSwitch<R> for TypesSwitch<R> {
 ///   let debug_pubtypes = DebugPubTypes::<EndianBuf<LittleEndian>>::new(read_debug_pubtypes_somehow());
 ///   ```
 ///
-/// * `from_reader(input: R) -> DebugPubTypes<R>`
-///
-///   Construct a new `DebugPubTypes` instance from the data in the `.debug_pubtypes`
-///   section.
-///
 /// * `items(&self) -> PubTypesEntryIter<R>`
 ///
 ///   Iterate the pubtypes in the `.debug_pubtypes` section.
@@ -130,19 +124,9 @@ impl<R: Reader> NamesOrTypesSwitch<R> for TypesSwitch<R> {
 ///   ```
 pub type DebugPubTypes<R> = DebugLookup<R, PubStuffParser<R, TypesSwitch<R>>>;
 
-impl<'input, Endian> Section<'input> for DebugPubTypes<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugPubTypes<R> {
     fn section_name() -> &'static str {
         ".debug_pubtypes"
-    }
-}
-
-impl<'input, Endian> From<&'input [u8]> for DebugPubTypes<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
     }
 }
 

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -33,20 +33,11 @@ impl<'input, Endian> DebugRanges<EndianBuf<'input, Endian>>
     /// let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(read_debug_ranges_section_somehow());
     /// ```
     pub fn new(debug_ranges_section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(debug_ranges_section))
+        Self::from(EndianBuf::new(debug_ranges_section))
     }
 }
 
 impl<R: Reader> DebugRanges<R> {
-    /// Construct a new `DebugRanges` instance from the data in the `.debug_ranges`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_ranges` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_ranges_section: R) -> Self {
-        DebugRanges { debug_ranges_section }
-    }
-
     /// Iterate over the `Range` list entries starting at the given offset.
     ///
     /// The `address_size` must be match the compilation unit for this range list.
@@ -84,19 +75,15 @@ impl<R: Reader> DebugRanges<R> {
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugRanges<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugRanges<R> {
     fn section_name() -> &'static str {
         ".debug_ranges"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugRanges<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugRanges<R> {
+    fn from(debug_ranges_section: R) -> Self {
+        DebugRanges { debug_ranges_section }
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -32,20 +32,11 @@ impl<'input, Endian> DebugStr<EndianBuf<'input, Endian>>
     /// let debug_str = DebugStr::<EndianBuf<LittleEndian>>::new(read_debug_str_section_somehow());
     /// ```
     pub fn new(debug_str_section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(debug_str_section))
+        Self::from(EndianBuf::new(debug_str_section))
     }
 }
 
 impl<R: Reader> DebugStr<R> {
-    /// Construct a new `DebugStr` instance from the data in the `.debug_str`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_str` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_str_section: R) -> Self {
-        DebugStr { debug_str_section }
-    }
-
     /// Lookup a string from the `.debug_str` section by DebugStrOffset.
     ///
     /// ```
@@ -65,18 +56,14 @@ impl<R: Reader> DebugStr<R> {
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugStr<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugStr<R> {
     fn section_name() -> &'static str {
         ".debug_str"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugStr<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugStr<R> {
+    fn from(debug_str_section: R) -> Self {
+        DebugStr { debug_str_section }
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -105,20 +105,11 @@ impl<'input, Endian> DebugInfo<EndianBuf<'input, Endian>>
     /// let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(read_debug_info_section_somehow());
     /// ```
     pub fn new(debug_info_section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(debug_info_section))
+        Self::from(EndianBuf::new(debug_info_section))
     }
 }
 
 impl<R: Reader> DebugInfo<R> {
-    /// Construct a new `DebugInfo` instance from the data in the `.debug_info`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_info` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_info_section: R) -> Self {
-        DebugInfo { debug_info_section }
-    }
-
     /// Iterate the compilation- and partial-units in this
     /// `.debug_info` section.
     ///
@@ -154,19 +145,15 @@ impl<R: Reader> DebugInfo<R> {
     }
 }
 
-impl<'input, Endian> Section<'input> for DebugInfo<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
+impl<R: Reader> Section<R> for DebugInfo<R> {
     fn section_name() -> &'static str {
         ".debug_info"
     }
 }
 
-impl<'input, Endian> From<&'input [u8]> for DebugInfo<EndianBuf<'input, Endian>>
-    where Endian: Endianity
-{
-    fn from(v: &'input [u8]) -> Self {
-        Self::new(v)
+impl<R: Reader> From<R> for DebugInfo<R> {
+    fn from(debug_info_section: R) -> Self {
+        DebugInfo { debug_info_section }
     }
 }
 
@@ -2321,20 +2308,24 @@ impl<'input, Endian> DebugTypes<EndianBuf<'input, Endian>>
     /// let debug_types = DebugTypes::<EndianBuf<LittleEndian>>::new(read_debug_types_section_somehow());
     /// ```
     pub fn new(debug_types_section: &'input [u8]) -> Self {
-        Self::from_reader(EndianBuf::new(debug_types_section))
+        Self::from(EndianBuf::new(debug_types_section))
     }
 }
 
-impl<R: Reader> DebugTypes<R> {
-    /// Construct a new `DebugTypes` instance from the data in the `.debug_types`
-    /// section.
-    ///
-    /// It is the caller's responsibility to read the `.debug_types` section.
-    /// That means using some ELF loader on Linux, a Mach-O loader on OSX, etc.
-    pub fn from_reader(debug_types_section: R) -> Self {
+impl<R: Reader> Section<R> for DebugTypes<R> {
+    fn section_name() -> &'static str {
+        ".debug_types"
+    }
+}
+
+impl<R: Reader> From<R> for DebugTypes<R> {
+    fn from(debug_types_section: R) -> Self {
         DebugTypes { debug_types_section }
     }
+}
 
+
+impl<R: Reader> DebugTypes<R> {
     /// Iterate the type-units in this `.debug_types` section.
     ///
     /// ```


### PR DESCRIPTION
I tried to keep the `From<&[u8]>`, but couldn't get it to work, eg something like:

```
// error[E0207]: the type parameter `Endian` is not constrained by the impl trait, self type, or predicates
impl<'input, Endian, T> From<&'input [u8]> for T
    where T: Section<EndianBuf<'input, Endian>>,
          Endian: Endianity
{
    fn from(v: &'input [u8]) -> Self {
        Self::from(EndianBuf::new(v))
    }
}
```