### PR TITLE
[WIP] Changes to dwarfdump required for Cow in object interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ crossbeam = "0.3.2"
 getopts = "0.2"
 memmap = "0.6"
 num_cpus = "1"
-object = "0.7"
+object = { path = "../object" }
 rayon = "1.0"
 regex = "0.2.6"
 test-assembler = "0.1.3"


### PR DESCRIPTION
This is for the `Cow` changes introduced in https://github.com/gimli-rs/object/pull/52

Once that merges and a new `object` is published, I will fix up this PR to use the new `object` from crates.io rather than my local path copy.

Unfortunately, these `object` changes mean that the data slices are `'file` rather than `'input` now, and the type inference trick also doesn't work anymore. Ah well.