### PR TITLE
Reexport `parser::Pointer` at the crate's top level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub mod leb128;
 
 mod parser;
 pub use parser::{Error, Format, Result};
-pub use parser::DebugMacinfoOffset;
+pub use parser::{DebugMacinfoOffset, Pointer};
 
 mod reader;
 pub use reader::{Reader, ReaderOffset};


### PR DESCRIPTION
Fixes #248 

r? @philipc 