### PR TITLE
Optimize EndianReader to use ptr/len

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ coveralls = { repository = "gimli-rs/gimli" }
 arrayvec = { version = "0.4.6", default-features = false }
 byteorder = { version = "1.0", default-features = false }
 fallible-iterator = { version = "0.1.4", default-features = false }
+stable_deref_trait = "1.0.0"
 
 [dev-dependencies]
 crossbeam = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,7 @@ extern crate core as std;
 extern crate arrayvec;
 extern crate byteorder;
 extern crate fallible_iterator;
+extern crate stable_deref_trait;
 
 #[cfg(feature = "std")]
 mod imports {
@@ -213,6 +214,8 @@ mod imports {
 }
 
 use imports::*;
+
+pub use stable_deref_trait::{CloneStableDeref, StableDeref};
 
 mod cfi;
 pub use cfi::*;


### PR DESCRIPTION
This requires `stable_deref_trait::CloneStableDeref` for the bytes. If needed in future, we could relax that to `stable_deref_trait::StableDeref` by implementing a `Clone` for `SubRange` that recalculates the `ptr`.

This doesn't show any significant change in the gimli benchmarks, but I have modified `addr2line` to use `Rc<Cow<[u8]>>`, and it shows about 15% improvement for all operations in that (both context creation and lookup).