### PR TITLE
Add RunTimeEndian

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -96,11 +96,12 @@ fn main() {
         let file = object::File::parse(unsafe { file.as_slice() })
             .expect("Should parse object file");
 
-        if file.is_little_endian() {
-            dump_file(&file, gimli::LittleEndian, &flags);
+        let endian = if file.is_little_endian() {
+            gimli::RunTimeEndian::Little
         } else {
-            dump_file(&file, gimli::BigEndian, &flags);
-        }
+            gimli::RunTimeEndian::Big
+        };
+        dump_file(&file, endian, &flags);
     }
 }
 

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -483,7 +483,7 @@ fn dump_type_signature<Endian>(signature: gimli::DebugTypeSignature)
 {
     // Convert back to bytes so we can match libdwarf-dwarfdump output.
     let mut buf = [0; 8];
-    Endian::write_u64(&mut buf, signature.0);
+    Endian::default().write_u64(&mut buf, signature.0);
     print!("0x");
     for byte in &buf {
         print!("{:02x}", byte);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -97,35 +97,37 @@ fn main() {
             .expect("Should parse object file");
 
         if file.is_little_endian() {
-            dump_file::<gimli::LittleEndian>(&file, &flags);
+            dump_file(&file, gimli::LittleEndian, &flags);
         } else {
-            dump_file::<gimli::BigEndian>(&file, &flags);
+            dump_file(&file, gimli::BigEndian, &flags);
         }
     }
 }
 
-fn dump_file<Endian>(file: &object::File, flags: &Flags)
+fn dump_file<Endian>(file: &object::File, endian: Endian, flags: &Flags)
     where Endian: gimli::Endianity
 {
-    fn load_section<'input, 'file, S, Endian>(file: &'file object::File<'input>) -> S
+    fn load_section<'input, 'file, S, Endian>(file: &'file object::File<'input>,
+                                              endian: Endian)
+                                              -> S
         where S: gimli::Section<gimli::EndianBuf<'input, Endian>>,
               Endian: gimli::Endianity,
               'file: 'input
     {
         let data = file.get_section(S::section_name()).unwrap_or(&[]);
-        S::from(gimli::EndianBuf::new(data))
+        S::from(gimli::EndianBuf::new(data, endian))
     }
 
-    let debug_abbrev: &gimli::DebugAbbrev<_> = &load_section::<_, Endian>(file);
-    let debug_aranges: &gimli::DebugAranges<_> = &load_section(file);
-    let debug_info: &gimli::DebugInfo<_> = &load_section(file);
-    let debug_line: &gimli::DebugLine<_> = &load_section(file);
-    let debug_loc: &gimli::DebugLoc<_> = &load_section(file);
-    let debug_pubnames: &gimli::DebugPubNames<_> = &load_section(file);
-    let debug_pubtypes: &gimli::DebugPubTypes<_> = &load_section(file);
-    let debug_ranges: &gimli::DebugRanges<_> = &load_section(file);
-    let debug_str: &gimli::DebugStr<_> = &load_section(file);
-    let debug_types: &gimli::DebugTypes<_> = &load_section(file);
+    let debug_abbrev = &load_section(file, endian);
+    let debug_aranges = &load_section(file, endian);
+    let debug_info = &load_section(file, endian);
+    let debug_line = &load_section(file, endian);
+    let debug_loc = &load_section(file, endian);
+    let debug_pubnames = &load_section(file, endian);
+    let debug_pubtypes = &load_section(file, endian);
+    let debug_ranges = &load_section(file, endian);
+    let debug_str = &load_section(file, endian);
+    let debug_types = &load_section(file, endian);
 
     if flags.info {
         dump_info(debug_info,
@@ -134,6 +136,7 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
                   debug_loc,
                   debug_ranges,
                   debug_str,
+                  endian,
                   flags);
         dump_types(debug_types,
                    debug_abbrev,
@@ -141,6 +144,7 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
                    debug_loc,
                    debug_ranges,
                    debug_str,
+                   endian,
                    flags);
         println!("");
     }
@@ -158,12 +162,14 @@ fn dump_file<Endian>(file: &object::File, flags: &Flags)
     }
 }
 
+#[allow(too_many_arguments)]
 fn dump_info<R: gimli::Reader>(debug_info: &gimli::DebugInfo<R>,
                                debug_abbrev: &gimli::DebugAbbrev<R>,
                                debug_line: &gimli::DebugLine<R>,
                                debug_loc: &gimli::DebugLoc<R>,
                                debug_ranges: &gimli::DebugRanges<R>,
                                debug_str: &gimli::DebugStr<R>,
+                               endian: R::Endian,
                                flags: &Flags) {
     println!("\n.debug_info");
 
@@ -180,16 +186,19 @@ fn dump_info<R: gimli::Reader>(debug_info: &gimli::DebugInfo<R>,
                      debug_loc,
                      debug_ranges,
                      debug_str,
+                     endian,
                      flags);
     }
 }
 
