### PR TITLE
Allow setting the target address size for CIE version < 4 

### DIFF
--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -5674,9 +5674,9 @@ mod tests {
         let section = section
             // +4 for the FDE length before the CIE offset.
             .mark(&start_of_fde1)
-            .fde(Endian::Little, (&end_of_cie - &start_of_cie + 4) as u64, &mut fde1)
+            .fde(Endian::Little, (&start_of_fde1 - &start_of_cie + 4) as u64, &mut fde1)
             .mark(&start_of_fde2)
-            .fde(Endian::Little, (&end_of_cie - &start_of_cie + 4) as u64, &mut fde2);
+            .fde(Endian::Little, (&start_of_fde2 - &start_of_cie + 4) as u64, &mut fde2);
 
         section.start().set_const(0);
         let section = section.get_contents().unwrap();
@@ -5708,7 +5708,10 @@ mod tests {
 
         let bases = Default::default();
 
-        let f = |_offset| Ok(cie.clone());
+        let f = |o: EhFrameOffset| {
+            assert_eq!(o, EhFrameOffset(start_of_cie.value().unwrap() as usize));
+            Ok(cie.clone())
+        };
         assert_eq!(table.lookup_and_parse(9, &bases, eh_frame.clone(), f), Ok(fde1.clone()));
         assert_eq!(table.lookup_and_parse(10, &bases, eh_frame.clone(), f), Ok(fde1.clone()));
         assert_eq!(table.lookup_and_parse(11, &bases, eh_frame.clone(), f), Ok(fde1));

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -338,16 +338,14 @@ fn test_parse_self_debug_pubtypes() {
     }
 }
 
-// Because `.eh_frame` doesn't contain address sizes, we need to assume the
-// native word size, so this test is only valid on 64-bit machines (as the
-// `.eh_frame` fixture data was created on a 64-bit machine).
-#[cfg(target_pointer_width = "64")]
 #[test]
 fn test_parse_self_eh_frame() {
     use gimli::{BaseAddresses, CieOrFde, EhFrame, UnwindSection};
 
     let eh_frame = read_section("eh_frame");
-    let eh_frame = EhFrame::new(&eh_frame, LittleEndian);
+    let mut eh_frame = EhFrame::new(&eh_frame, LittleEndian);
+    // The `.eh_frame` fixture data was created on a 64-bit machine.
+    eh_frame.set_address_size(8);
 
     let bases = BaseAddresses::default().set_cfi(0).set_data(0).set_text(0);
     let mut entries = eh_frame.entries(&bases);


### PR DESCRIPTION
Partial fix for #318 

It's a bit ugly that this needs to be set after section creation, but `Section<R: Reader>: From<R>` doesn't allow extra parameters.