### PR TITLE
tarpaulin currently requires nightly Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    # Coverage should only run on Linux and stable Rust.
-    - rust: stable
+    # Coverage should only run on Linux. tarpaulin currently requires nightly Rust.
+    - rust: nightly
       os: linux
       sudo: required
       env: GIMLI_JOB="coverage"     GIMLI_PROFILE=

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -39,7 +39,7 @@ case "$GIMLI_JOB" in
 
     "coverage")
         RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin
-        cargo tarpaulin --verbose --no-count --ciserver travis-ci --coveralls "$TRAVIS_JOB_ID";
+        cargo tarpaulin --verbose --ciserver travis-ci --coveralls "$TRAVIS_JOB_ID";
         ;;
 
     "cross")


### PR DESCRIPTION
Also --no-count option no longer exists (it is the default).