### PR TITLE
Add Reader::Offset associated type

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -147,7 +147,7 @@ fn bench_parsing_debug_pubtypes(b: &mut test::Bencher) {
 // We happen to know that there is a line number program and header at
 // offset 0 and that address size is 8 bytes. No need to parse DIEs to grab
 // this info off of the compilation units.
-const OFFSET: DebugLineOffset = DebugLineOffset(0);
+const OFFSET: DebugLineOffset<usize> = DebugLineOffset(0);
 const ADDRESS_SIZE: u8 = 8;
 
 #[bench]
@@ -572,17 +572,18 @@ mod cfi {
         });
     }
 
-    fn instrs_len<R: Reader>(fde: &FrameDescriptionEntry<R, EhFrame<R>>) -> usize {
+    fn instrs_len<R: Reader>(fde: &FrameDescriptionEntry<R, R::Offset, EhFrame<R>>) -> usize {
         fde.instructions()
             .fold(0, |count, _| count + 1)
             .expect("fold over instructions OK")
     }
 
-    fn get_fde_with_longest_cfi_instructions<R: Reader>(eh_frame: &EhFrame<R>)
-                                                        -> FrameDescriptionEntry<R, EhFrame<R>> {
+    fn get_fde_with_longest_cfi_instructions<R: Reader>
+        (eh_frame: &EhFrame<R>)
+         -> FrameDescriptionEntry<R, R::Offset, EhFrame<R>> {
         let bases = BaseAddresses::default().set_cfi(0).set_data(0).set_text(0);
 
-        let mut longest: Option<(usize, FrameDescriptionEntry<_, _>)> = None;
+        let mut longest: Option<(usize, FrameDescriptionEntry<_, _, _>)> = None;
 
         let mut entries = eh_frame.entries(&bases);
         while let Some(entry) = entries.next().expect("Should parse CFI entry OK") {

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -10,7 +10,7 @@ use Section;
 
 /// An offset into the `.debug_abbrev` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DebugAbbrevOffset(pub usize);
+pub struct DebugAbbrevOffset<T>(pub T);
 
 /// The `DebugAbbrev` struct represents the abbreviations describing
 /// `DebuggingInformationEntry`s' attribute names and forms found in the
@@ -47,7 +47,9 @@ impl<R: Reader> DebugAbbrev<R> {
     /// `.debug_abbrev` section.
     ///
     /// The `offset` should generally be retrieved from a unit header.
-    pub fn abbreviations(&self, debug_abbrev_offset: DebugAbbrevOffset) -> Result<Abbreviations> {
+    pub fn abbreviations(&self,
+                         debug_abbrev_offset: DebugAbbrevOffset<R::Offset>)
+                         -> Result<Abbreviations> {
         let input = &mut self.debug_abbrev_section.clone();
         input.skip(debug_abbrev_offset.0)?;
         Abbreviations::parse(input)
@@ -280,7 +282,7 @@ impl AttributeSpecification {
     ///
     /// Note that because some attributes are variably sized, the size cannot
     /// always be known without parsing, in which case we return `None`.
-    pub fn size<R: Reader>(&self, header: &UnitHeader<R>) -> Option<usize> {
+    pub fn size<R: Reader>(&self, header: &UnitHeader<R, R::Offset>) -> Option<usize> {
         match self.form {
             constants::DW_FORM_addr => Some(header.address_size() as usize),
 

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -1,4 +1,4 @@
-//! Types for compile-time endianity.
+//! Types for compile-time and run-time endianity.
 
 use byteorder;
 use byteorder::ByteOrder;
@@ -192,7 +192,7 @@ pub type NativeEndian = BigEndian;
 #[doc(hidden)]
 pub const NativeEndian: BigEndian = BigEndian;
 
-/// A `&[u8]` slice with compile-time endianity metadata.
+/// A `&[u8]` slice with endianity metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EndianBuf<'input, Endian>
     where Endian: Endianity
@@ -363,6 +363,7 @@ impl<'input, Endian> Reader for EndianBuf<'input, Endian>
     where Endian: Endianity
 {
     type Endian = Endian;
+    type Offset = usize;
 
     #[inline]
     fn endian(&self) -> Endian {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ pub use parser::{Error, Result, Format};
 pub use parser::DebugMacinfoOffset;
 
 mod reader;
-pub use reader::Reader;
+pub use reader::{Reader, ReaderOffset};
 
 mod abbrev;
 pub use abbrev::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation,

--- a/src/pubnames.rs
+++ b/src/pubnames.rs
@@ -9,8 +9,8 @@ use Section;
 /// A single parsed pubname.
 #[derive(Debug, Clone)]
 pub struct PubNamesEntry<R: Reader> {
-    unit_header_offset: DebugInfoOffset,
-    die_offset: UnitOffset,
+    unit_header_offset: DebugInfoOffset<R::Offset>,
+    die_offset: UnitOffset<R::Offset>,
     name: R,
 }
 
@@ -22,19 +22,22 @@ impl<R: Reader> PubNamesEntry<R> {
 
     /// Returns the offset into the .debug_info section for the header of the compilation unit
     /// which contains this name.
-    pub fn unit_header_offset(&self) -> DebugInfoOffset {
+    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
         self.unit_header_offset
     }
 
     /// Returns the offset into the compilation unit for the debugging information entry which
     /// has this name.
-    pub fn die_offset(&self) -> UnitOffset {
+    pub fn die_offset(&self) -> UnitOffset<R::Offset> {
         self.die_offset
     }
 }
 
 impl<R: Reader> PubStuffEntry<R> for PubNamesEntry<R> {
-    fn new(die_offset: UnitOffset, name: R, unit_header_offset: DebugInfoOffset) -> Self {
+    fn new(die_offset: UnitOffset<R::Offset>,
+           name: R,
+           unit_header_offset: DebugInfoOffset<R::Offset>)
+           -> Self {
         PubNamesEntry {
             unit_header_offset,
             die_offset,

--- a/src/pubtypes.rs
+++ b/src/pubtypes.rs
@@ -9,8 +9,8 @@ use Section;
 /// A single parsed pubtype.
 #[derive(Debug, Clone)]
 pub struct PubTypesEntry<R: Reader> {
-    unit_header_offset: DebugInfoOffset,
-    die_offset: UnitOffset,
+    unit_header_offset: DebugInfoOffset<R::Offset>,
+    die_offset: UnitOffset<R::Offset>,
     name: R,
 }
 
@@ -22,19 +22,22 @@ impl<R: Reader> PubTypesEntry<R> {
 
     /// Returns the offset into the .debug_info section for the header of the compilation unit
     /// which contains the type with this name.
-    pub fn unit_header_offset(&self) -> DebugInfoOffset {
+    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
         self.unit_header_offset
     }
 
     /// Returns the offset into the compilation unit for the debugging information entry which
     /// the type with this name.
-    pub fn die_offset(&self) -> UnitOffset {
+    pub fn die_offset(&self) -> UnitOffset<R::Offset> {
         self.die_offset
     }
 }
 
 impl<R: Reader> PubStuffEntry<R> for PubTypesEntry<R> {
-    fn new(die_offset: UnitOffset, name: R, unit_header_offset: DebugInfoOffset) -> Self {
+    fn new(die_offset: UnitOffset<R::Offset>,
+           name: R,
+           unit_header_offset: DebugInfoOffset<R::Offset>)
+           -> Self {
         PubTypesEntry {
             unit_header_offset,
             die_offset,

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -6,7 +6,7 @@ use Section;
 
 /// An offset into the `.debug_ranges` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DebugRangesOffset(pub usize);
+pub struct DebugRangesOffset<T>(pub T);
 
 /// The `DebugRanges` struct represents the DWARF strings
 /// found in the `.debug_ranges` section.
@@ -47,7 +47,7 @@ impl<R: Reader> DebugRanges<R> {
     /// Can be [used with
     /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn ranges(&self,
-                  offset: DebugRangesOffset,
+                  offset: DebugRangesOffset<R::Offset>,
                   address_size: u8,
                   base_address: u64)
                   -> Result<RangesIter<R>> {
@@ -66,7 +66,7 @@ impl<R: Reader> DebugRanges<R> {
     /// Can be [used with
     /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn raw_ranges(&self,
-                      offset: DebugRangesOffset,
+                      offset: DebugRangesOffset<R::Offset>,
                       address_size: u8)
                       -> Result<RawRangesIter<R>> {
         let mut input = self.debug_ranges_section.clone();

--- a/src/str.rs
+++ b/src/str.rs
@@ -5,7 +5,7 @@ use Section;
 
 /// An offset into the `.debug_str` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DebugStrOffset(pub usize);
+pub struct DebugStrOffset<T>(pub T);
 
 /// The `DebugStr` struct represents the DWARF strings
 /// found in the `.debug_str` section.
@@ -49,7 +49,7 @@ impl<R: Reader> DebugStr<R> {
     /// let debug_str = DebugStr::new(read_debug_str_section_somehow(), LittleEndian);
     /// println!("Found string {:?}", debug_str.get_str(debug_str_offset_somehow()));
     /// ```
-    pub fn get_str(&self, offset: DebugStrOffset) -> Result<R> {
+    pub fn get_str(&self, offset: DebugStrOffset<R::Offset>) -> Result<R> {
         let input = &mut self.debug_str_section.clone();
         input.skip(offset.0)?;
         input.read_null_terminated_slice()


### PR DESCRIPTION
This allows 64-bit readers to be used on 32-bit systems.

One annoyance is that in a few places I've had to use:
 `struct S<R: Reader<Offset=Offset>, Offset: ReaderOffset> { ... }`
instead of `struct S<R: Reader>`, due to rust's variance rules (specifically, structs containing associated types are invariant). This manifested as lifetime errors in the tests. I've only used this form in places where the tests required it. I'm not sure if this error is something that will occur in practice. If it is, then there may be more places that we need to convert to use it.

There is also a performance regression for `bench_parsing_debug_info_tree`. I think this is due to changes in what is inlined, but I haven't tracked it down fully. I'm not happy with how dependent the benchmarks are on inlining; it means that consumers of this crate may not be getting the same performance as our benchmarks.