### PR TITLE
Reader improvements

### DIFF
--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -401,8 +401,8 @@ impl<'input, Endian> Reader for EndianBuf<'input, Endian>
     }
 
     #[inline]
-    fn find(&self, byte: u8) -> Option<usize> {
-        self.find(byte)
+    fn find(&self, byte: u8) -> Result<usize> {
+        self.find(byte).ok_or(Error::UnexpectedEof)
     }
 
     #[inline]
@@ -422,21 +422,21 @@ impl<'input, Endian> Reader for EndianBuf<'input, Endian>
     }
 
     #[inline]
-    fn to_slice(&self) -> Cow<[u8]> {
-        Cow::from(self.buf)
+    fn to_slice(&self) -> Result<Cow<[u8]>> {
+        Ok(self.buf.into())
     }
 
     #[inline]
     fn to_string(&self) -> Result<Cow<str>> {
         match str::from_utf8(self.buf) {
-            Ok(s) => Ok(Cow::from(s)),
+            Ok(s) => Ok(s.into()),
             _ => Err(Error::BadUtf8),
         }
     }
 
     #[inline]
-    fn to_string_lossy(&self) -> Cow<str> {
-        String::from_utf8_lossy(self.buf)
+    fn to_string_lossy(&self) -> Result<Cow<str>> {
+        Ok(String::from_utf8_lossy(self.buf))
     }
 
     #[inline]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,6 +2,7 @@
 
 use std::error;
 use std::fmt::{self, Debug};
+use std::io;
 use std::result;
 use cfi::BaseAddresses;
 use constants;
@@ -10,6 +11,8 @@ use reader::{Reader, ReaderOffset};
 /// An error that occurred when parsing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
+    /// An I/O error occurred while reading.
+    Io,
     /// Found a CFI relative pointer, but the CFI base is undefined.
     CfiRelativePointerButCfiBaseIsUndefined,
     /// Found a `.text` relative pointer, but the `.text` base is undefined.
@@ -138,6 +141,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
+            Error::Io => "An I/O error occurred while reading.",
             Error::CfiRelativePointerButCfiBaseIsUndefined => {
                 "Found a CFI relative pointer, but the CFI base is undefined."
             }
@@ -240,6 +244,12 @@ impl error::Error for Error {
                 "Attempted to push onto the CFI stack, but it was already at full capacity."
             }
         }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(_: io::Error) -> Self {
+        Error::Io
     }
 }
 


### PR DESCRIPTION
This is the result of an experiment in implementing `Reader` for:
```rust
pub struct EndianRead<T, Endian>
    where T: Read + Seek + Clone,
          Endian: Endianity
{
    buf: T,
    position: u64,
    len: u64,
    endian: Endian,
}
```

I looked into benchmarking this for `std::io::File`, but I didn't think it was going to be worth it without implementing buffering, and the `Clone` requirement also makes it a bit more complicated (eg we can't just use `std::io::BufReader`).

I did check that dwarfdump produces identical output when using `EndianRead<io::Cursor<&'input [u8]>, Endian>` instead of `EndianBuf`.