### PR TITLE
Properly handle DW_CFA_GNU_args_size

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -610,6 +610,9 @@ fn dump_cfi_instructions<R: Reader, W: Write>(
                 RestoreState => {
                     writeln!(w, "                DW_CFA_restore_state")?;
                 }
+                ArgsSize { size } => {
+                    writeln!(w, "                DW_CFA_GNU_args_size ({})", size)?;
+                }
                 Nop => {
                     writeln!(w, "                DW_CFA_nop")?;
                 }

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -6204,7 +6204,7 @@ mod tests {
             mem::size_of::<
                 UnwindContext<EhFrame<EndianSlice<NativeEndian>>, EndianSlice<NativeEndian>>,
             >(),
-            5384
+            5416
         );
     }
 

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -2283,6 +2283,12 @@ where
                 self.ctx.set_start_address(start_address);
             }
 
+            // GNU Extension. Save the size somewhere so the unwinder can use
+            // it when restoring IP
+            ArgsSize { size } => {
+                // TODO: Ignore for now.
+            }
+
             // No operation.
             Nop => {}
         };
@@ -2905,6 +2911,19 @@ pub enum CallFrameInstruction<R: Reader> {
     /// > them in the current row.
     RestoreState,
 
+
+    /// > DW_CFA_GNU_args_size
+    /// > 
+    /// > GNU Extension
+    /// >
+    /// > The DW_CFA_GNU_args_size instruction takes an unsigned LEB128 operand
+    /// > representing an argument size. This instruction specifies the total of
+    /// > the size of the arguments which have been pushed onto the stack.
+    ArgsSize {
+        /// The size of the arguments which have been pushed onto the stack
+        size: u64
+    },
+
     // 6.4.2.5 Padding Instruction
     /// > 1. DW_CFA_nop
     /// >
@@ -3096,6 +3115,13 @@ impl<R: Reader> CallFrameInstruction<R> {
                 Ok(CallFrameInstruction::ValExpression {
                     register: register,
                     expression: Expression(expression),
+                })
+            }
+
+            constants::DW_CFA_GNU_args_size => {
+                let size = input.read_uleb128()?;
+                Ok(CallFrameInstruction::ArgsSize {
+                    size
                 })
             }
 


### PR DESCRIPTION
Pretty simple, really. It stores the value of DW_CFA_GNU_args_size inside the UnwindTableRow. Defaults to 0.

As we talked in #130 unwinders should add this value to SP when setting IP.

CC @main-- 

So indeed, i686-pc-windows-gnu generates those. I've been unable to make any other target generate them, even with custom target changing the data-layout. So testing this is a bit painful since there's no 32-bit x86 backend to unwind-rs (I might work on this soon though!)