+#[allow(too_many_arguments)]
 fn dump_types<R: gimli::Reader>(debug_types: &gimli::DebugTypes<R>,
                                 debug_abbrev: &gimli::DebugAbbrev<R>,
                                 debug_line: &gimli::DebugLine<R>,
                                 debug_loc: &gimli::DebugLoc<R>,
                                 debug_ranges: &gimli::DebugRanges<R>,
                                 debug_str: &gimli::DebugStr<R>,
+                                endian: R::Endian,
                                 flags: &Flags) {
     println!("\n.debug_types");
 
@@ -200,7 +209,7 @@ fn dump_types<R: gimli::Reader>(debug_types: &gimli::DebugTypes<R>,
 
         println!("\nCU_HEADER:");
         print!("  signature        = ");
-        dump_type_signature::<R::Endian>(unit.type_signature());
+        dump_type_signature(unit.type_signature(), endian);
         println!("");
         println!("  typeoffset       = 0x{:08x} {}",
                  unit.type_offset().0,
@@ -214,12 +223,14 @@ fn dump_types<R: gimli::Reader>(debug_types: &gimli::DebugTypes<R>,
                      debug_loc,
                      debug_ranges,
                      debug_str,
+                     endian,
                      flags);
     }
 }
 
 // TODO: most of this should be moved to the main library.
 struct Unit<R: gimli::Reader> {
+    endian: R::Endian,
     format: gimli::Format,
     address_size: u8,
     base_address: u64,
@@ -237,8 +248,10 @@ fn dump_entries<R: gimli::Reader>(offset: usize,
                                   debug_loc: &gimli::DebugLoc<R>,
                                   debug_ranges: &gimli::DebugRanges<R>,
                                   debug_str: &gimli::DebugStr<R>,
+                                  endian: R::Endian,
                                   flags: &Flags) {
     let mut unit = Unit {
+        endian: endian,
         format: format,
         address_size: address_size,
         base_address: 0,
@@ -421,7 +434,7 @@ fn dump_attr_value<R: gimli::Reader>(attr: &gimli::Attribute<R>,
             dump_range_list(debug_ranges, offset, unit);
         }
         gimli::AttributeValue::DebugTypesRef(signature) => {
-            dump_type_signature::<R::Endian>(signature);
+            dump_type_signature(signature, unit.endian);
             println!(" <type signature>");
         }
         gimli::AttributeValue::DebugStrRef(offset) => {
@@ -478,12 +491,12 @@ fn dump_attr_value<R: gimli::Reader>(attr: &gimli::Attribute<R>,
     }
 }
 
-fn dump_type_signature<Endian>(signature: gimli::DebugTypeSignature)
+fn dump_type_signature<Endian>(signature: gimli::DebugTypeSignature, endian: Endian)
     where Endian: gimli::Endianity
 {
     // Convert back to bytes so we can match libdwarf-dwarfdump output.
     let mut buf = [0; 8];
-    Endian::default().write_u64(&mut buf, signature.0);
+    endian.write_u64(&mut buf, signature.0);
     print!("0x");
     for byte in &buf {
         print!("{:02x}", byte);

--- a/src/aranges.rs
+++ b/src/aranges.rs
@@ -181,15 +181,15 @@ impl<'input, Endian> DebugAranges<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugAranges, EndianBuf, LittleEndian};
+    /// use gimli::{DebugAranges, LittleEndian};
     ///
     /// # let buf = [];
     /// # let read_debug_aranges_section = || &buf;
     /// let debug_aranges =
-    ///     DebugAranges::<EndianBuf<LittleEndian>>::new(read_debug_aranges_section());
+    ///     DebugAranges::new(read_debug_aranges_section(), LittleEndian);
     /// ```
-    pub fn new(debug_aranges_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_aranges_section))
+    pub fn new(debug_aranges_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_aranges_section, endian))
     }
 }
 
@@ -201,8 +201,7 @@ impl<R: Reader> DebugAranges<R> {
     ///
     /// # let buf = [];
     /// # let read_debug_aranges_section = || &buf;
-    /// let debug_aranges =
-    ///     DebugAranges::<EndianBuf<LittleEndian>>::new(read_debug_aranges_section());
+    /// let debug_aranges = DebugAranges::new(read_debug_aranges_section(), LittleEndian);
     ///
     /// let mut iter = debug_aranges.items();
     /// while let Some(arange) = iter.next().unwrap() {
@@ -294,13 +293,13 @@ mod tests {
             0x00, 0x00, 0x00, 0x00,
         ];
 
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         let (tuples, header) = ArangeParser::parse_header(rest)
             .expect("should parse header ok");
 
-        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 16..]));
-        assert_eq!(tuples, EndianBuf::new(&buf[buf.len() - 32..buf.len() - 16]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 16..], LittleEndian));
+        assert_eq!(tuples, EndianBuf::new(&buf[buf.len() - 32..buf.len() - 16], LittleEndian));
         assert_eq!(header,
                    ArangeHeader {
                        format: Format::Dwarf32,
@@ -323,9 +322,9 @@ mod tests {
             segment_size: 0,
         };
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
         let entry = ArangeParser::parse_entry(rest, &header).expect("should parse entry ok");
-        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..], LittleEndian));
         assert_eq!(entry,
                    Some(ArangeEntry {
                             segment: None,
@@ -356,10 +355,10 @@ mod tests {
             // Next tuple.
             0x09
         ];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
         let entry = ArangeParser::parse_entry(rest, &header)
             .expect("should parse entry ok");
-        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..], LittleEndian));
         assert_eq!(entry,
                    Some(ArangeEntry {
                        segment: Some(0x1817161514131211),
@@ -390,10 +389,10 @@ mod tests {
             // Next tuple.
             0x09
         ];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
         let entry = ArangeParser::parse_entry(rest, &header)
             .expect("should parse entry ok");
-        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..]));
+        assert_eq!(*rest, EndianBuf::new(&buf[buf.len() - 1..], LittleEndian));
         assert_eq!(entry,
                    Some(ArangeEntry {
                        segment: None,

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -104,6 +104,33 @@ pub trait Endianity: Debug + Default + Clone + Copy + PartialEq + Eq {
     }
 }
 
+/// Byte order that is selectable at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RunTimeEndian {
+    /// Little endian byte order.
+    Little,
+    /// Big endian byte order.
+    Big,
+}
+
+impl Default for RunTimeEndian {
+    #[cfg(target_endian = "little")]
+    fn default() -> RunTimeEndian {
+        RunTimeEndian::Little
+    }
+
+    #[cfg(target_endian = "big")]
+    fn default() -> RunTimeEndian {
+        RunTimeEndian::Big
+    }
+}
+
+impl Endianity for RunTimeEndian {
+    fn is_big_endian(self) -> bool {
+        self != RunTimeEndian::Little
+    }
+}
+
 /// Little endian byte order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LittleEndian;

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -18,7 +18,7 @@
 //! }
 //!
 //! // Read from anything that implements `gimli::Reader`.
-//! let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+//! let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
 //! let val = leb128::read::signed(&mut readable).expect("Should read number");
 //! assert_eq!(val, -12345);
 //! ```
@@ -35,7 +35,7 @@
 //!     leb128::write::unsigned(&mut writable, 98765).expect("Should write number");
 //! }
 //!
-//! let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+//! let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
 //! let val = leb128::read::unsigned(&mut readable).expect("Should read number");
 //! assert_eq!(val, 98765);
 //! ```
@@ -209,32 +209,32 @@ mod tests {
     #[test]
     fn test_read_unsigned() {
         let buf = [2u8];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(2,
                    read::unsigned(&mut readable).expect("Should read number"));
 
         let buf = [127u8];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(127,
                    read::unsigned(&mut readable).expect("Should read number"));
 
         let buf = [CONTINUATION_BIT, 1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(128,
                    read::unsigned(&mut readable).expect("Should read number"));
 
         let buf = [1u8 | CONTINUATION_BIT, 1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(129,
                    read::unsigned(&mut readable).expect("Should read number"));
 
         let buf = [2u8 | CONTINUATION_BIT, 1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(130,
                    read::unsigned(&mut readable).expect("Should read number"));
 
         let buf = [57u8 | CONTINUATION_BIT, 100];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(12857,
                    read::unsigned(&mut readable).expect("Should read number"));
     }
@@ -243,40 +243,40 @@ mod tests {
     #[test]
     fn test_read_signed() {
         let buf = [2u8];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(2, read::signed(&mut readable).expect("Should read number"));
 
         let buf = [0x7eu8];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(-2, read::signed(&mut readable).expect("Should read number"));
 
         let buf = [127u8 | CONTINUATION_BIT, 0];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(127,
                    read::signed(&mut readable).expect("Should read number"));
 
         let buf = [1u8 | CONTINUATION_BIT, 0x7f];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(-127,
                    read::signed(&mut readable).expect("Should read number"));
 
         let buf = [CONTINUATION_BIT, 1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(128,
                    read::signed(&mut readable).expect("Should read number"));
 
         let buf = [CONTINUATION_BIT, 0x7f];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(-128,
                    read::signed(&mut readable).expect("Should read number"));
 
         let buf = [1u8 | CONTINUATION_BIT, 1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(129,
                    read::signed(&mut readable).expect("Should read number"));
 
         let buf = [0x7fu8 | CONTINUATION_BIT, 0x7e];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(-129,
                    read::signed(&mut readable).expect("Should read number"));
     }
@@ -292,7 +292,7 @@ mod tests {
                    CONTINUATION_BIT,
                    CONTINUATION_BIT,
                    0x40];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(-0x4000000000000000,
                    read::signed(&mut readable).expect("Should read number"));
     }
@@ -300,14 +300,14 @@ mod tests {
     #[test]
     fn test_read_unsigned_not_enough_data() {
         let buf = [CONTINUATION_BIT];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(read::unsigned(&mut readable), Err(Error::UnexpectedEof));
     }
 
     #[test]
     fn test_read_signed_not_enough_data() {
         let buf = [CONTINUATION_BIT];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(read::signed(&mut readable), Err(Error::UnexpectedEof));
     }
 
@@ -341,7 +341,7 @@ mod tests {
                 write::signed(&mut writable, i).expect("Should write signed number");
             }
 
-            let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+            let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
             let result = read::signed(&mut readable).expect("Should be able to read it back again");
             assert_eq!(i, result);
         }
@@ -361,7 +361,7 @@ mod tests {
                 write::unsigned(&mut writable, i).expect("Should write signed number");
             }
 
-            let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+            let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
             let result = read::unsigned(&mut readable)
                 .expect("Should be able to read it back again");
             assert_eq!(i, result);
@@ -401,7 +401,7 @@ mod tests {
                    2 | CONTINUATION_BIT,
                    2 | CONTINUATION_BIT,
                    1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert!(read::unsigned(&mut readable).is_err());
     }
 
@@ -438,7 +438,7 @@ mod tests {
                    2 | CONTINUATION_BIT,
                    2 | CONTINUATION_BIT,
                    1];
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert!(read::signed(&mut readable).is_err());
     }
 
@@ -446,7 +446,7 @@ mod tests {
     fn test_read_multiple() {
         let buf = [2u8 | CONTINUATION_BIT, 1u8, 1u8];
 
-        let mut readable = EndianBuf::<NativeEndian>::new(&buf[..]);
+        let mut readable = EndianBuf::new(&buf[..], NativeEndian {});
         assert_eq!(read::unsigned(&mut readable).expect("Should read first number"),
                    130u64);
         assert_eq!(read::unsigned(&mut readable).expect("Should read first number"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,9 @@
 //! # let read_debug_abbrev = || &debug_abbrev_buf;
 //! // Read the .debug_info and .debug_abbrev sections with whatever object
 //! // loader you're using.
-//! let debug_info = gimli::DebugInfo::<gimli::EndianBuf<gimli::LittleEndian>>::new(read_debug_info());
-//! let debug_abbrev = gimli::DebugAbbrev::<gimli::EndianBuf<gimli::LittleEndian>>::new(read_debug_abbrev());
+//! let endian = gimli::LittleEndian;
+//! let debug_info = gimli::DebugInfo::new(read_debug_info(), endian);
+//! let debug_abbrev = gimli::DebugAbbrev::new(read_debug_abbrev(), endian);
 //!
 //! // Iterate over all compilation units.
 //! let mut iter = debug_info.units();
@@ -234,7 +235,7 @@ pub use unit::{AttrsIter, Attribute, AttributeValue};
 /// }
 ///
 /// let buf = [0x00, 0x01, 0x02, 0x03];
-/// let reader = EndianBuf::<LittleEndian>::new(&buf);
+/// let reader = EndianBuf::new(&buf, LittleEndian);
 ///
 /// let debug_info: DebugInfo<_> = load_section(|_: &'static str| reader);
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ mod constants;
 pub use constants::*;
 
 mod endianity;
-pub use endianity::{Endianity, EndianBuf, LittleEndian, BigEndian, NativeEndian};
+pub use endianity::{Endianity, EndianBuf, RunTimeEndian, LittleEndian, BigEndian, NativeEndian};
 
 pub mod leb128;
 

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -27,14 +27,14 @@ impl<'input, Endian> DebugLoc<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugLoc, EndianBuf, LittleEndian};
+    /// use gimli::{DebugLoc, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_loc_section_somehow = || &buf;
-    /// let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(read_debug_loc_section_somehow());
+    /// let debug_loc = DebugLoc::new(read_debug_loc_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_loc_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_loc_section))
+    pub fn new(debug_loc_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_loc_section, endian))
     }
 }
 
@@ -268,7 +268,7 @@ mod tests {
             .L32(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_loc = DebugLoc::new(&buf, LittleEndian);
         let offset = DebugLocOffset((&first - &start) as usize);
         let mut locations = debug_loc.locations(offset, 4, 0x01000000).unwrap();
 
@@ -279,7 +279,7 @@ mod tests {
                                    begin: 0x01010200,
                                    end: 0x01010300,
                                },
-                               data: EndianBuf::new(&[2, 0, 0, 0]),
+                               data: EndianBuf::new(&[2, 0, 0, 0], LittleEndian),
                            })));
 
         // A base address selection followed by a normal location.
@@ -289,7 +289,7 @@ mod tests {
                                    begin: 0x02010400,
                                    end: 0x02010500,
                                },
-                               data: EndianBuf::new(&[3, 0, 0, 0]),
+                               data: EndianBuf::new(&[3, 0, 0, 0], LittleEndian),
                            })));
 
         // An empty location range followed by a normal location.
@@ -299,7 +299,7 @@ mod tests {
                                    begin: 0x02010800,
                                    end: 0x02010900,
                                },
-                               data: EndianBuf::new(&[5, 0, 0, 0]),
+                               data: EndianBuf::new(&[5, 0, 0, 0], LittleEndian),
                            })));
 
         // A location range that starts at 0.
@@ -309,7 +309,7 @@ mod tests {
                                    begin: 0x02000000,
                                    end: 0x02000001,
                                },
-                               data: EndianBuf::new(&[6, 0, 0, 0]),
+                               data: EndianBuf::new(&[6, 0, 0, 0], LittleEndian),
                            })));
 
         // A location range that ends at -1.
@@ -319,7 +319,7 @@ mod tests {
                                    begin: 0x00000000,
                                    end: 0xffffffff,
                                },
-                               data: EndianBuf::new(&[7, 0, 0, 0]),
+                               data: EndianBuf::new(&[7, 0, 0, 0], LittleEndian),
                            })));
 
         // A location list end.
@@ -360,7 +360,7 @@ mod tests {
             .L64(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_loc = DebugLoc::new(&buf, LittleEndian);
         let offset = DebugLocOffset((&first - &start) as usize);
         let mut locations = debug_loc.locations(offset, 8, 0x01000000).unwrap();
 
@@ -371,7 +371,7 @@ mod tests {
                                    begin: 0x01010200,
                                    end: 0x01010300,
                                },
-                               data: EndianBuf::new(&[2, 0, 0, 0]),
+                               data: EndianBuf::new(&[2, 0, 0, 0], LittleEndian),
                            })));
 
         // A base address selection followed by a normal location.
@@ -381,7 +381,7 @@ mod tests {
                                    begin: 0x02010400,
                                    end: 0x02010500,
                                },
-                               data: EndianBuf::new(&[3, 0, 0, 0]),
+                               data: EndianBuf::new(&[3, 0, 0, 0], LittleEndian),
                            })));
 
         // An empty location range followed by a normal location.
