### PR TITLE
Parallelize dwarfdump per-unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ byteorder = { version = "1.0", default-features = false }
 fallible-iterator = { version = "0.1.4", default-features = false }
 
 [dev-dependencies]
+crossbeam = "0.3.2"
 getopts = "0.2"
 memmap = "0.6"
+num_cpus = "1"
 object = "0.7"
 test-assembler = "0.1.3"
 


### PR DESCRIPTION
Maybe you won't like the memory usage increase, but this is a pretty nice speedup when you're not writing the results to a file. Fearless concurrency FTW.

I have a followup patch that adds a dwarfdump option to drop the output for compilation units where the output doesn't match a given regex, which makes this more useful.