### PR TITLE
Update to memmap 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ fallible-iterator = "0.1.2"
 
 [dev-dependencies]
 getopts = "0.2"
-memmap = "0.5.2"
+memmap = "0.6"
 object = "0.4.0"
 test-assembler = "0.1.3"
 

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -169,7 +169,7 @@ fn main() {
                 continue;
             }
         };
-        let file = match memmap::Mmap::open(&file, memmap::Protection::Read) {
+        let file = match unsafe { memmap::Mmap::map(&file) } {
             Ok(mmap) => mmap,
             Err(err) => {
                 println!(
@@ -180,7 +180,7 @@ fn main() {
                 continue;
             }
         };
-        let file = match object::File::parse(unsafe { file.as_slice() }) {
+        let file = match object::File::parse(&*file) {
             Ok(file) => file,
             Err(err) => {
                 println!("Failed to parse file '{}': {}", file_path, err);


### PR DESCRIPTION
Update to memmap 0.6

`memmap` 0.6.0 introduces major API changes in anticipation of a 1.0
release. See https://github.com/danburkert/memmap-rs/releases/tag/0.6.0
for more information. CC danburkert/memmap-rs#33.