### PR TITLE
Skip compilatiion units whose output doesn't match a given regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ getopts = "0.2"
 memmap = "0.6"
 num_cpus = "1"
 object = "0.7"
+regex = "0.2.6"
 test-assembler = "0.1.3"
 
 [features]


### PR DESCRIPTION
Being able to write out 25G of pretty-printed DWARF isn't all that useful on its own. It's much more useful if we can filter the output to specific compilation units containing output of interest. Here I add an option to print the output for a compilation unit only if it matches a specific regex. Note that this is much more useful than filtering by compilation unit name; for example we can search for mentions of specific function or type names without needing to know which compilation units reference those names.