### PR TITLE
Support for DW_OP_addrx

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -74,6 +74,7 @@ struct Flags {
     pubtypes: bool,
     aranges: bool,
     raw: bool,
+    addr: bool,
 }
 
 fn print_usage(opts: &getopts::Options) -> ! {
@@ -89,6 +90,7 @@ fn main() {
     opts.optflag("p", "", "print .debug_pubnames section");
     opts.optflag("r", "", "print .debug_aranges section");
     opts.optflag("y", "", "print .debug_pubtypes section");
+    opts.optflag("a", "", "print .debug_addr section");
     opts.optflag("", "raw", "print raw data values");
 
     let matches = match opts.parse(env::args().skip(1)) {
@@ -126,6 +128,10 @@ fn main() {
     }
     if matches.opt_present("raw") {
         flags.raw = true;
+    }
+    if matches.opt_present("a") {
+        flags.addr = true;
+        all = false;
     }
     if all {
         flags.info = true;
@@ -199,6 +205,7 @@ fn dump_file<Endian>(file: &object::File, endian: Endian, flags: &Flags) -> Resu
     let debug_ranges = &load_section(file, endian);
     let debug_str = &load_section(file, endian);
     let debug_types = &load_section(file, endian);
+    let debug_addr = &load_section(file, endian);
 
     if flags.info {
         dump_info(debug_info,
@@ -230,6 +237,9 @@ fn dump_file<Endian>(file: &object::File, endian: Endian, flags: &Flags) -> Resu
     }
     if flags.pubtypes {
         dump_pubtypes(debug_pubtypes, debug_info)?;
+    }
+    if flags.addr {
+        dump_addr(debug_addr)?;
     }
     Ok(())
 }
@@ -1043,5 +1053,10 @@ fn dump_aranges<R: Reader>(debug_aranges: &gimli::DebugAranges<R>,
                  arange.length(),
                  cu_die_offset.0);
     }
+    Ok(())
+}
+
+fn dump_addr<R: Reader> (debug_addr: &gimli::DebugAddr<R>) -> Result<()> {
+    println!("worked and size is {0}", debug_addr.len());
     Ok(())
 }

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,0 +1,95 @@
+///! Functions for parsing DWARF `.debug_info` and `.debug_types` sections.
+
+use endianity::{Endianity, EndianBuf};
+use parser::{Result};
+/// gchampagne: readd use fallible_iterator::FallibleIterator;
+use reader::{Reader, ReaderOffset};
+use Section;
+
+/// An offset into the `.debug_addr` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DebugAddrOffset<T = usize>(pub T);
+
+/// The `DebugAddr` struct represents the DWARF debugging information found in
+/// the `.debug_addr` section.
+#[derive(Debug, Clone, Copy)]
+pub struct DebugAddr<R: Reader> {
+    debug_addr_section: R,
+}
+
+impl<'input, Endian> DebugAddr<EndianBuf<'input, Endian>>
+    where Endian: Endianity
+{
+    /// Construct a new `DebugAddr` instance from the data in the `.debug_addr`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_addr` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on OSX, etc.
+    ///
+    /// ```
+    /// use gimli::{DebugAddr, LittleEndian};
+    /// gchampagne: compelete this
+    /// ```
+    pub fn new(debug_addr_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianBuf::new(debug_addr_section, endian))
+    }
+}
+
+impl <R: Reader> DebugAddr<R> {
+
+    /// gchampagne: add comments + rename?
+    pub fn set_of_entries(&self) -> AddressTableSetIter<R> {
+        AddressTableSetIter {
+            input: self.debug_addr_section.clone(),
+            offset: DebugAddrOffset(R::Offset::from_u8(0)),
+        }
+    }
+    
+    /// cheezus
+    pub fn len(&self) -> R::Offset {
+        self.debug_addr_section.len()
+    }
+}
+
+impl<R: Reader> Section<R> for DebugAddr<R> {
+    fn section_name() -> &'static str {
+        ".debug_info"
+    }
+}
+
+impl<R: Reader> From<R> for DebugAddr<R> {
+    fn from(debug_addr_section : R) -> Self {
+        DebugAddr { debug_addr_section }
+    }
+}
+
+/// An iterator over the sets of entry contained in the debug_addr section
+#[derive(Clone, Debug)]
+pub struct AddressTableSetIter<R: Reader> {
+    input: R,
+    offset: DebugAddrOffset<R::Offset>,
+}
+
+impl<R: Reader> AddressTableSetIter<R> {
+    /// Advance the iterator to the next set on entries 
+    pub fn next(&mut self) -> Result<Option<AddressTableEntryHeader<R, R::Offset>>> {
+        Ok(None)
+    }
+}
+
+/// Header of a set of entry 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AddressTableEntryHeader<R, Offset = usize>
+    where R : Reader<Offset = Offset>,
+          Offset: ReaderOffset
+{
+    /// gchampagne: add comments
+    unit_length: Offset,
+    version: u16,
+    address_size: u8,
+    segment_size: u8,
+    offset: DebugAddrOffset<Offset>,
+    entries_buf: R,
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,9 @@ pub use unit::{EntriesCursor, EntriesTree, EntriesTreeIter, EntriesTreeNode,
                DebuggingInformationEntry};
 pub use unit::{AttrsIter, Attribute, AttributeValue};
 
+mod addr;
+pub use addr::*;
+
 /// A convenience trait for loading DWARF sections from object files.  To be
 /// used like:
 ///


### PR DESCRIPTION
Hi,
I tried adding support for DW_OP_addrx. I am looking for feedback at this point since I'm not 100% everything I did is correct. Also, I am aware we would be missing a test for `resume_with_addr_base`.

I am not sure my interpretation of what DW_OP_addrx does is correct. I interpreted it as doing the same thing as DW_OP_addr, but in the .debug_addr section. In the case the I am correct, the implementation of DW_OP_constx would mostly reuse the same code I think?