### PR TITLE
Fix code coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - libelf-dev
     - libdw-dev
     - binutils-dev
+    - libiberty-dev # same
 
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/coverage
+++ b/coverage
@@ -16,7 +16,7 @@
 export RUSTFLAGS="-C link-dead-code"
 TEST_FILES=$(cargo test 2>&1 >/dev/null | awk '/^     Running target\/debug\// { print $2 }')
 
-KCOV_OPTS="--verify --exclude-pattern=/.cargo"
+KCOV_OPTS="--verify --exclude-pattern=/.cargo --include-pattern=$PWD"
 OUT_DIR=target/kcov
 
 for f in $TEST_FILES; do


### PR DESCRIPTION
kcov needs libiberty for --verify to work, and it also has a bug that causes
it to crash dealing with Rust source files from the standard library, so
use --include-pattern to ignore anything that's not from this crate.