### PR TITLE
Changes to README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # `gimli`
 
-[![](http://meritbadge.herokuapp.com/gimli) ![](https://img.shields.io/crates/d/gimli.png)](https://crates.io/crates/gimli) [![](https://docs.rs/gimli/badge.svg)](https://docs.rs/gimli/) [![Build Status](https://travis-ci.org/gimli-rs/gimli.png?branch=master)](https://travis-ci.org/gimli-rs/gimli) [![Coverage Status](https://coveralls.io/repos/github/gimli-rs/gimli/badge.svg?branch=master)](https://coveralls.io/github/gimli-rs/gimli?branch=master)
+[![](http://meritbadge.herokuapp.com/gimli) ![](https://img.shields.io/crates/d/gimli.png)](https://crates.io/crates/gimli)
+[![](https://docs.rs/gimli/badge.svg)](https://docs.rs/gimli/)
+[![Build Status](https://travis-ci.org/gimli-rs/gimli.png?branch=master)](https://travis-ci.org/gimli-rs/gimli)
+[![Coverage Status](https://coveralls.io/repos/github/gimli-rs/gimli/badge.svg?branch=master)](https://coveralls.io/github/gimli-rs/gimli?branch=master)
 
 A lazy, zero-copy parser for the [DWARF debugging format](http://dwarfstd.org/).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # `gimli`
 
-[![](http://meritbadge.herokuapp.com/gimli) ![](https://img.shields.io/crates/d/gimli.png)](https://crates.io/crates/gimli)
+[![](http://meritbadge.herokuapp.com/gimli) ![](https://img.shields.io/crates/d/gimli.svg)](https://crates.io/crates/gimli)
 [![](https://docs.rs/gimli/badge.svg)](https://docs.rs/gimli/)
-[![Build Status](https://travis-ci.org/gimli-rs/gimli.png?branch=master)](https://travis-ci.org/gimli-rs/gimli)
+[![Build Status](https://travis-ci.org/gimli-rs/gimli.svg?branch=master)](https://travis-ci.org/gimli-rs/gimli)
 [![Coverage Status](https://coveralls.io/repos/github/gimli-rs/gimli/badge.svg?branch=master)](https://coveralls.io/github/gimli-rs/gimli?branch=master)
 
 A lazy, zero-copy parser for the [DWARF debugging format](http://dwarfstd.org/).


### PR DESCRIPTION
Changes:
- Separated by newline
- Uses SVG for all badges
    - PNG results in a pixelation on macOS when using a retina display