### PR TITLE
Add #![no_std] support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
       with_debug_info=$(find ./target/debug -type f -perm -100 | grep gimli | head -n 1) &&
       travis-cargo run -- --example dwarfdump "$with_debug_info" > /dev/null
   )) &&
+  travis-cargo --only nightly build -- --no-default-features --features nightly &&
   travis-cargo --only stable doc
 
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ travis-ci = { repository = "gimli-rs/gimli" }
 coveralls = { repository = "gimli-rs/gimli" }
 
 [dependencies]
-arrayvec = "0.4.6"
-byteorder = "1"
-fallible-iterator = "0.1.2"
+arrayvec = { version = "0.4.6", default-features = false }
+byteorder = { version = "1.0", default-features = false }
+fallible-iterator = { version = "0.1.4", default-features = false }
 
 [dev-dependencies]
 getopts = "0.2"
@@ -26,4 +26,6 @@ object = "0.6"
 test-assembler = "0.1.3"
 
 [features]
-nightly = []
+std = ["fallible-iterator/std"]
+nightly = ["fallible-iterator/alloc"]
+default = ["std"]

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -5,7 +5,8 @@ use endianity::{EndianBuf, Endianity};
 use parser::{Error, Format, Result};
 use reader::Reader;
 use unit::UnitHeader;
-use std::collections::btree_map;
+use vec::Vec;
+use btree_map;
 use Section;
 
 /// An offset into the `.debug_abbrev` section.

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -5,7 +5,7 @@ use endianity::{EndianBuf, Endianity};
 use parser::{Error, Format, Result};
 use reader::Reader;
 use unit::UnitHeader;
-use std::collections::hash_map;
+use std::collections::btree_map;
 use Section;
 
 /// An offset into the `.debug_abbrev` section.
@@ -80,7 +80,7 @@ impl<R: Reader> From<R> for DebugAbbrev<R> {
 #[derive(Debug, Default, Clone)]
 pub struct Abbreviations {
     vec: Vec<Abbreviation>,
-    map: hash_map::HashMap<u64, Abbreviation>,
+    map: btree_map::BTreeMap<u64, Abbreviation>,
 }
 
 impl Abbreviations {
@@ -88,7 +88,7 @@ impl Abbreviations {
     fn empty() -> Abbreviations {
         Abbreviations {
             vec: Vec::new(),
-            map: hash_map::HashMap::new(),
+            map: btree_map::BTreeMap::new(),
         }
     }
 
@@ -116,8 +116,8 @@ impl Abbreviations {
             }
         }
         match self.map.entry(abbrev.code) {
-            hash_map::Entry::Occupied(_) => Err(()),
-            hash_map::Entry::Vacant(entry) => {
+            btree_map::Entry::Occupied(_) => Err(()),
+            btree_map::Entry::Vacant(entry) => {
                 entry.insert(abbrev);
                 Ok(())
             }

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -13,6 +13,7 @@ use std::marker::PhantomData;
 use std::cmp::{Ord, Ordering};
 use std::mem;
 use std::str;
+use boxed::Box;
 use Section;
 
 /// An offset into the `.debug_frame` section.
@@ -3105,6 +3106,7 @@ mod tests {
     use std::marker::PhantomData;
     use std::mem;
     use std::u64;
+    use vec::Vec;
     use test_util::GimliSectionMethods;
 
     type DebugFrameCie<R, O = usize> = CommonInformationEntry<DebugFrame<R>, R, O>;

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -2,11 +2,12 @@
 
 use byteorder;
 use byteorder::ByteOrder;
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::mem;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 use std::str;
+use string::String;
+use borrow::Cow;
 use parser::{Error, Result};
 use reader::Reader;
 

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -51,6 +51,7 @@ fn low_bits_of_byte(byte: u8) -> u8 {
 }
 
 #[inline]
+#[allow(dead_code)]
 fn low_bits_of_u64(val: u64) -> u8 {
     let byte = val & (std::u8::MAX as u64);
     low_bits_of_byte(byte as u8)
@@ -119,6 +120,7 @@ pub mod read {
 }
 
 /// A module for writing integers encoded as LEB128.
+#[cfg(feature = "std")]
 pub mod write {
     use super::{low_bits_of_u64, CONTINUATION_BIT};
     use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,43 @@
 // False positives when block expressions are used inside an assertion.
 #![allow(panic_params)]
 
+#![no_std]
+#![cfg_attr(feature = "nightly", feature(alloc))]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate core as std;
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 extern crate arrayvec;
 extern crate byteorder;
 extern crate fallible_iterator;
+
+#[cfg(feature = "std")]
+mod imports {
+    pub use std::boxed;
+    pub use std::vec;
+    pub use std::string;
+    pub use std::borrow;
+    pub use std::collections::btree_map;
+}
+
+#[cfg(not(feature = "std"))]
+mod imports {
+    pub use alloc::boxed;
+    pub use alloc::vec;
+    pub use alloc::string;
+    pub use alloc::borrow;
+    pub use alloc::btree_map;
+}
+
+use imports::*;
 
 mod cfi;
 pub use cfi::*;

--- a/src/line.rs
+++ b/src/line.rs
@@ -3,6 +3,7 @@ use endianity::{EndianBuf, Endianity};
 use parser;
 use reader::{Reader, ReaderOffset};
 use std::fmt;
+use vec::Vec;
 use Section;
 
 /// An offset into the `.debug_line` section.

--- a/src/op.rs
+++ b/src/op.rs
@@ -5,6 +5,7 @@ use parser::{Error, Format};
 use reader::{Reader, ReaderOffset};
 use unit::{DebugInfoOffset, UnitOffset};
 use std::mem;
+use vec::Vec;
 
 /// A reference to a DIE, either relative to the current CU or
 /// relative to the section.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,9 @@
 //! Functions for parsing DWARF debugging information.
 
-use std::error;
 use std::fmt::{self, Debug};
-use std::io;
 use std::result;
+#[cfg(feature = "std")]
+use std::{io, error};
 use cfi::BaseAddresses;
 use constants;
 use reader::{Reader, ReaderOffset};
@@ -143,8 +143,9 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
+impl Error {
+    /// A short description of the error.
+    pub fn description(&self) -> &str {
         match *self {
             Error::Io => "An I/O error occurred while reading.",
             Error::CfiRelativePointerButCfiBaseIsUndefined => {
@@ -259,6 +260,14 @@ impl error::Error for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        Error::description(self)
+    }
+}
+
+#[cfg(feature = "std")]
 impl From<io::Error> for Error {
     fn from(_: io::Error) -> Self {
         Error::Io

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Sub};
+use borrow::Cow;
 
 use endianity::Endianity;
 use leb128;

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -2,6 +2,8 @@
 
 extern crate test_assembler;
 
+use vec::Vec;
+
 use leb128;
 use self::test_assembler::{Endian, Section, ToLabelOrNum};
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -2816,6 +2816,7 @@ mod tests {
     use str::DebugStrOffset;
     use std;
     use std::cell::Cell;
+    use vec::Vec;
     use test_util::GimliSectionMethods;
 
     // Mixin methods for `Section` to help define binary test data.


### PR DESCRIPTION
Fixes #138.

This was surprisingly easy. There are essentially no meaningful changes required.