### PR TITLE
Optimise line number iteration

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -195,12 +195,16 @@ where
         let maximum_operations_per_instruction =
             self.header().maximum_operations_per_instruction as u64;
 
-        let op_index_with_advance = self.row.registers.op_index + operation_advance;
-
-        self.row.registers.address += minimum_instruction_length *
-            (op_index_with_advance / maximum_operations_per_instruction);
-
-        self.row.registers.op_index = op_index_with_advance % maximum_operations_per_instruction;
+        if maximum_operations_per_instruction == 1 {
+            self.row.registers.address += minimum_instruction_length * operation_advance;
+            self.row.registers.op_index = 0;
+        } else {
+            let op_index_with_advance = self.row.registers.op_index + operation_advance;
+            self.row.registers.address += minimum_instruction_length
+                * (op_index_with_advance / maximum_operations_per_instruction);
+            self.row.registers.op_index =
+                op_index_with_advance % maximum_operations_per_instruction;
+        }
     }
 
     fn adjust_opcode(&self, opcode: u8) -> u8 {

--- a/src/line.rs
+++ b/src/line.rs
@@ -713,6 +713,8 @@ impl<R: Reader> OpcodesIter<R> {
     ///
     /// Unfortunately, the `header` parameter means that this cannot be a
     /// `FallibleIterator`.
+    #[allow(inline_always)]
+    #[inline(always)]
     pub fn next_opcode(
         &mut self,
         header: &LineNumberProgramHeader<R>,

--- a/src/line.rs
+++ b/src/line.rs
@@ -215,16 +215,15 @@ where
     fn exec_special_opcode(&mut self, opcode: u8) {
         let adjusted_opcode = self.adjust_opcode(opcode);
 
-        // Step 1
-
-        let line_base = self.header().line_base as i64;
         let line_range = self.header().line_range;
-        let line_increment = line_base + (adjusted_opcode % line_range) as i64;
-        self.apply_line_advance(line_increment);
+        let line_advance = adjusted_opcode % line_range;
+        let operation_advance = adjusted_opcode / line_range;
+
+        // Step 1
+        let line_base = self.header().line_base as i64;
+        self.apply_line_advance(line_base + line_advance as i64);
 
         // Step 2
-
-        let operation_advance = adjusted_opcode / self.header().line_range;
         self.apply_operation_advance(operation_advance as u64);
     }
 


### PR DESCRIPTION
Useful for addr2line. Adds another `inline(always)` unfortunately.