### PR TITLE
Add a link to the `EhFrame` type in module docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@
 //!
 //!   * [`DebugTypes`](./struct.DebugTypes.html): The `.debug_types` section.
 //!
+//!   * [`EhFrame`](./struct.EhFrame.html): The `.eh_frame` section.
+//!
 //! * Each section type exposes methods for accessing the debugging data encoded
 //! in that section. For example, the [`DebugInfo`](./struct.DebugInfo.html)
 //! struct has the [`units`](./struct.DebugInfo.html#method.units) method for


### PR DESCRIPTION
In the part of the module docs that enumerate and link-to each object file section's corresponding `gimli` type, we were missing `EhFrame`/`.eh_frame`.

r? @philipc 