@@ -391,7 +391,7 @@ mod tests {
                                    begin: 0x02010800,
                                    end: 0x02010900,
                                },
-                               data: EndianBuf::new(&[5, 0, 0, 0]),
+                               data: EndianBuf::new(&[5, 0, 0, 0], LittleEndian),
                            })));
 
         // A location range that starts at 0.
@@ -401,7 +401,7 @@ mod tests {
                                    begin: 0x02000000,
                                    end: 0x02000001,
                                },
-                               data: EndianBuf::new(&[6, 0, 0, 0]),
+                               data: EndianBuf::new(&[6, 0, 0, 0], LittleEndian),
                            })));
 
         // A location range that ends at -1.
@@ -411,7 +411,7 @@ mod tests {
                                    begin: 0x0,
                                    end: 0xffffffffffffffff,
                                },
-                               data: EndianBuf::new(&[7, 0, 0, 0]),
+                               data: EndianBuf::new(&[7, 0, 0, 0], LittleEndian),
                            })));
 
         // A location list end.
@@ -433,7 +433,7 @@ mod tests {
             .L32(0x20000).L32(0xff010000).L16(4).L32(2);
 
         let buf = section.get_contents().unwrap();
-        let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_loc = DebugLoc::new(&buf, LittleEndian);
 
         // An invalid location range.
         let mut locations = debug_loc

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -59,15 +59,15 @@ impl<'input, Endian> DebugPubNames<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugPubNames, EndianBuf, LittleEndian};
+    /// use gimli::{DebugPubNames, LittleEndian};
     ///
     /// # let buf = [];
     /// # let read_debug_pubnames_section_somehow = || &buf;
     /// let debug_pubnames =
-    ///     DebugPubNames::<EndianBuf<LittleEndian>>::new(read_debug_pubnames_section_somehow());
+    ///     DebugPubNames::new(read_debug_pubnames_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_pubnames_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_pubnames_section))
+    pub fn new(debug_pubnames_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_pubnames_section, endian))
     }
 }
 
@@ -80,7 +80,7 @@ impl<R: Reader> DebugPubNames<R> {
     /// # let buf = [];
     /// # let read_debug_pubnames_section_somehow = || &buf;
     /// let debug_pubnames =
-    ///     DebugPubNames::<EndianBuf<LittleEndian>>::new(read_debug_pubnames_section_somehow());
+    ///     DebugPubNames::new(read_debug_pubnames_section_somehow(), LittleEndian);
     ///
     /// let mut iter = debug_pubnames.items();
     /// while let Some(pubname) = iter.next().unwrap() {

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -59,15 +59,15 @@ impl<'input, Endian> DebugPubTypes<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugPubTypes, EndianBuf, LittleEndian};
+    /// use gimli::{DebugPubTypes, LittleEndian};
     ///
     /// # let buf = [];
     /// # let read_debug_pubtypes_somehow = || &buf;
     /// let debug_pubtypes =
-    ///     DebugPubTypes::<EndianBuf<LittleEndian>>::new(read_debug_pubtypes_somehow());
+    ///     DebugPubTypes::new(read_debug_pubtypes_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_pubtypes_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_pubtypes_section))
+    pub fn new(debug_pubtypes_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_pubtypes_section, endian))
     }
 }
 
@@ -80,7 +80,7 @@ impl<R: Reader> DebugPubTypes<R> {
     /// # let buf = [];
     /// # let read_debug_pubtypes_section_somehow = || &buf;
     /// let debug_pubtypes =
-    ///     DebugPubTypes::<EndianBuf<LittleEndian>>::new(read_debug_pubtypes_section_somehow());
+    ///     DebugPubTypes::new(read_debug_pubtypes_section_somehow(), LittleEndian);
     ///
     /// let mut iter = debug_pubtypes.items();
     /// while let Some(pubtype) = iter.next().unwrap() {

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -26,14 +26,14 @@ impl<'input, Endian> DebugRanges<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugRanges, EndianBuf, LittleEndian};
+    /// use gimli::{DebugRanges, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_ranges_section_somehow = || &buf;
-    /// let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(read_debug_ranges_section_somehow());
+    /// let debug_ranges = DebugRanges::new(read_debug_ranges_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_ranges_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_ranges_section))
+    pub fn new(debug_ranges_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_ranges_section, endian))
     }
 }
 
