### PR TITLE
Empty ranges

### DIFF
--- a/src/loclists.rs
+++ b/src/loclists.rs
@@ -471,11 +471,6 @@ impl<R: Reader> LocListIter<R> {
                 }
             };
 
-            if range.begin == range.end {
-                // An empty location list entry, skip it.
-                continue;
-            }
-
             if range.begin > range.end {
                 self.raw.input.empty();
                 return Err(Error::InvalidLocationAddressRange);
@@ -593,6 +588,16 @@ mod tests {
             locations.next(),
             Ok(Some(LocationListEntry {
                 range: Range {
+                    begin: 0x02010600,
+                    end: 0x02010600,
+                },
+                data: Expression(EndianBuf::new(&[4, 0, 0, 0], LittleEndian)),
+            }))
+        );
+        assert_eq!(
+            locations.next(),
+            Ok(Some(LocationListEntry {
+                range: Range {
                     begin: 0x02010800,
                     end: 0x02010900,
                 },
@@ -600,7 +605,7 @@ mod tests {
             }))
         );
 
-        // An empty location range followed by a normal location.
+        // A normal location.
         assert_eq!(
             locations.next(),
             Ok(Some(LocationListEntry {
@@ -612,7 +617,7 @@ mod tests {
             }))
         );
 
-        // An empty location range followed by a normal location.
+        // A normal location.
         assert_eq!(
             locations.next(),
             Ok(Some(LocationListEntry {
@@ -746,6 +751,16 @@ mod tests {
             locations.next(),
             Ok(Some(LocationListEntry {
                 range: Range {
+                    begin: 0x02010600,
+                    end: 0x02010600,
+                },
+                data: Expression(EndianBuf::new(&[4, 0, 0, 0], LittleEndian)),
+            }))
+        );
+        assert_eq!(
+            locations.next(),
+            Ok(Some(LocationListEntry {
+                range: Range {
                     begin: 0x02010800,
                     end: 0x02010900,
                 },
@@ -753,7 +768,7 @@ mod tests {
             }))
         );
 
-        // An empty location range followed by a normal location.
+        // A normal location.
         assert_eq!(
             locations.next(),
             Ok(Some(LocationListEntry {
@@ -765,7 +780,7 @@ mod tests {
             }))
         );
 
-        // An empty location range followed by a normal location.
+        // A normal location.
         assert_eq!(
             locations.next(),
             Ok(Some(LocationListEntry {
@@ -887,6 +902,16 @@ mod tests {
             locations.next(),
             Ok(Some(LocationListEntry {
                 range: Range {
+                    begin: 0x02010600,
+                    end: 0x02010600,
+                },
+                data: Expression(EndianBuf::new(&[4, 0, 0, 0], LittleEndian)),
+            }))
+        );
+        assert_eq!(
+            locations.next(),
+            Ok(Some(LocationListEntry {
+                range: Range {
                     begin: 0x02010800,
                     end: 0x02010900,
                 },
@@ -988,6 +1013,16 @@ mod tests {
         );
 
         // An empty location range followed by a normal location.
+        assert_eq!(
+            locations.next(),
+            Ok(Some(LocationListEntry {
+                range: Range {
+                    begin: 0x02010600,
+                    end: 0x02010600,
+                },
+                data: Expression(EndianBuf::new(&[4, 0, 0, 0], LittleEndian)),
+            }))
+        );
         assert_eq!(
             locations.next(),
             Ok(Some(LocationListEntry {

--- a/src/rnglists.rs
+++ b/src/rnglists.rs
@@ -441,11 +441,6 @@ impl<R: Reader> RngListIter<R> {
                 }
             };
 
-            if range.begin == range.end {
-                // An empty range list entry, skip it.
-                continue;
-            }
-
             if range.begin > range.end {
                 self.raw.input.empty();
                 return Err(Error::InvalidAddressRange);
@@ -594,6 +589,13 @@ mod tests {
         assert_eq!(
             ranges.next(),
             Ok(Some(Range {
+                begin: 0x02010600,
+                end: 0x02010600,
+            }))
+        );
+        assert_eq!(
+            ranges.next(),
+            Ok(Some(Range {
                 begin: 0x02010800,
                 end: 0x02010900,
             }))
@@ -709,6 +711,13 @@ mod tests {
         );
 
         // An empty range followed by a normal range.
+        assert_eq!(
+            ranges.next(),
+            Ok(Some(Range {
+                begin: 0x02010600,
+                end: 0x02010600,
+            }))
+        );
         assert_eq!(
             ranges.next(),
             Ok(Some(Range {
@@ -852,6 +861,13 @@ mod tests {
         assert_eq!(
             ranges.next(),
             Ok(Some(Range {
+                begin: 0x02010600,
+                end: 0x02010600,
+            }))
+        );
+        assert_eq!(
+            ranges.next(),
+            Ok(Some(Range {
                 begin: 0x02010800,
                 end: 0x02010900,
             }))
@@ -939,6 +955,13 @@ mod tests {
         );
 
         // An empty range followed by a normal range.
+        assert_eq!(
+            ranges.next(),
+            Ok(Some(Range {
+                begin: 0x02010600,
+                end: 0x02010600,
+            }))
+        );
         assert_eq!(
             ranges.next(),
             Ok(Some(Range {


### PR DESCRIPTION
`dwarfdump` panics on optimized Firefox `libxul.so`. The problem is that `dwarfdump` iterates through location lists and range lists by running "raw" and "cooked" iterators in parallel to print both raw and cooked results. My `libxul.so` contains empty ranges so the "cooked" iterator finishes early and `dwarfdump` panics trying to unwrap `None`.

I think any code processing ranges should be able to handle empty ranges without writing special cases for them.