### PR TITLE
Use 'write' macro instead of 'format' in 'dw'

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -69,9 +69,9 @@ macro_rules! dw {
                     $(
                         $name => f.pad(stringify!($name)),
                     )+
-                    otherwise => f.pad(&format!("Unknown {}: {}",
-                                                stringify!($struct_name),
-                                                otherwise.0)),
+                    otherwise => write!(f, "Unknown {}: {}",
+                                        stringify!($struct_name),
+                                        otherwise.0),
                 }
             }
         }


### PR DESCRIPTION
Using `format!` allocates a new `String` that then immediately gets dropped.