### PR TITLE
Add self tests and benchmarks for parsing and evaluating expressions

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -396,8 +396,8 @@ fn dump_attr_value<R: gimli::Reader>(attr: &gimli::Attribute<R>,
         }
         gimli::AttributeValue::Exprloc(ref data) => {
             if let gimli::AttributeValue::Exprloc(_) = attr.raw_value() {
-                print!("len 0x{:04x}: ", data.len());
-                for byte in data.to_slice().iter() {
+                print!("len 0x{:04x}: ", data.0.len());
+                for byte in data.0.to_slice().iter() {
                     print!("{:02x}", byte);
                 }
                 print!(": ");
@@ -526,13 +526,13 @@ fn dump_file_index<R: gimli::Reader>(file: u64, unit: &Unit<R>) {
     print!("{}", file.path_name().to_string_lossy());
 }
 
-fn dump_exprloc<R: gimli::Reader>(data: &R, unit: &Unit<R>) {
-    let mut pc = data.clone();
+fn dump_exprloc<R: gimli::Reader>(data: &gimli::Expression<R>, unit: &Unit<R>) {
+    let mut pc = data.0.clone();
     let mut space = false;
     while pc.len() != 0 {
         let mut op_pc = pc.clone();
         let dwop = gimli::DwOp(op_pc.read_u8().expect("Should read from non-empty reader"));
-        match gimli::Operation::parse(&mut pc, data, unit.address_size, unit.format) {
+        match gimli::Operation::parse(&mut pc, &data.0, unit.address_size, unit.format) {
             Ok(op) => {
                 if space {
                     print!(" ");

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -1,6 +1,7 @@
 use endianity::{Endianity, EndianBuf};
 use fallible_iterator::FallibleIterator;
 use parser::{Error, Result};
+use op::Expression;
 use reader::Reader;
 use ranges::Range;
 use Section;
@@ -203,7 +204,7 @@ pub struct LocationListEntry<R: Reader> {
     pub range: Range,
 
     /// The data containing a single location description.
-    pub data: R,
+    pub data: Expression<R>,
 }
 
 impl<R: Reader> LocationListEntry<R> {
@@ -215,7 +216,7 @@ impl<R: Reader> LocationListEntry<R> {
             data.empty();
             let location = LocationListEntry {
                 range: range,
-                data: data,
+                data: Expression(data),
             };
             Ok(location)
         } else {
@@ -223,7 +224,7 @@ impl<R: Reader> LocationListEntry<R> {
             let data = input.split(len as usize)?;
             let location = LocationListEntry {
                 range: range,
-                data: data,
+                data: Expression(data),
             };
             Ok(location)
         }
@@ -279,7 +280,7 @@ mod tests {
                                    begin: 0x01010200,
                                    end: 0x01010300,
                                },
-                               data: EndianBuf::new(&[2, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[2, 0, 0, 0], LittleEndian)),
                            })));
 
         // A base address selection followed by a normal location.
@@ -289,7 +290,7 @@ mod tests {
                                    begin: 0x02010400,
                                    end: 0x02010500,
                                },
-                               data: EndianBuf::new(&[3, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[3, 0, 0, 0], LittleEndian)),
                            })));
 
         // An empty location range followed by a normal location.
@@ -299,7 +300,7 @@ mod tests {
                                    begin: 0x02010800,
                                    end: 0x02010900,
                                },
-                               data: EndianBuf::new(&[5, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[5, 0, 0, 0], LittleEndian)),
                            })));
 
         // A location range that starts at 0.
@@ -309,7 +310,7 @@ mod tests {
                                    begin: 0x02000000,
                                    end: 0x02000001,
                                },
-                               data: EndianBuf::new(&[6, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[6, 0, 0, 0], LittleEndian)),
                            })));
 
         // A location range that ends at -1.
@@ -319,7 +320,7 @@ mod tests {
                                    begin: 0x00000000,
                                    end: 0xffffffff,
                                },
-                               data: EndianBuf::new(&[7, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[7, 0, 0, 0], LittleEndian)),
                            })));
 
         // A location list end.
@@ -371,7 +372,7 @@ mod tests {
                                    begin: 0x01010200,
                                    end: 0x01010300,
                                },
-                               data: EndianBuf::new(&[2, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[2, 0, 0, 0], LittleEndian)),
                            })));
 
         // A base address selection followed by a normal location.
@@ -381,7 +382,7 @@ mod tests {
                                    begin: 0x02010400,
                                    end: 0x02010500,
                                },
-                               data: EndianBuf::new(&[3, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[3, 0, 0, 0], LittleEndian)),
                            })));
 
         // An empty location range followed by a normal location.
@@ -391,7 +392,7 @@ mod tests {
                                    begin: 0x02010800,
                                    end: 0x02010900,
                                },
-                               data: EndianBuf::new(&[5, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[5, 0, 0, 0], LittleEndian)),
                            })));
 
         // A location range that starts at 0.
@@ -401,7 +402,7 @@ mod tests {
                                    begin: 0x02000000,
                                    end: 0x02000001,
                                },
-                               data: EndianBuf::new(&[6, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[6, 0, 0, 0], LittleEndian)),
                            })));
 
         // A location range that ends at -1.
@@ -411,7 +412,7 @@ mod tests {
                                    begin: 0x0,
                                    end: 0xffffffffffffffff,
                                },
-                               data: EndianBuf::new(&[7, 0, 0, 0], LittleEndian),
+                               data: Expression(EndianBuf::new(&[7, 0, 0, 0], LittleEndian)),
                            })));
 
         // A location list end.

--- a/src/op.rs
+++ b/src/op.rs
@@ -853,6 +853,35 @@ pub enum EvaluationResult<R: Reader> {
     RequiresTextBase,
 }
 
+/// The bytecode for a DWARF expression or location description.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Expression<R: Reader>(pub R);
+
+impl<R: Reader> Expression<R> {
+    /// Create an evaluation for this expression.
+    ///
+    /// The `address_size` and `format` are determined by the
+    /// [CompilationUnitHeader](struct.CompilationUnitHeader.html) or
+    /// [TypeUnitHeader](struct.TypeUnitHeader.html)
+    /// that this expression relates to.
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// use gimli::Expression;
+    /// # let endian = gimli::LittleEndian;
+    /// # let debug_info = gimli::DebugInfo::from(gimli::EndianBuf::new(&[], endian));
+    /// # let unit = debug_info.units().next().unwrap().unwrap();
+    /// # let bytecode = gimli::EndianBuf::new(&[], endian);
+    /// let expression = gimli::Expression(bytecode);
+    /// let mut eval = expression.evaluation(unit.address_size(), unit.format());
+    /// let mut result = eval.evaluate().unwrap();
+    /// ```
+    #[inline]
+    pub fn evaluation(self, address_size: u8, format: Format) -> Evaluation<R> {
+        Evaluation::new(self.0, address_size, format)
+    }
+}
+
 /// A DWARF expression evaluator.
 ///
 /// # Usage


### PR DESCRIPTION
Also added an `Expression` newtype, to make it easier for a user to find out what to do with the contents of `AttributeValue::Exprloc` and `LocationListEntry`. Maybe we want to have separate newtypes for expressions and locations? Not sure if it adds any value.