@@ -312,7 +312,7 @@ mod tests {
             .L32(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_ranges = DebugRanges::new(&buf, LittleEndian);
         let offset = DebugRangesOffset((&first - &start) as usize);
         let mut ranges = debug_ranges.ranges(offset, 4, 0x01000000).unwrap();
 
@@ -389,7 +389,7 @@ mod tests {
             .L64(0);
 
         let buf = section.get_contents().unwrap();
-        let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_ranges = DebugRanges::new(&buf, LittleEndian);
         let offset = DebugRangesOffset((&first - &start) as usize);
         let mut ranges = debug_ranges.ranges(offset, 8, 0x01000000).unwrap();
 
@@ -447,7 +447,7 @@ mod tests {
             .L32(0x20000).L32(0xff010000);
 
         let buf = section.get_contents().unwrap();
-        let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_ranges = DebugRanges::new(&buf, LittleEndian);
 
         // An invalid range.
         let mut ranges = debug_ranges

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -14,6 +14,9 @@ pub trait Reader: Debug + Clone {
     /// The endianity of bytes that are read.
     type Endian: Endianity;
 
+    /// Return the endianity of bytes that are read.
+    fn endian(&self) -> Self::Endian;
+
     /// Return the number of bytes remaining.
     fn len(&self) -> usize;
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -25,14 +25,14 @@ impl<'input, Endian> DebugStr<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugStr, EndianBuf, LittleEndian};
+    /// use gimli::{DebugStr, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_str_section_somehow = || &buf;
-    /// let debug_str = DebugStr::<EndianBuf<LittleEndian>>::new(read_debug_str_section_somehow());
+    /// let debug_str = DebugStr::new(read_debug_str_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_str_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_str_section))
+    pub fn new(debug_str_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_str_section, endian))
     }
 }
 
@@ -40,13 +40,13 @@ impl<R: Reader> DebugStr<R> {
     /// Lookup a string from the `.debug_str` section by DebugStrOffset.
     ///
     /// ```
-    /// use gimli::{DebugStr, DebugStrOffset, EndianBuf, LittleEndian};
+    /// use gimli::{DebugStr, DebugStrOffset, LittleEndian};
     ///
     /// # let buf = [0x01, 0x02, 0x00];
     /// # let offset = DebugStrOffset(0);
     /// # let read_debug_str_section_somehow = || &buf;
     /// # let debug_str_offset_somehow = || offset;
-    /// let debug_str = DebugStr::<EndianBuf<LittleEndian>>::new(read_debug_str_section_somehow());
+    /// let debug_str = DebugStr::new(read_debug_str_section_somehow(), LittleEndian);
     /// println!("Found string {:?}", debug_str.get_str(debug_str_offset_somehow()));
     /// ```
     pub fn get_str(&self, offset: DebugStrOffset) -> Result<R> {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -2,7 +2,6 @@
 
 use constants;
 use abbrev::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation, AttributeSpecification};
-use byteorder::ByteOrder;
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
 use line::DebugLineOffset;
@@ -1395,9 +1394,9 @@ impl<R: Reader> Attribute<R> {
     pub fn udata_value(&self) -> Option<u64> {
         Some(match self.value {
                  AttributeValue::Data1(ref data) => data[0] as u64,
-                 AttributeValue::Data2(ref data) => R::Endian::read_u16(data) as u64,
-                 AttributeValue::Data4(ref data) => R::Endian::read_u32(data) as u64,
-                 AttributeValue::Data8(ref data) => R::Endian::read_u64(data),
+                 AttributeValue::Data2(ref data) => R::Endian::default().read_u16(data) as u64,
+                 AttributeValue::Data4(ref data) => R::Endian::default().read_u32(data) as u64,
+                 AttributeValue::Data8(ref data) => R::Endian::default().read_u64(data),
                  AttributeValue::Udata(data) => data,
                  _ => return None,
              })
@@ -1407,9 +1406,9 @@ impl<R: Reader> Attribute<R> {
     pub fn sdata_value(&self) -> Option<i64> {
         Some(match self.value {
                  AttributeValue::Data1(ref data) => data[0] as i8 as i64,
-                 AttributeValue::Data2(ref data) => R::Endian::read_u16(data) as i16 as i64,
-                 AttributeValue::Data4(ref data) => R::Endian::read_u32(data) as i32 as i64,
-                 AttributeValue::Data8(ref data) => R::Endian::read_u64(data) as i64,
+                 AttributeValue::Data2(ref data) => R::Endian::default().read_u16(data) as i16 as i64,
+                 AttributeValue::Data4(ref data) => R::Endian::default().read_u32(data) as i32 as i64,
+                 AttributeValue::Data8(ref data) => R::Endian::default().read_u64(data) as i64,
                  AttributeValue::Sdata(data) => data,
                  _ => return None,
              })
@@ -1421,11 +1420,11 @@ impl<R: Reader> Attribute<R> {
     pub fn offset_value(&self) -> Option<usize> {
         match self.value {
             AttributeValue::Data4(ref data) => {
-                let offset = R::Endian::read_u32(data) as u64;
+                let offset = R::Endian::default().read_u32(data) as u64;
                 u64_to_offset(offset).ok()
             }
             AttributeValue::Data8(ref data) => {
-                let offset = R::Endian::read_u64(data);
+                let offset = R::Endian::default().read_u64(data);
                 u64_to_offset(offset).ok()
             }
             AttributeValue::SecOffset(offset) => Some(offset),

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -97,14 +97,14 @@ impl<'input, Endian> DebugInfo<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugInfo, EndianBuf, LittleEndian};
+    /// use gimli::{DebugInfo, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_info_section_somehow = || &buf;
-    /// let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(read_debug_info_section_somehow());
+    /// let debug_info = DebugInfo::new(read_debug_info_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_info_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_info_section))
+    pub fn new(debug_info_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_info_section, endian))
     }
 }
 
@@ -113,11 +113,11 @@ impl<R: Reader> DebugInfo<R> {
     /// `.debug_info` section.
     ///
     /// ```
-    /// use gimli::{DebugInfo, EndianBuf, LittleEndian};
+    /// use gimli::{DebugInfo, LittleEndian};
     ///
     /// # let buf = [];
     /// # let read_debug_info_section_somehow = || &buf;
-    /// let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(read_debug_info_section_somehow());
+    /// let debug_info = DebugInfo::new(read_debug_info_section_somehow(), LittleEndian);
     ///
     /// let mut iter = debug_info.units();
     /// while let Some(unit) = iter.next().unwrap() {
@@ -282,7 +282,7 @@ impl<R: Reader> CompilationUnitHeader<R> {
     ///
     /// ```
     /// use gimli::DebugAbbrev;
-    /// # use gimli::{DebugInfo, EndianBuf, LittleEndian};
+    /// # use gimli::{DebugInfo, LittleEndian};
     /// # let info_buf = [
     /// #     // Comilation unit header
     /// #
@@ -327,7 +327,7 @@ impl<R: Reader> CompilationUnitHeader<R> {
     /// #       // End of children
     /// #       0x00,
     /// # ];
-    /// # let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&info_buf);
+    /// # let debug_info = DebugInfo::new(&info_buf, LittleEndian);
     /// #
     /// # let abbrev_buf = [
     /// #     // Code
@@ -353,7 +353,7 @@ impl<R: Reader> CompilationUnitHeader<R> {
     /// let unit = get_some_unit();
     ///
     /// # let read_debug_abbrev_section_somehow = || &abbrev_buf;
-    /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
+    /// let debug_abbrev = DebugAbbrev::new(read_debug_abbrev_section_somehow(), LittleEndian);
     /// let abbrevs_for_unit = unit.abbreviations(&debug_abbrev).unwrap();
     /// ```
     pub fn abbreviations(&self, debug_abbrev: &DebugAbbrev<R>) -> Result<Abbreviations> {
@@ -643,7 +643,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// Get this entry's `DW_TAG_whatever` tag.
     ///
     /// ```
-    /// # use gimli::{DebugAbbrev, DebugInfo, EndianBuf, LittleEndian};
+    /// # use gimli::{DebugAbbrev, DebugInfo, LittleEndian};
     /// # let info_buf = [
     /// #     // Comilation unit header
     /// #
@@ -663,7 +663,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// #     // Attribute of form DW_FORM_string = "foo\0"
     /// #     0x66, 0x6f, 0x6f, 0x00,
     /// # ];
-    /// # let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&info_buf);
+    /// # let debug_info = DebugInfo::new(&info_buf, LittleEndian);
     /// # let abbrev_buf = [
     /// #     // Code
     /// #     0x01,
@@ -682,7 +682,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// #     // Null terminator
     /// #     0x00
     /// # ];
-    /// # let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
+    /// # let debug_abbrev = DebugAbbrev::new(&abbrev_buf, LittleEndian);
     /// # let unit = debug_info.units().next().unwrap().unwrap();
     /// # let abbrevs = unit.abbreviations(&debug_abbrev).unwrap();
     /// # let mut cursor = unit.entries(&abbrevs);
@@ -715,7 +715,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// Iterate over this entry's set of attributes.
     ///
     /// ```
-    /// use gimli::{DebugAbbrev, DebugInfo, EndianBuf, LittleEndian};
+    /// use gimli::{DebugAbbrev, DebugInfo, LittleEndian};
     ///
     /// // Read the `.debug_info` section.
     ///
@@ -739,7 +739,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// #     0x66, 0x6f, 0x6f, 0x00,
     /// # ];
     /// # let read_debug_info_section_somehow = || &info_buf;
-    /// let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(read_debug_info_section_somehow());
+    /// let debug_info = DebugInfo::new(read_debug_info_section_somehow(), LittleEndian);
     ///
     /// // Get the data about the first compilation unit out of the `.debug_info`.
     ///
@@ -769,7 +769,7 @@ impl<'abbrev, 'unit, R: Reader> DebuggingInformationEntry<'abbrev, 'unit, R> {
     /// #     0x00
     /// # ];
     /// # let read_debug_abbrev_section_somehow = || &abbrev_buf;
-    /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
+    /// let debug_abbrev = DebugAbbrev::new(read_debug_abbrev_section_somehow(), LittleEndian);
     /// let abbrevs = unit.abbreviations(&debug_abbrev).unwrap();
     ///
     /// // Get the first entry from that compilation unit.
@@ -850,21 +850,21 @@ pub enum AttributeValue<R: Reader> {
     /// From section 7 of the standard: "Depending on context, it may be a
     /// signed integer, an unsigned integer, a floating-point constant, or
     /// anything else."
-    Data2([u8; 2]),
+    Data2(([u8; 2], R::Endian)),
 
     /// A four byte constant data value. How to interpret the bytes depends on context.
     ///
     /// From section 7 of the standard: "Depending on context, it may be a
     /// signed integer, an unsigned integer, a floating-point constant, or
     /// anything else."
-    Data4([u8; 4]),
+    Data4(([u8; 4], R::Endian)),
 
     /// An eight byte constant data value. How to interpret the bytes depends on context.
     ///
     /// From section 7 of the standard: "Depending on context, it may be a
     /// signed integer, an unsigned integer, a floating-point constant, or
     /// anything else."
-    Data8([u8; 8]),
+    Data8(([u8; 8], R::Endian)),
 
     /// A signed integer constant.
     Sdata(i64),
@@ -1394,9 +1394,9 @@ impl<R: Reader> Attribute<R> {
     pub fn udata_value(&self) -> Option<u64> {
         Some(match self.value {
                  AttributeValue::Data1(ref data) => data[0] as u64,
-                 AttributeValue::Data2(ref data) => R::Endian::default().read_u16(data) as u64,
-                 AttributeValue::Data4(ref data) => R::Endian::default().read_u32(data) as u64,
-                 AttributeValue::Data8(ref data) => R::Endian::default().read_u64(data),
+                 AttributeValue::Data2((ref data, endian)) => endian.read_u16(data) as u64,
+                 AttributeValue::Data4((ref data, endian)) => endian.read_u32(data) as u64,
+                 AttributeValue::Data8((ref data, endian)) => endian.read_u64(data),
                  AttributeValue::Udata(data) => data,
                  _ => return None,
              })
@@ -1406,9 +1406,9 @@ impl<R: Reader> Attribute<R> {
     pub fn sdata_value(&self) -> Option<i64> {
         Some(match self.value {
                  AttributeValue::Data1(ref data) => data[0] as i8 as i64,
-                 AttributeValue::Data2(ref data) => R::Endian::default().read_u16(data) as i16 as i64,
-                 AttributeValue::Data4(ref data) => R::Endian::default().read_u32(data) as i32 as i64,
-                 AttributeValue::Data8(ref data) => R::Endian::default().read_u64(data) as i64,
+                 AttributeValue::Data2((ref data, endian)) => endian.read_u16(data) as i16 as i64,
+                 AttributeValue::Data4((ref data, endian)) => endian.read_u32(data) as i32 as i64,
+                 AttributeValue::Data8((ref data, endian)) => endian.read_u64(data) as i64,
                  AttributeValue::Sdata(data) => data,
                  _ => return None,
              })
@@ -1419,12 +1419,12 @@ impl<R: Reader> Attribute<R> {
     /// Offsets will be `Data` in DWARF version 2/3, and `SecOffset` otherwise.
     pub fn offset_value(&self) -> Option<usize> {
         match self.value {
-            AttributeValue::Data4(ref data) => {
-                let offset = R::Endian::default().read_u32(data) as u64;
+            AttributeValue::Data4((ref data, endian)) => {
+                let offset = endian.read_u32(data) as u64;
                 u64_to_offset(offset).ok()
             }
-            AttributeValue::Data8(ref data) => {
-                let offset = R::Endian::default().read_u64(data);
+            AttributeValue::Data8((ref data, endian)) => {
+                let offset = endian.read_u64(data);
                 u64_to_offset(offset).ok()
             }
             AttributeValue::SecOffset(offset) => Some(offset),
@@ -1518,7 +1518,7 @@ fn parse_attribute<'unit, R: Reader>(input: &mut R,
             }
             constants::DW_FORM_data2 => {
                 let data = input.read_u8_array()?;
-                AttributeValue::Data2(data)
+                AttributeValue::Data2((data, input.endian()))
             }
             constants::DW_FORM_data4 => {
                 // DWARF version 2/3 may use DW_FORM_data4/8 for section offsets.
@@ -1532,7 +1532,7 @@ fn parse_attribute<'unit, R: Reader>(input: &mut R,
                     AttributeValue::SecOffset(offset as usize)
                 } else {
                     let data = input.read_u8_array()?;
-                    AttributeValue::Data4(data)
+                    AttributeValue::Data4((data, input.endian()))
                 }
             }
             constants::DW_FORM_data8 => {
@@ -1547,7 +1547,7 @@ fn parse_attribute<'unit, R: Reader>(input: &mut R,
                     AttributeValue::SecOffset(offset as usize)
                 } else {
                     let data = input.read_u8_array()?;
-                    AttributeValue::Data8(data)
+                    AttributeValue::Data8((data, input.endian()))
                 }
             }
             constants::DW_FORM_udata => {
@@ -1815,7 +1815,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// does not have any children.
     ///
     /// ```
-    /// # use gimli::{DebugAbbrev, DebugInfo, EndianBuf, LittleEndian};
+    /// # use gimli::{DebugAbbrev, DebugInfo, LittleEndian};
     /// # let info_buf = [
     /// #     // Comilation unit header
     /// #
@@ -1860,7 +1860,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// #       // End of children
     /// #       0x00,
     /// # ];
-    /// # let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&info_buf);
+    /// # let debug_info = DebugInfo::new(&info_buf, LittleEndian);
     /// #
     /// # let abbrev_buf = [
     /// #     // Code
@@ -1880,7 +1880,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// #     // Null terminator
     /// #     0x00
     /// # ];
-    /// # let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
+    /// # let debug_abbrev = DebugAbbrev::new(&abbrev_buf, LittleEndian);
     /// #
     /// # let get_some_unit = || debug_info.units().next().unwrap().unwrap();
     ///
@@ -1940,7 +1940,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// root entry:
     ///
     /// ```
-    /// # use gimli::{DebugAbbrev, DebugInfo, EndianBuf, LittleEndian};
+    /// # use gimli::{DebugAbbrev, DebugInfo, LittleEndian};
     /// # let info_buf = [
     /// #     // Comilation unit header
     /// #
@@ -1985,7 +1985,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// #       // End of children
     /// #       0x00,
     /// # ];
-    /// # let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&info_buf);
+    /// # let debug_info = DebugInfo::new(&info_buf, LittleEndian);
     /// #
     /// # let get_some_unit = || debug_info.units().next().unwrap().unwrap();
     ///
@@ -2007,7 +2007,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
     /// #     // Null terminator
     /// #     0x00
     /// # ];
-    /// # let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
+    /// # let debug_abbrev = DebugAbbrev::new(&abbrev_buf, LittleEndian);
     /// #
     /// let unit = get_some_unit();
     /// # let get_abbrevs_for_unit = |_| unit.abbreviations(&debug_abbrev).unwrap();
@@ -2101,10 +2101,10 @@ impl<'abbrev, 'unit, R: Reader> EntriesCursor<'abbrev, 'unit, R> {
 /// extern crate gimli;
 ///
 /// # fn example() -> Result<(), gimli::Error> {
-/// # let debug_info = gimli::DebugInfo::<gimli::EndianBuf<gimli::LittleEndian>>::new(&[]);
+/// # let debug_info = gimli::DebugInfo::new(&[], gimli::LittleEndian);
 /// # let get_some_unit = || debug_info.units().next().unwrap().unwrap();
 /// let unit = get_some_unit();
-/// # let debug_abbrev = gimli::DebugAbbrev::<gimli::EndianBuf<gimli::LittleEndian>>::new(&[]);
+/// # let debug_abbrev = gimli::DebugAbbrev::new(&[], gimli::LittleEndian);
 /// # let get_abbrevs_for_unit = |_| unit.abbreviations(&debug_abbrev).unwrap();
 /// let abbrevs = get_abbrevs_for_unit(&unit);
 ///
@@ -2300,14 +2300,14 @@ impl<'input, Endian> DebugTypes<EndianBuf<'input, Endian>>
     /// Linux, a Mach-O loader on OSX, etc.
     ///
     /// ```
-    /// use gimli::{DebugTypes, EndianBuf, LittleEndian};
+    /// use gimli::{DebugTypes, LittleEndian};
     ///
     /// # let buf = [0x00, 0x01, 0x02, 0x03];
     /// # let read_debug_types_section_somehow = || &buf;
-    /// let debug_types = DebugTypes::<EndianBuf<LittleEndian>>::new(read_debug_types_section_somehow());
+    /// let debug_types = DebugTypes::new(read_debug_types_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_types_section: &'input [u8]) -> Self {
-        Self::from(EndianBuf::new(debug_types_section))
+    pub fn new(debug_types_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_types_section, endian))
     }
 }
 
@@ -2328,11 +2328,11 @@ impl<R: Reader> DebugTypes<R> {
     /// Iterate the type-units in this `.debug_types` section.
     ///
     /// ```
-    /// use gimli::{DebugTypes, EndianBuf, LittleEndian};
+    /// use gimli::{DebugTypes, LittleEndian};
     ///
     /// # let buf = [];
     /// # let read_debug_types_section_somehow = || &buf;
-    /// let debug_types = DebugTypes::<EndianBuf<LittleEndian>>::new(read_debug_types_section_somehow());
+    /// let debug_types = DebugTypes::new(read_debug_types_section_somehow(), LittleEndian);
     ///
     /// let mut iter = debug_types.units();
     /// while let Some(unit) = iter.next().unwrap() {
@@ -2508,7 +2508,7 @@ impl<R: Reader> TypeUnitHeader<R> {
     ///
     /// ```
     /// use gimli::DebugAbbrev;
-    /// # use gimli::{DebugTypes, EndianBuf, LittleEndian};
+    /// # use gimli::{DebugTypes, LittleEndian};
     /// # let types_buf = [
     /// #     // Type unit header
     /// #
@@ -2557,7 +2557,7 @@ impl<R: Reader> TypeUnitHeader<R> {
     /// #       // End of children
     /// #       0x00,
     /// # ];
-    /// # let debug_types = DebugTypes::<EndianBuf<LittleEndian>>::new(&types_buf);
+    /// # let debug_types = DebugTypes::new(&types_buf, LittleEndian);
     /// #
     /// # let abbrev_buf = [
     /// #     // Code
@@ -2583,7 +2583,7 @@ impl<R: Reader> TypeUnitHeader<R> {
     /// let unit = get_some_type_unit();
     ///
     /// # let read_debug_abbrev_section_somehow = || &abbrev_buf;
-    /// let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(read_debug_abbrev_section_somehow());
+    /// let debug_abbrev = DebugAbbrev::new(read_debug_abbrev_section_somehow(), LittleEndian);
     /// let abbrevs_for_unit = unit.abbreviations(&debug_abbrev).unwrap();
     /// ```
     pub fn abbreviations(&self, debug_abbrev: &DebugAbbrev<R>) -> Result<Abbreviations> {
@@ -2726,7 +2726,7 @@ mod tests {
     fn test_parse_debug_abbrev_offset_32() {
         let section = Section::with_endian(Endian::Little).L32(0x04030201);
         let buf = section.get_contents().unwrap();
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_abbrev_offset(buf, Format::Dwarf32) {
             Ok(val) => assert_eq!(val, DebugAbbrevOffset(0x04030201)),
@@ -2737,7 +2737,7 @@ mod tests {
     #[test]
     fn test_parse_debug_abbrev_offset_32_incomplete() {
         let buf = [0x01, 0x02];
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_abbrev_offset(buf, Format::Dwarf32) {
             Err(Error::UnexpectedEof) => assert!(true),
@@ -2750,7 +2750,7 @@ mod tests {
     fn test_parse_debug_abbrev_offset_64() {
         let section = Section::with_endian(Endian::Little).L64(0x0807060504030201);
         let buf = section.get_contents().unwrap();
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_abbrev_offset(buf, Format::Dwarf64) {
             Ok(val) => assert_eq!(val, DebugAbbrevOffset(0x0807060504030201)),
@@ -2761,7 +2761,7 @@ mod tests {
     #[test]
     fn test_parse_debug_abbrev_offset_64_incomplete() {
         let buf = [0x01, 0x02];
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_abbrev_offset(buf, Format::Dwarf64) {
             Err(Error::UnexpectedEof) => assert!(true),
@@ -2773,7 +2773,7 @@ mod tests {
     fn test_parse_debug_info_offset_32() {
         let section = Section::with_endian(Endian::Little).L32(0x04030201);
         let buf = section.get_contents().unwrap();
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_info_offset(buf, Format::Dwarf32) {
             Ok(val) => assert_eq!(val, DebugInfoOffset(0x04030201)),
@@ -2784,7 +2784,7 @@ mod tests {
     #[test]
     fn test_parse_debug_info_offset_32_incomplete() {
         let buf = [0x01, 0x02];
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_info_offset(buf, Format::Dwarf32) {
             Err(Error::UnexpectedEof) => assert!(true),
@@ -2797,7 +2797,7 @@ mod tests {
     fn test_parse_debug_info_offset_64() {
         let section = Section::with_endian(Endian::Little).L64(0x0807060504030201);
         let buf = section.get_contents().unwrap();
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_info_offset(buf, Format::Dwarf64) {
             Ok(val) => assert_eq!(val, DebugInfoOffset(0x0807060504030201)),
@@ -2808,7 +2808,7 @@ mod tests {
     #[test]
     fn test_parse_debug_info_offset_64_incomplete() {
         let buf = [0x01, 0x02];
-        let buf = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let buf = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_debug_info_offset(buf, Format::Dwarf64) {
             Err(Error::UnexpectedEof) => assert!(true),
@@ -2827,7 +2827,7 @@ mod tests {
                 debug_abbrev_offset: DebugAbbrevOffset(0x0102030405060708),
                 address_size: 8,
                 format: Format::Dwarf64,
-                entries_buf: EndianBuf::new(expected_rest),
+                entries_buf: EndianBuf::new(expected_rest, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
@@ -2838,7 +2838,7 @@ mod tests {
                 debug_abbrev_offset: DebugAbbrevOffset(0x08070605),
                 address_size: 4,
                 format: Format::Dwarf32,
-                entries_buf: EndianBuf::new(expected_rest),
+                entries_buf: EndianBuf::new(expected_rest, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
@@ -2847,7 +2847,7 @@ mod tests {
             .comp_unit(&mut unit32);
         let buf = section.get_contents().unwrap();
 
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&buf);
+        let debug_info = DebugInfo::new(&buf, LittleEndian);
         let mut units = debug_info.units();
 
         assert_eq!(units.next(), Ok(Some(unit64)));
@@ -2859,12 +2859,12 @@ mod tests {
     fn test_unit_version_ok() {
         // Version 4 and two extra bytes
         let buf = [0x04, 0x00, 0xff, 0xff];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_version(rest) {
             Ok(val) => {
                 assert_eq!(val, 4);
-                assert_eq!(*rest, EndianBuf::new(&[0xff, 0xff]));
+                assert_eq!(*rest, EndianBuf::new(&[0xff, 0xff], LittleEndian));
             }
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
@@ -2873,7 +2873,7 @@ mod tests {
     #[test]
     fn test_unit_version_unknown_version() {
         let buf = [0xab, 0xcd];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_version(rest) {
             Err(Error::UnknownVersion) => assert!(true),
@@ -2881,7 +2881,7 @@ mod tests {
         };
 
         let buf = [0x1, 0x0];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_version(rest) {
             Err(Error::UnknownVersion) => assert!(true),
@@ -2892,7 +2892,7 @@ mod tests {
     #[test]
     fn test_unit_version_incomplete() {
         let buf = [0x04];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_version(rest) {
             Err(Error::UnexpectedEof) => assert!(true),
@@ -2909,16 +2909,16 @@ mod tests {
             debug_abbrev_offset: DebugAbbrevOffset(0x08070605),
             address_size: 4,
             format: Format::Dwarf32,
-            entries_buf: EndianBuf::new(expected_rest),
+            entries_buf: EndianBuf::new(expected_rest, LittleEndian),
         };
         let section = Section::with_endian(Endian::Little)
             .unit(&mut expected_unit, &[])
             .append_bytes(expected_rest);
         let buf = section.get_contents().unwrap();
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         assert_eq!(parse_unit_header(rest), Ok(expected_unit));
-        assert_eq!(*rest, EndianBuf::new(expected_rest));
+        assert_eq!(*rest, EndianBuf::new(expected_rest, LittleEndian));
     }
 
     #[test]
@@ -2931,22 +2931,22 @@ mod tests {
             debug_abbrev_offset: DebugAbbrevOffset(0x0102030405060708),
             address_size: 8,
             format: Format::Dwarf64,
-            entries_buf: EndianBuf::new(expected_rest),
+            entries_buf: EndianBuf::new(expected_rest, LittleEndian),
         };
         let section = Section::with_endian(Endian::Little)
             .unit(&mut expected_unit, &[])
             .append_bytes(expected_rest);
         let buf = section.get_contents().unwrap();
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         assert_eq!(parse_unit_header(rest), Ok(expected_unit));
-        assert_eq!(*rest, EndianBuf::new(expected_rest));
+        assert_eq!(*rest, EndianBuf::new(expected_rest, LittleEndian));
     }
 
     #[test]
     fn test_parse_type_offset_32_ok() {
         let buf = [0x12, 0x34, 0x56, 0x78, 0x00];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_type_offset(rest, Format::Dwarf32) {
             Ok(offset) => {
@@ -2961,7 +2961,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_parse_type_offset_64_ok() {
         let buf = [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xff, 0x00];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_type_offset(rest, Format::Dwarf64) {
             Ok(offset) => {
@@ -2976,7 +2976,7 @@ mod tests {
     fn test_parse_type_offset_incomplete() {
         // Need at least 4 bytes.
         let buf = [0xff, 0xff, 0xff];
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         match parse_type_offset(rest, Format::Dwarf32) {
             Err(Error::UnexpectedEof) => assert!(true),
@@ -2995,7 +2995,7 @@ mod tests {
                 debug_abbrev_offset: DebugAbbrevOffset(0x08070605),
                 address_size: 8,
                 format: Format::Dwarf64,
-                entries_buf: EndianBuf::new(expected_rest),
+                entries_buf: EndianBuf::new(expected_rest, LittleEndian),
             },
             offset: DebugTypesOffset(0),
             type_signature: DebugTypeSignature(0xdeadbeefdeadbeef),
@@ -3005,11 +3005,11 @@ mod tests {
             .type_unit(&mut expected_unit)
             .append_bytes(expected_rest);
         let buf = section.get_contents().unwrap();
-        let rest = &mut EndianBuf::<LittleEndian>::new(&buf);
+        let rest = &mut EndianBuf::new(&buf, LittleEndian);
 
         assert_eq!(parse_type_unit_header(rest, DebugTypesOffset(0)),
                    Ok(expected_unit));
-        assert_eq!(*rest, EndianBuf::new(expected_rest));
+        assert_eq!(*rest, EndianBuf::new(expected_rest, LittleEndian));
     }
 
     fn section_contents<F>(f: F) -> Vec<u8>
@@ -3024,23 +3024,24 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_attribute_value() {
         let mut unit = test_parse_attribute_unit_default();
+        let endian = unit.entries_buf.endian();
 
         let block_data = &[1, 2, 3, 4];
         let buf = section_contents(|s| s.uleb(block_data.len() as u64).append_bytes(block_data));
-        let block = EndianBuf::<LittleEndian>::new(&buf);
+        let block = EndianBuf::new(&buf, endian);
 
         let buf = section_contents(|s| s.L32(0x01020304));
-        let data4 = EndianBuf::<LittleEndian>::new(&buf);
+        let data4 = EndianBuf::new(&buf, endian);
 
         let buf = section_contents(|s| s.L64(0x0102030405060708));
-        let data8 = EndianBuf::<LittleEndian>::new(&buf);
+        let data8 = EndianBuf::new(&buf, endian);
 
         let tests = [(2,
                       constants::DW_AT_data_member_location,
                       constants::DW_FORM_block,
                       block,
-                      AttributeValue::Block(EndianBuf::new(block_data)),
-                      AttributeValue::Exprloc(EndianBuf::new(block_data))),
+                      AttributeValue::Block(EndianBuf::new(block_data, endian)),
+                      AttributeValue::Exprloc(EndianBuf::new(block_data, endian))),
                      (2,
                       constants::DW_AT_data_member_location,
                       constants::DW_FORM_data4,
@@ -3051,7 +3052,7 @@ mod tests {
                       constants::DW_AT_data_member_location,
                       constants::DW_FORM_data4,
                       data4,
-                      AttributeValue::Data4([4, 3, 2, 1]),
+                      AttributeValue::Data4(([4, 3, 2, 1], endian)),
                       AttributeValue::Udata(0x01020304)),
                      (2,
                       constants::DW_AT_data_member_location,
@@ -3063,7 +3064,7 @@ mod tests {
                       constants::DW_AT_data_member_location,
                       constants::DW_FORM_data8,
                       data8,
-                      AttributeValue::Data8([8, 7, 6, 5, 4, 3, 2, 1]),
+                      AttributeValue::Data8(([8, 7, 6, 5, 4, 3, 2, 1], endian)),
                       AttributeValue::Udata(0x0102030405060708))];
 
         for test in tests.iter() {
@@ -3079,15 +3080,16 @@ mod tests {
 
     #[test]
     fn test_attribute_udata_sdata_value() {
+        let endian = LittleEndian;
         let tests: &[(AttributeValue<EndianBuf<LittleEndian>>, _, _)] =
             &[(AttributeValue::Data1([1]), Some(1), Some(1)),
               (AttributeValue::Data1([255]), Some(std::u8::MAX as u64), Some(-1)),
-              (AttributeValue::Data2([1, 0]), Some(1), Some(1)),
-              (AttributeValue::Data2([255; 2]), Some(std::u16::MAX as u64), Some(-1)),
-              (AttributeValue::Data4([1, 0, 0, 0]), Some(1), Some(1)),
-              (AttributeValue::Data4([255; 4]), Some(std::u32::MAX as u64), Some(-1)),
-              (AttributeValue::Data8([1, 0, 0, 0, 0, 0, 0, 0]), Some(1), Some(1)),
-              (AttributeValue::Data8([255; 8]), Some(std::u64::MAX), Some(-1)),
+              (AttributeValue::Data2(([1, 0], endian)), Some(1), Some(1)),
+              (AttributeValue::Data2(([255; 2], endian)), Some(std::u16::MAX as u64), Some(-1)),
+              (AttributeValue::Data4(([1, 0, 0, 0], endian)), Some(1), Some(1)),
+              (AttributeValue::Data4(([255; 4], endian)), Some(std::u32::MAX as u64), Some(-1)),
+              (AttributeValue::Data8(([1, 0, 0, 0, 0, 0, 0, 0], endian)), Some(1), Some(1)),
+              (AttributeValue::Data8(([255; 8], endian)), Some(std::u64::MAX), Some(-1)),
               (AttributeValue::Sdata(1), None, Some(1)),
               (AttributeValue::Udata(1), Some(1), None)];
         for test in tests.iter() {
@@ -3102,27 +3104,28 @@ mod tests {
     }
 
     fn test_parse_attribute_unit<Endian>(address_size: u8,
-                                         format: Format)
+                                         format: Format,
+                                         endian: Endian)
                                          -> UnitHeader<EndianBuf<'static, Endian>>
         where Endian: Endianity
     {
-        UnitHeader::<EndianBuf<Endian>>::new(7,
-                                             4,
-                                             DebugAbbrevOffset(0x08070605),
-                                             address_size,
-                                             format,
-                                             EndianBuf::new(&[]))
+        UnitHeader::new(7,
+                        4,
+                        DebugAbbrevOffset(0x08070605),
+                        address_size,
+                        format,
+                        EndianBuf::new(&[], endian))
     }
 
     fn test_parse_attribute_unit_default() -> UnitHeader<EndianBuf<'static, LittleEndian>> {
-        test_parse_attribute_unit(4, Format::Dwarf32)
+        test_parse_attribute_unit(4, Format::Dwarf32, LittleEndian)
     }
 
-    fn test_parse_attribute<Endian>(buf: &[u8],
-                                    len: usize,
-                                    unit: &UnitHeader<EndianBuf<Endian>>,
-                                    form: constants::DwForm,
-                                    value: AttributeValue<EndianBuf<Endian>>)
+    fn test_parse_attribute<'input, Endian>(buf: &'input [u8],
+                                            len: usize,
+                                            unit: &UnitHeader<EndianBuf<'input, Endian>>,
+                                            form: constants::DwForm,
+                                            value: AttributeValue<EndianBuf<'input, Endian>>)
         where Endian: Endianity
     {
         let spec = AttributeSpecification::new(constants::DW_AT_low_pc, form);
@@ -3132,11 +3135,11 @@ mod tests {
             value: value,
         };
 
-        let rest = &mut EndianBuf::new(buf);
+        let rest = &mut EndianBuf::new(buf, Endian::default());
         match parse_attribute(rest, unit, spec) {
             Ok(attr) => {
                 assert_eq!(attr, expect);
-                assert_eq!(*rest, EndianBuf::new(&buf[len..]));
+                assert_eq!(*rest, EndianBuf::new(&buf[len..], Endian::default()));
             }
             otherwise => {
                 println!("Unexpected parse result = {:#?}", otherwise);
@@ -3148,7 +3151,7 @@ mod tests {
     #[test]
     fn test_parse_attribute_addr() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf32);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf32, LittleEndian);
         let form = constants::DW_FORM_addr;
         let value = AttributeValue::Addr(0x04030201);
         test_parse_attribute(&buf, 4, &unit, form, value);
@@ -3157,7 +3160,7 @@ mod tests {
     #[test]
     fn test_parse_attribute_addr8() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-        let unit = test_parse_attribute_unit::<LittleEndian>(8, Format::Dwarf32);
+        let unit = test_parse_attribute_unit(8, Format::Dwarf32, LittleEndian);
         let form = constants::DW_FORM_addr;
         let value = AttributeValue::Addr(0x0807060504030201);
         test_parse_attribute(&buf, 8, &unit, form, value);
@@ -3169,7 +3172,7 @@ mod tests {
         let buf = [0x03, 0x09, 0x09, 0x09, 0x00, 0x00];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_block1;
-        let value = AttributeValue::Block(EndianBuf::new(&buf[1..4]));
+        let value = AttributeValue::Block(EndianBuf::new(&buf[1..4], LittleEndian));
         test_parse_attribute(&buf, 4, &unit, form, value);
     }
 
@@ -3179,7 +3182,7 @@ mod tests {
         let buf = [0x02, 0x00, 0x09, 0x09, 0x00, 0x00];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_block2;
-        let value = AttributeValue::Block(EndianBuf::new(&buf[2..4]));
+        let value = AttributeValue::Block(EndianBuf::new(&buf[2..4], LittleEndian));
         test_parse_attribute(&buf, 4, &unit, form, value);
     }
 
@@ -3189,7 +3192,7 @@ mod tests {
         let buf = [0x02, 0x00, 0x00, 0x00, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_block4;
-        let value = AttributeValue::Block(EndianBuf::new(&buf[4..]));
+        let value = AttributeValue::Block(EndianBuf::new(&buf[4..], LittleEndian));
         test_parse_attribute(&buf, 6, &unit, form, value);
     }
 
@@ -3199,7 +3202,7 @@ mod tests {
         let buf = [0x02, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_block;
-        let value = AttributeValue::Block(EndianBuf::new(&buf[1..]));
+        let value = AttributeValue::Block(EndianBuf::new(&buf[1..], LittleEndian));
         test_parse_attribute(&buf, 3, &unit, form, value);
     }
 
@@ -3217,7 +3220,7 @@ mod tests {
         let buf = [0x02, 0x01, 0x0];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data2;
-        let value = AttributeValue::Data2([0x02, 0x01]);
+        let value = AttributeValue::Data2(([0x02, 0x01], LittleEndian));
         test_parse_attribute(&buf, 2, &unit, form, value);
     }
 
@@ -3226,7 +3229,7 @@ mod tests {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data4;
-        let value = AttributeValue::Data4([0x01, 0x02, 0x03, 0x04]);
+        let value = AttributeValue::Data4(([0x01, 0x02, 0x03, 0x04], LittleEndian));
         test_parse_attribute(&buf, 4, &unit, form, value);
     }
 
@@ -3235,7 +3238,8 @@ mod tests {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_data8;
-        let value = AttributeValue::Data8([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        let value = AttributeValue::Data8(([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+                                           LittleEndian));
         test_parse_attribute(&buf, 8, &unit, form, value);
     }
 
@@ -3275,7 +3279,7 @@ mod tests {
         let buf = [0x02, 0x99, 0x99, 0x11];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_exprloc;
-        let value = AttributeValue::Exprloc(EndianBuf::new(&buf[1..3]));
+        let value = AttributeValue::Exprloc(EndianBuf::new(&buf[1..3], LittleEndian));
         test_parse_attribute(&buf, 3, &unit, form, value);
     }
 
@@ -3310,7 +3314,7 @@ mod tests {
     #[test]
     fn test_parse_attribute_sec_offset_32() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf32);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf32, LittleEndian);
         let form = constants::DW_FORM_sec_offset;
         let value = AttributeValue::SecOffset(0x04030201);
         test_parse_attribute(&buf, 4, &unit, form, value);
@@ -3320,7 +3324,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_parse_attribute_sec_offset_64() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf64);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
         let form = constants::DW_FORM_sec_offset;
         let value = AttributeValue::SecOffset(0x0807060504030201);
         test_parse_attribute(&buf, 8, &unit, form, value);
@@ -3381,7 +3385,7 @@ mod tests {
     #[test]
     fn test_parse_attribute_refaddr_32() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf32);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf32, LittleEndian);
         let form = constants::DW_FORM_ref_addr;
         let value = AttributeValue::DebugInfoRef(DebugInfoOffset(67305985));
         test_parse_attribute(&buf, 4, &unit, form, value);
@@ -3391,7 +3395,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_parse_attribute_refaddr_64() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf64);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
         let form = constants::DW_FORM_ref_addr;
         let value = AttributeValue::DebugInfoRef(DebugInfoOffset(578437695752307201));
         test_parse_attribute(&buf, 8, &unit, form, value);
@@ -3400,7 +3404,7 @@ mod tests {
     #[test]
     fn test_parse_attribute_refaddr_version2() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
-        let mut unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf32);
+        let mut unit = test_parse_attribute_unit(4, Format::Dwarf32, LittleEndian);
         unit.version = 2;
         let form = constants::DW_FORM_ref_addr;
         let value = AttributeValue::DebugInfoRef(DebugInfoOffset(0x04030201));
@@ -3411,7 +3415,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_parse_attribute_refaddr8_version2() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
-        let mut unit = test_parse_attribute_unit::<LittleEndian>(8, Format::Dwarf32);
+        let mut unit = test_parse_attribute_unit(8, Format::Dwarf32, LittleEndian);
         unit.version = 2;
         let form = constants::DW_FORM_ref_addr;
         let value = AttributeValue::DebugInfoRef(DebugInfoOffset(0x0807060504030201));
@@ -3432,14 +3436,14 @@ mod tests {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x0, 0x99, 0x99];
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_string;
-        let value = AttributeValue::String(EndianBuf::new(&buf[..5]));
+        let value = AttributeValue::String(EndianBuf::new(&buf[..5], LittleEndian));
         test_parse_attribute(&buf, 6, &unit, form, value);
     }
 
     #[test]
     fn test_parse_attribute_strp_32() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf32);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf32, LittleEndian);
         let form = constants::DW_FORM_strp;
         let value = AttributeValue::DebugStrRef(DebugStrOffset(67305985));
         test_parse_attribute(&buf, 4, &unit, form, value);
@@ -3449,7 +3453,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_parse_attribute_strp_64() {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x99];
-        let unit = test_parse_attribute_unit::<LittleEndian>(4, Format::Dwarf64);
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
         let form = constants::DW_FORM_strp;
         let value = AttributeValue::DebugStrRef(DebugStrOffset(578437695752307201));
         test_parse_attribute(&buf, 8, &unit, form, value);
@@ -3474,12 +3478,12 @@ mod tests {
 
     #[test]
     fn test_attrs_iter() {
-        let unit = UnitHeader::<EndianBuf<LittleEndian>>::new(7,
-                                                              4,
-                                                              DebugAbbrevOffset(0x08070605),
-                                                              4,
-                                                              Format::Dwarf32,
-                                                              EndianBuf::new(&[]));
+        let unit = UnitHeader::new(7,
+                                   4,
+                                   DebugAbbrevOffset(0x08070605),
+                                   4,
+                                   Format::Dwarf32,
+                                   EndianBuf::new(&[], LittleEndian));
 
         let abbrev =
             Abbreviation::new(42,
@@ -3498,14 +3502,14 @@ mod tests {
 
         let entry = DebuggingInformationEntry {
             offset: UnitOffset(0),
-            attrs_slice: EndianBuf::new(&buf),
+            attrs_slice: EndianBuf::new(&buf, LittleEndian),
             attrs_len: Cell::new(None),
             abbrev: &abbrev,
             unit: &unit,
         };
 
         let mut attrs = AttrsIter {
-            input: EndianBuf::new(&buf),
+            input: EndianBuf::new(&buf, LittleEndian),
             attributes: abbrev.attributes(),
             entry: &entry,
         };
@@ -3515,7 +3519,7 @@ mod tests {
                 assert_eq!(attr,
                            Attribute {
                                name: constants::DW_AT_name,
-                               value: AttributeValue::String(EndianBuf::new(b"foo")),
+                               value: AttributeValue::String(EndianBuf::new(b"foo", LittleEndian)),
                            });
             }
             otherwise => {
@@ -3566,12 +3570,12 @@ mod tests {
 
     #[test]
     fn test_attrs_iter_incomplete() {
-        let unit = UnitHeader::<EndianBuf<LittleEndian>>::new(7,
-                                                              4,
-                                                              DebugAbbrevOffset(0x08070605),
-                                                              4,
-                                                              Format::Dwarf32,
-                                                              EndianBuf::new(&[]));
+        let unit = UnitHeader::new(7,
+                                   4,
+                                   DebugAbbrevOffset(0x08070605),
+                                   4,
+                                   Format::Dwarf32,
+                                   EndianBuf::new(&[], LittleEndian));
 
         let abbrev =
             Abbreviation::new(42,
@@ -3589,14 +3593,14 @@ mod tests {
 
         let entry = DebuggingInformationEntry {
             offset: UnitOffset(0),
-            attrs_slice: EndianBuf::new(&buf),
+            attrs_slice: EndianBuf::new(&buf, LittleEndian),
             attrs_len: Cell::new(None),
             abbrev: &abbrev,
             unit: &unit,
         };
 
         let mut attrs = AttrsIter {
-            input: EndianBuf::new(&buf),
+            input: EndianBuf::new(&buf, LittleEndian),
             attributes: abbrev.attributes(),
             entry: &entry,
         };
@@ -3606,7 +3610,7 @@ mod tests {
                 assert_eq!(attr,
                            Attribute {
                                name: constants::DW_AT_name,
-                               value: AttributeValue::String(EndianBuf::new(b"foo")),
+                               value: AttributeValue::String(EndianBuf::new(b"foo", LittleEndian)),
                            });
             }
             otherwise => {
@@ -3638,7 +3642,7 @@ mod tests {
             .expect("Should have found the name attribute");
 
         assert_eq!(value,
-                   AttributeValue::String(EndianBuf::new(name.as_bytes())));
+                   AttributeValue::String(EndianBuf::new(name.as_bytes(), Endian::default())));
     }
 
     fn assert_current_name<Endian>(cursor: &EntriesCursor<EndianBuf<Endian>>, name: &str)
@@ -3749,14 +3753,14 @@ mod tests {
                 .die_null();
         let entries_buf = section.get_contents().unwrap();
 
-        let mut unit = CompilationUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = CompilationUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: Format::Dwarf32,
-                entries_buf: EndianBuf::new(&entries_buf),
+                entries_buf: EndianBuf::new(&entries_buf, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
@@ -3773,27 +3777,27 @@ mod tests {
                     .die(1, |s| s);
         let entries_buf = section.get_contents().unwrap();
 
-        let mut unit = CompilationUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = CompilationUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: Format::Dwarf32,
-                entries_buf: EndianBuf::new(&entries_buf),
+                entries_buf: EndianBuf::new(&entries_buf, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
         let section = Section::with_endian(Endian::Little).comp_unit(&mut unit);
         let info_buf = &section.get_contents().unwrap();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(info_buf);
+        let debug_info = DebugInfo::new(info_buf, LittleEndian);
 
         let unit = debug_info.units().next()
             .expect("should have a unit result")
             .expect("and it should be ok");
 
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(abbrevs_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -3820,14 +3824,14 @@ mod tests {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_cursor_next_entry() {
         let info_buf = &entries_cursor_tests_debug_info_buf();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(info_buf);
+        let debug_info = DebugInfo::new(info_buf, LittleEndian);
 
         let unit = debug_info.units().next()
             .expect("should have a unit result")
             .expect("and it should be ok");
 
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(abbrevs_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -3863,14 +3867,14 @@ mod tests {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_cursor_next_dfs() {
         let info_buf = &entries_cursor_tests_debug_info_buf();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(info_buf);
+        let debug_info = DebugInfo::new(info_buf, LittleEndian);
 
         let unit = debug_info.units().next()
             .expect("should have a unit result")
             .expect("and it should be ok");
 
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(abbrevs_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -3896,14 +3900,14 @@ mod tests {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_cursor_next_sibling_no_sibling_ptr() {
         let info_buf = &entries_cursor_tests_debug_info_buf();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(info_buf);
+        let debug_info = DebugInfo::new(info_buf, LittleEndian);
 
         let unit = debug_info.units().next()
             .expect("should have a unit result")
             .expect("and it should be ok");
 
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(abbrevs_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -3931,7 +3935,7 @@ mod tests {
     #[test]
     fn test_cursor_next_sibling_continuation() {
         let info_buf = &entries_cursor_tests_debug_info_buf();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(info_buf);
+        let debug_info = DebugInfo::new(info_buf, LittleEndian);
 
         let unit = debug_info
             .units()
@@ -3940,7 +3944,7 @@ mod tests {
             .expect("and it should be ok");
 
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(abbrevs_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -4081,20 +4085,20 @@ mod tests {
         let header_size = CompilationUnitHeader::<EndianBuf<LittleEndian>>::size_of_header(format);
         let entries_buf = entries_cursor_sibling_entries_buf(header_size);
 
-        let mut unit = CompilationUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = CompilationUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: format,
-                entries_buf: EndianBuf::new(&entries_buf),
+                entries_buf: EndianBuf::new(&entries_buf, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
         let section = Section::with_endian(Endian::Little).comp_unit(&mut unit);
         let info_buf = section.get_contents().unwrap();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&info_buf);
+        let debug_info = DebugInfo::new(&info_buf, LittleEndian);
 
         let unit = debug_info
             .units()
@@ -4103,7 +4107,7 @@ mod tests {
             .expect("and it should be ok");
 
         let abbrev_buf = entries_cursor_sibling_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
+        let debug_abbrev = DebugAbbrev::new(&abbrev_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -4118,14 +4122,14 @@ mod tests {
         let header_size = TypeUnitHeader::<EndianBuf<LittleEndian>>::size_of_header(format);
         let entries_buf = entries_cursor_sibling_entries_buf(header_size);
 
-        let mut unit = TypeUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = TypeUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: format,
-                entries_buf: EndianBuf::new(&entries_buf),
+                entries_buf: EndianBuf::new(&entries_buf, LittleEndian),
             },
             type_signature: DebugTypeSignature(0),
             type_offset: UnitOffset(0),
@@ -4133,7 +4137,7 @@ mod tests {
         };
         let section = Section::with_endian(Endian::Little).type_unit(&mut unit);
         let info_buf = section.get_contents().unwrap();
-        let debug_types = DebugTypes::<EndianBuf<LittleEndian>>::new(&info_buf);
+        let debug_types = DebugTypes::new(&info_buf, LittleEndian);
 
         let unit = debug_types
             .units()
@@ -4142,7 +4146,7 @@ mod tests {
             .expect("and it should be ok");
 
         let abbrev_buf = entries_cursor_sibling_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrev_buf);
+        let debug_abbrev = DebugAbbrev::new(&abbrev_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -4154,7 +4158,7 @@ mod tests {
     #[test]
     fn test_entries_at_offset() {
         let info_buf = &entries_cursor_tests_debug_info_buf();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(info_buf);
+        let debug_info = DebugInfo::new(info_buf, LittleEndian);
 
         let unit = debug_info
             .units()
@@ -4163,7 +4167,7 @@ mod tests {
             .expect("and it should be ok");
 
         let abbrevs_buf = &entries_cursor_tests_abbrev_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(abbrevs_buf, LittleEndian);
 
         let abbrevs = unit.abbreviations(&debug_abbrev)
             .expect("Should parse abbreviations");
@@ -4261,19 +4265,19 @@ mod tests {
         }
 
         let abbrevs_buf = entries_tree_tests_debug_abbrevs_buf();
-        let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&abbrevs_buf);
+        let debug_abbrev = DebugAbbrev::new(&abbrevs_buf, LittleEndian);
 
         let format = Format::Dwarf32;
         let header_size = CompilationUnitHeader::<EndianBuf<LittleEndian>>::size_of_header(format);
         let (entries_buf, entry2) = entries_tree_tests_debug_info_buf(header_size);
-        let mut unit = CompilationUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = CompilationUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: format,
-                entries_buf: EndianBuf::new(&entries_buf),
+                entries_buf: EndianBuf::new(&entries_buf, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
@@ -4281,7 +4285,7 @@ mod tests {
             .comp_unit(&mut unit)
             .get_contents()
             .unwrap();
-        let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&info_buf);
+        let debug_info = DebugInfo::new(&info_buf, LittleEndian);
 
         let unit = debug_info
             .units()
@@ -4362,14 +4366,14 @@ mod tests {
     fn test_debug_info_offset() {
         let padding = &[0; 10];
         let entries = &[0; 20];
-        let mut unit = CompilationUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = CompilationUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: Format::Dwarf32,
-                entries_buf: EndianBuf::new(entries),
+                entries_buf: EndianBuf::new(entries, LittleEndian),
             },
             offset: DebugInfoOffset(0),
         };
@@ -4400,14 +4404,14 @@ mod tests {
     fn test_debug_types_offset() {
         let padding = &[0; 10];
         let entries = &[0; 20];
-        let mut unit = TypeUnitHeader::<EndianBuf<LittleEndian>> {
+        let mut unit = TypeUnitHeader {
             header: UnitHeader {
                 unit_length: 0,
                 version: 4,
                 debug_abbrev_offset: DebugAbbrevOffset(0),
                 address_size: 4,
                 format: Format::Dwarf32,
-                entries_buf: EndianBuf::new(entries),
+                entries_buf: EndianBuf::new(entries, LittleEndian),
             },
             type_signature: DebugTypeSignature(0),
             type_offset: UnitOffset(0),

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -1,7 +1,7 @@
 extern crate gimli;
 
 use gimli::{AttributeValue, DebugAbbrev, DebugAranges, DebugInfo, DebugLine, DebugLoc,
-            DebugPubNames, DebugPubTypes, DebugRanges, DebugStr, LittleEndian, EndianBuf};
+            DebugPubNames, DebugPubTypes, DebugRanges, DebugStr, LittleEndian};
 use std::env;
 use std::collections::hash_map::HashMap;
 use std::fs::File;
@@ -28,10 +28,10 @@ fn read_section(section: &str) -> Vec<u8> {
 #[test]
 fn test_parse_self_debug_info() {
     let debug_info = read_section("debug_info");
-    let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&debug_info);
+    let debug_info = DebugInfo::new(&debug_info, LittleEndian);
 
     let debug_abbrev = read_section("debug_abbrev");
-    let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
+    let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
@@ -52,16 +52,16 @@ fn test_parse_self_debug_info() {
 #[test]
 fn test_parse_self_debug_line() {
     let debug_info = read_section("debug_info");
-    let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&debug_info);
+    let debug_info = DebugInfo::new(&debug_info, LittleEndian);
 
     let debug_abbrev = read_section("debug_abbrev");
-    let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
+    let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
     let debug_line = read_section("debug_line");
-    let debug_line = DebugLine::<EndianBuf<LittleEndian>>::new(&debug_line);
+    let debug_line = DebugLine::new(&debug_line, LittleEndian);
 
     let debug_str = read_section("debug_str");
-    let debug_str = DebugStr::<EndianBuf<LittleEndian>>::new(&debug_str);
+    let debug_str = DebugStr::new(&debug_str, LittleEndian);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
@@ -127,13 +127,13 @@ fn test_parse_self_debug_line() {
 #[test]
 fn test_parse_self_debug_loc() {
     let debug_info = read_section("debug_info");
-    let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&debug_info);
+    let debug_info = DebugInfo::new(&debug_info, LittleEndian);
 
     let debug_abbrev = read_section("debug_abbrev");
-    let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
+    let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
     let debug_loc = read_section("debug_loc");
-    let debug_loc = DebugLoc::<EndianBuf<LittleEndian>>::new(&debug_loc);
+    let debug_loc = DebugLoc::new(&debug_loc, LittleEndian);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
@@ -175,13 +175,13 @@ fn test_parse_self_debug_loc() {
 #[test]
 fn test_parse_self_debug_ranges() {
     let debug_info = read_section("debug_info");
-    let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&debug_info);
+    let debug_info = DebugInfo::new(&debug_info, LittleEndian);
 
     let debug_abbrev = read_section("debug_abbrev");
-    let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
+    let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
     let debug_ranges = read_section("debug_ranges");
-    let debug_ranges = DebugRanges::<EndianBuf<LittleEndian>>::new(&debug_ranges);
+    let debug_ranges = DebugRanges::new(&debug_ranges, LittleEndian);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
@@ -223,7 +223,7 @@ fn test_parse_self_debug_ranges() {
 #[test]
 fn test_parse_self_debug_aranges() {
     let debug_aranges = read_section("debug_aranges");
-    let debug_aranges = DebugAranges::<EndianBuf<LittleEndian>>::new(&debug_aranges);
+    let debug_aranges = DebugAranges::new(&debug_aranges, LittleEndian);
 
     let mut aranges = debug_aranges.items();
     while let Some(_) = aranges.next().expect("Should parse arange OK") {
@@ -234,13 +234,13 @@ fn test_parse_self_debug_aranges() {
 #[test]
 fn test_parse_self_debug_pubnames() {
     let debug_info = read_section("debug_info");
-    let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&debug_info);
+    let debug_info = DebugInfo::new(&debug_info, LittleEndian);
 
     let debug_abbrev = read_section("debug_abbrev");
-    let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
+    let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
     let debug_pubnames = read_section("debug_pubnames");
-    let debug_pubnames = DebugPubNames::<EndianBuf<LittleEndian>>::new(&debug_pubnames);
+    let debug_pubnames = DebugPubNames::new(&debug_pubnames, LittleEndian);
 
     let mut units = HashMap::new();
     let mut abbrevs = HashMap::new();
@@ -267,13 +267,13 @@ fn test_parse_self_debug_pubnames() {
 #[test]
 fn test_parse_self_debug_pubtypes() {
     let debug_info = read_section("debug_info");
-    let debug_info = DebugInfo::<EndianBuf<LittleEndian>>::new(&debug_info);
+    let debug_info = DebugInfo::new(&debug_info, LittleEndian);
 
     let debug_abbrev = read_section("debug_abbrev");
-    let debug_abbrev = DebugAbbrev::<EndianBuf<LittleEndian>>::new(&debug_abbrev);
+    let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
     let debug_pubtypes = read_section("debug_pubtypes");
-    let debug_pubtypes = DebugPubTypes::<EndianBuf<LittleEndian>>::new(&debug_pubtypes);
+    let debug_pubtypes = DebugPubTypes::new(&debug_pubtypes, LittleEndian);
 
     let mut units = HashMap::new();
     let mut abbrevs = HashMap::new();
@@ -306,7 +306,7 @@ fn test_parse_self_eh_frame() {
     use gimli::{BaseAddresses, CieOrFde, EhFrame, UnwindSection};
 
     let eh_frame = read_section("eh_frame");
-    let eh_frame = EhFrame::<EndianBuf<LittleEndian>>::new(&eh_frame);
+    let eh_frame = EhFrame::new(&eh_frame, LittleEndian);
 
     let bases = BaseAddresses::default().set_cfi(0).set_data(0).set_text(0);
     let mut entries = eh_frame.entries(&bases);


### PR DESCRIPTION
Fixes #84 

No noticeable change in benchmarks when not using `RunTimeEndian`. I didn't measure with it.

I changed dwarfdump to use it since performance doesn't matter much there, to test it and to see what the size change was:

Before:
```
   text	   data	    bss	    dec	    hex	filename
 680902	  22249	   3704	 706855	  ac927	target/release/examples/dwarfdump
```
After:
```
   text	   data	    bss	    dec	    hex	filename
 593190	  22025	   3704	 618919	  971a7	target/release/examples/dwarfdump
```
