### PR TITLE
Add read::Dwarf

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -874,7 +874,7 @@ where
     let out = io::stdout();
     writeln!(&mut BufWriter::new(out.lock()), "\n.debug_info")?;
 
-    let units = dwarf.debug_info.units().collect::<Vec<_>>().unwrap();
+    let units = dwarf.units().collect::<Vec<_>>().unwrap();
     let process_unit =
         |unit: CompilationUnitHeader<R, R::Offset>, buf: &mut Vec<u8>| -> Result<()> {
             let abbrevs = match dwarf.abbreviations(&unit) {
@@ -929,7 +929,7 @@ fn dump_types<R: Reader, W: Write>(
 ) -> Result<()> {
     writeln!(w, "\n.debug_types")?;
 
-    let mut iter = dwarf.debug_types.units();
+    let mut iter = dwarf.type_units();
     while let Some(unit) = iter.next()? {
         let abbrevs = match dwarf.type_abbreviations(&unit) {
             Ok(abbrevs) => abbrevs,
@@ -1666,7 +1666,7 @@ fn dump_range_list<R: Reader, W: Write>(
 }
 
 fn dump_line<R: Reader, W: Write>(w: &mut W, dwarf: &gimli::Dwarf<R>) -> Result<()> {
-    let mut iter = dwarf.debug_info.units();
+    let mut iter = dwarf.units();
     while let Some(ref unit) = iter.next()? {
         writeln!(
             w,

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -869,7 +869,7 @@ where
     let units = dwarf.debug_info.units().collect::<Vec<_>>().unwrap();
     let process_unit =
         |unit: CompilationUnitHeader<R, R::Offset>, buf: &mut Vec<u8>| -> Result<()> {
-            let abbrevs = match unit.abbreviations(&dwarf.debug_abbrev) {
+            let abbrevs = match dwarf.abbreviations(&unit) {
                 Ok(abbrevs) => abbrevs,
                 Err(err) => {
                     writeln!(
@@ -923,7 +923,7 @@ fn dump_types<R: Reader, W: Write>(
 
     let mut iter = dwarf.debug_types.units();
     while let Some(unit) = iter.next()? {
-        let abbrevs = match unit.abbreviations(&dwarf.debug_abbrev) {
+        let abbrevs = match dwarf.type_abbreviations(&unit) {
             Ok(abbrevs) => abbrevs,
             Err(err) => {
                 writeln!(
@@ -1683,7 +1683,7 @@ fn dump_line_program<R: Reader, W: Write>(
     unit: &CompilationUnitHeader<R, R::Offset>,
     dwarf: &gimli::Dwarf<R>,
 ) -> Result<()> {
-    let abbrevs = unit.abbreviations(&dwarf.debug_abbrev)?;
+    let abbrevs = dwarf.abbreviations(unit)?;
 
     let mut cursor = unit.entries(&abbrevs);
     cursor.next_dfs()?;

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -866,7 +866,6 @@ fn dump_cfi_instructions<R: Reader, W: Write>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn dump_info<R: Reader>(dwarf: &gimli::Dwarf<R, R::Endian>, flags: &Flags) -> Result<()>
 where
     R::Endian: Send + Sync,
@@ -921,7 +920,6 @@ where
     parallel_output(16, units, process_unit)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn dump_types<R: Reader, W: Write>(
     w: &mut W,
     dwarf: &gimli::Dwarf<R, R::Endian>,

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -867,7 +867,7 @@ fn dump_cfi_instructions<R: Reader, W: Write>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn dump_info<R: Reader>(dwarf: &gimli::Dwarf<R>, flags: &Flags) -> Result<()>
+fn dump_info<R: Reader>(dwarf: &gimli::Dwarf<R, R::Endian>, flags: &Flags) -> Result<()>
 where
     R::Endian: Send + Sync,
 {
@@ -924,7 +924,7 @@ where
 #[allow(clippy::too_many_arguments)]
 fn dump_types<R: Reader, W: Write>(
     w: &mut W,
-    dwarf: &gimli::Dwarf<R>,
+    dwarf: &gimli::Dwarf<R, R::Endian>,
     flags: &Flags,
 ) -> Result<()> {
     writeln!(w, "\n.debug_types")?;
@@ -1001,7 +1001,7 @@ fn dump_entries<R: Reader, W: Write>(
     address_size: u8,
     version: u16,
     format: gimli::Format,
-    dwarf: &gimli::Dwarf<R>,
+    dwarf: &gimli::Dwarf<R, R::Endian>,
     flags: &Flags,
 ) -> Result<()> {
     let mut unit = Unit {
@@ -1098,7 +1098,7 @@ fn dump_attr_value<R: Reader, W: Write>(
     w: &mut W,
     attr: &gimli::Attribute<R>,
     unit: &Unit<R>,
-    dwarf: &gimli::Dwarf<R>,
+    dwarf: &gimli::Dwarf<R, R::Endian>,
 ) -> Result<()> {
     let value = attr.value();
     match value {
@@ -1665,7 +1665,7 @@ fn dump_range_list<R: Reader, W: Write>(
     Ok(())
 }
 
-fn dump_line<R: Reader, W: Write>(w: &mut W, dwarf: &gimli::Dwarf<R>) -> Result<()> {
+fn dump_line<R: Reader, W: Write>(w: &mut W, dwarf: &gimli::Dwarf<R, R::Endian>) -> Result<()> {
     let mut iter = dwarf.units();
     while let Some(ref unit) = iter.next()? {
         writeln!(
@@ -1689,7 +1689,7 @@ fn dump_line<R: Reader, W: Write>(w: &mut W, dwarf: &gimli::Dwarf<R>) -> Result<
 fn dump_line_program<R: Reader, W: Write>(
     w: &mut W,
     unit: &CompilationUnitHeader<R, R::Offset>,
-    dwarf: &gimli::Dwarf<R>,
+    dwarf: &gimli::Dwarf<R, R::Endian>,
 ) -> Result<()> {
     let abbrevs = dwarf.abbreviations(unit)?;
 

--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -11,7 +11,7 @@ use read::{EndianSlice, Error, Reader, Result, Section, UnitHeader};
 /// The `DebugAbbrev` struct represents the abbreviations describing
 /// `DebuggingInformationEntry`s' attribute names and forms found in the
 /// `.debug_abbrev` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugAbbrev<R: Reader> {
     debug_abbrev_section: R,
 }

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,0 +1,31 @@
+use read::{
+    DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugTypes, LocationLists, RangeLists, Reader,
+};
+
+/// All of the commonly used DWARF sections, and other common information.
+#[derive(Debug, Default)]
+pub struct Dwarf<R: Reader> {
+    /// The endianity of bytes that are read.
+    pub endian: R::Endian,
+
+    /// The `.debug_abbrev` section.
+    pub debug_abbrev: DebugAbbrev<R>,
+
+    /// The `.debug_info` section.
+    pub debug_info: DebugInfo<R>,
+
+    /// The `.debug_line` section.
+    pub debug_line: DebugLine<R>,
+
+    /// The `.debug_str` section.
+    pub debug_str: DebugStr<R>,
+
+    /// The `.debug_types` section.
+    pub debug_types: DebugTypes<R>,
+
+    /// The location lists in the `.debug_loc` and `.debug_loclists` sections.
+    pub locations: LocationLists<R>,
+
+    /// The range lists in the `.debug_ranges` and `.debug_rnglists` sections.
+    pub ranges: RangeLists<R>,
+}

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,5 +1,6 @@
 use read::{
-    DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugTypes, LocationLists, RangeLists, Reader,
+    Abbreviations, CompilationUnitHeader, DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugTypes,
+    LocationLists, RangeLists, Reader, Result, TypeUnitHeader,
 };
 
 /// All of the commonly used DWARF sections, and other common information.
@@ -28,4 +29,23 @@ pub struct Dwarf<R: Reader> {
 
     /// The range lists in the `.debug_ranges` and `.debug_rnglists` sections.
     pub ranges: RangeLists<R>,
+}
+
+impl<R: Reader> Dwarf<R> {
+    /// Parse the abbreviations for a compilation unit.
+    // TODO: provide caching of abbreviations
+    #[inline]
+    pub fn abbreviations(
+        &self,
+        unit: &CompilationUnitHeader<R, R::Offset>,
+    ) -> Result<Abbreviations> {
+        unit.abbreviations(&self.debug_abbrev)
+    }
+
+    /// Parse the abbreviations for a type unit.
+    // TODO: provide caching of abbreviations
+    #[inline]
+    pub fn type_abbreviations(&self, unit: &TypeUnitHeader<R, R::Offset>) -> Result<Abbreviations> {
+        unit.abbreviations(&self.debug_abbrev)
+    }
 }

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,6 +1,7 @@
 use read::{
-    Abbreviations, Attribute, AttributeValue, CompilationUnitHeader, DebugAbbrev, DebugInfo,
-    DebugLine, DebugStr, DebugTypes, LocationLists, RangeLists, Reader, Result, TypeUnitHeader,
+    Abbreviations, Attribute, AttributeValue, CompilationUnitHeader, CompilationUnitHeadersIter,
+    DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugTypes, LocationLists, RangeLists, Reader,
+    Result, TypeUnitHeader, TypeUnitHeadersIter,
 };
 
 /// All of the commonly used DWARF sections, and other common information.
@@ -35,6 +36,25 @@ pub struct Dwarf<R: Reader> {
 }
 
 impl<R: Reader> Dwarf<R> {
+    /// Iterate the compilation- and partial-units in this
+    /// `.debug_info` section.
+    ///
+    /// Can be [used with
+    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
+    #[inline]
+    pub fn units(&self) -> CompilationUnitHeadersIter<R> {
+        self.debug_info.units()
+    }
+
+    /// Iterate the type-units in this `.debug_types` section.
+    ///
+    /// Can be [used with
+    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
+    #[inline]
+    pub fn type_units(&self) -> TypeUnitHeadersIter<R> {
+        self.debug_types.units()
+    }
+
     /// Parse the abbreviations for a compilation unit.
     // TODO: provide caching of abbreviations
     #[inline]

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -12,7 +12,7 @@ use read::{Error, Reader, Result};
 /// A `&[u8]` slice with endianity metadata.
 ///
 /// This implements the `Reader` trait, which is used for all reading of DWARF sections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EndianSlice<'input, Endian>
 where
     Endian: Endianity,

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -9,7 +9,7 @@ use read::{EndianSlice, Error, Reader, ReaderOffset, Result, Section};
 
 /// The `DebugLine` struct contains the source location to instruction mapping
 /// found in the `.debug_line` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugLine<R: Reader> {
     debug_line_section: R,
 }

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -71,7 +71,8 @@ impl<R: Reader> DebugLine<R> {
     ) -> Result<IncompleteLineNumberProgram<R, R::Offset>> {
         let input = &mut self.debug_line_section.clone();
         input.skip(offset.0)?;
-        let header = LineNumberProgramHeader::parse(input, address_size, comp_dir, comp_name)?;
+        let header =
+            LineNumberProgramHeader::parse(input, offset, address_size, comp_dir, comp_name)?;
         let program = IncompleteLineNumberProgram { header };
         Ok(program)
     }
@@ -1008,6 +1009,7 @@ where
     R: Reader<Offset = Offset>,
     Offset: ReaderOffset,
 {
+    offset: DebugLineOffset<Offset>,
     unit_length: Offset,
 
     /// "A version number. This number is specific to the line number
@@ -1085,6 +1087,11 @@ where
     R: Reader<Offset = Offset>,
     Offset: ReaderOffset,
 {
+    /// Return the offset of the line number program header in the `.debug_line` section.
+    pub fn offset(&self) -> DebugLineOffset<R::Offset> {
+        self.offset
+    }
+
     /// Return the length of the line number program and header, not including
     /// the length of the encoded length itself.
     pub fn unit_length(&self) -> R::Offset {
@@ -1221,6 +1228,7 @@ where
 
     fn parse(
         input: &mut R,
+        offset: DebugLineOffset<Offset>,
         address_size: u8,
         comp_dir: Option<R>,
         comp_name: Option<R>,
@@ -1292,6 +1300,7 @@ where
         });
 
         let header = LineNumberProgramHeader {
+            offset,
             unit_length,
             version,
             header_length,
@@ -1589,14 +1598,21 @@ mod tests {
         let comp_dir = EndianSlice::new(b"/comp_dir", LittleEndian);
         let comp_name = EndianSlice::new(b"/comp_name", LittleEndian);
 
-        let header = LineNumberProgramHeader::parse(rest, 4, Some(comp_dir), Some(comp_name))
-            .expect("should parse header ok");
+        let header = LineNumberProgramHeader::parse(
+            rest,
+            DebugLineOffset(0),
+            4,
+            Some(comp_dir),
+            Some(comp_name),
+        )
+        .expect("should parse header ok");
 
         assert_eq!(
             *rest,
             EndianSlice::new(&buf[buf.len() - 16..], LittleEndian)
         );
 
+        assert_eq!(header.offset, DebugLineOffset(0));
         assert_eq!(header.version, 4);
         assert_eq!(header.minimum_instruction_length(), 1);
         assert_eq!(header.maximum_operations_per_instruction(), 1);
@@ -1688,7 +1704,7 @@ mod tests {
 
         let input = &mut EndianSlice::new(&buf, LittleEndian);
 
-        match LineNumberProgramHeader::parse(input, 4, None, None) {
+        match LineNumberProgramHeader::parse(input, DebugLineOffset(0), 4, None, None) {
             Err(Error::UnexpectedEof) => return,
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         }
@@ -1749,7 +1765,7 @@ mod tests {
 
         let input = &mut EndianSlice::new(&buf, LittleEndian);
 
-        match LineNumberProgramHeader::parse(input, 4, None, None) {
+        match LineNumberProgramHeader::parse(input, DebugLineOffset(0), 4, None, None) {
             Err(Error::UnexpectedEof) => return,
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         }
@@ -1762,6 +1778,7 @@ mod tests {
         buf: EndianSlice<LittleEndian>,
     ) -> LineNumberProgramHeader<EndianSlice<LittleEndian>> {
         LineNumberProgramHeader {
+            offset: DebugLineOffset(0),
             opcode_base: OPCODE_BASE,
             address_size: 8,
             minimum_instruction_length: 1,

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -10,7 +10,7 @@ use read::{
 
 /// The `DebugLoc` struct represents the DWARF strings
 /// found in the `.debug_loc` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugLoc<R: Reader> {
     pub(crate) debug_loc_section: R,
 }
@@ -52,7 +52,7 @@ impl<R: Reader> From<R> for DebugLoc<R> {
 
 /// The `DebugLocLists` struct represents the DWARF data
 /// found in the `.debug_loclists` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugLocLists<R: Reader> {
     debug_loclists_section: R,
 }
@@ -101,6 +101,16 @@ struct LocListsHeader {
     offset_entry_count: u32,
 }
 
+impl Default for LocListsHeader {
+    fn default() -> Self {
+        LocListsHeader {
+            format: Format::Dwarf32,
+            address_size: 0,
+            offset_entry_count: 0,
+        }
+    }
+}
+
 impl LocListsHeader {
     /// Return the serialized size of the table header.
     #[inline]
@@ -133,7 +143,7 @@ fn parse_header<R: Reader>(input: &mut R) -> Result<LocListsHeader> {
 }
 
 /// The DWARF data found in `.debug_loc` and `.debug_loclists` sections.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct LocationLists<R: Reader> {
     debug_loc: DebugLoc<R>,
     debug_loclists: DebugLocLists<R>,
@@ -150,11 +160,7 @@ impl<R: Reader> LocationLists<R> {
     ) -> Result<LocationLists<R>> {
         let mut input = debug_loclists.debug_loclists_section.clone();
         let header = if input.is_empty() {
-            LocListsHeader {
-                format: Format::Dwarf32,
-                address_size: 0,
-                offset_entry_count: 0,
-            }
+            LocListsHeader::default()
         } else {
             parse_header(&mut input)?
         };

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -11,6 +11,9 @@ use constants;
 mod cfi;
 pub use self::cfi::*;
 
+mod dwarf;
+pub use self::dwarf::*;
+
 mod endian_slice;
 pub use self::endian_slice::*;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -206,6 +206,10 @@ pub enum Error {
     UnsupportedAddressIndex,
     /// Nonzero segment selector sizes aren't supported yet.
     UnsupportedSegmentSize,
+    /// A compilation unit or type unit is missing its top level DIE.
+    MissingUnitDie,
+    /// A DIE attribute used an unsupported form.
+    UnsupportedAttributeForm,
 }
 
 impl fmt::Display for Error {
@@ -338,6 +342,10 @@ impl Error {
             Error::UnsupportedUnitType => "The `DW_UT_*` value for this unit is not supported yet",
             Error::UnsupportedAddressIndex => "Ranges involving AddressIndex are not supported yet",
             Error::UnsupportedSegmentSize => "Nonzero segment size not supported yet",
+            Error::MissingUnitDie => {
+                "A compilation unit or type unit is missing its top level DIE."
+            }
+            Error::UnsupportedAttributeForm => "A DIE attribute used an unsupported form.",
         }
     }
 }

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -11,7 +11,7 @@ pub struct AddressIndex(pub u64);
 
 /// The `DebugRanges` struct represents the DWARF strings
 /// found in the `.debug_ranges` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugRanges<R: Reader> {
     pub(crate) debug_ranges_section: R,
 }
@@ -55,7 +55,7 @@ impl<R: Reader> From<R> for DebugRanges<R> {
 
 /// The `DebugRngLists` struct represents the contents of the
 /// `.debug_rnglists` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugRngLists<R: Reader> {
     debug_rnglists_section: R,
 }
@@ -105,6 +105,16 @@ struct RngListsHeader {
     offset_entry_count: u32,
 }
 
+impl Default for RngListsHeader {
+    fn default() -> Self {
+        RngListsHeader {
+            format: Format::Dwarf32,
+            address_size: 0,
+            offset_entry_count: 0,
+        }
+    }
+}
+
 impl RngListsHeader {
     /// Return the serialized size of the table header.
     #[inline]
@@ -137,7 +147,7 @@ fn parse_header<R: Reader>(input: &mut R) -> Result<RngListsHeader> {
 }
 
 /// The DWARF data found in `.debug_ranges` and `.debug_rnglists` sections.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct RangeLists<R: Reader> {
     debug_ranges: DebugRanges<R>,
     debug_rnglists: DebugRngLists<R>,
@@ -154,11 +164,7 @@ impl<R: Reader> RangeLists<R> {
     ) -> Result<RangeLists<R>> {
         let mut input = debug_rnglists.debug_rnglists_section.clone();
         let header = if input.is_empty() {
-            RngListsHeader {
-                format: Format::Dwarf32,
-                address_size: 0,
-                offset_entry_count: 0,
-            }
+            RngListsHeader::default()
         } else {
             parse_header(&mut input)?
         };

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -4,7 +4,7 @@ use read::{EndianSlice, Reader, Result, Section};
 
 /// The `DebugStr` struct represents the DWARF strings
 /// found in the `.debug_str` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugStr<R: Reader> {
     debug_str_section: R,
 }

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -89,7 +89,7 @@ impl<T: ReaderOffset> UnitOffset<T> {
 
 /// The `DebugInfo` struct represents the DWARF debugging information found in
 /// the `.debug_info` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugInfo<R: Reader> {
     debug_info_section: R,
 }
@@ -2507,7 +2507,7 @@ fn parse_type_offset<R: Reader>(input: &mut R, format: Format) -> Result<UnitOff
 
 /// The `DebugTypes` struct represents the DWARF type information
 /// found in the `.debug_types` section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct DebugTypes<R: Reader> {
     debug_types_section: R,
 }

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1046,7 +1046,7 @@ mod convert {
     use write::{self, ConvertError, ConvertResult};
 
     pub(crate) struct ConvertUnitContext<'a, R: Reader<Offset = usize> + 'a> {
-        pub dwarf: &'a read::Dwarf<R>,
+        pub dwarf: &'a read::Dwarf<R, R::Endian>,
         pub strings: &'a mut write::StringTable,
         pub convert_address: &'a Fn(u64) -> Option<Address>,
         pub line_program: Option<(DebugLineOffset, LineProgramId)>,
@@ -1065,7 +1065,7 @@ mod convert {
         /// responsibility to determine the symbol and addend corresponding to the address
         /// and return `Address::Relative { symbol, addend }`.
         pub fn from<R: Reader<Offset = usize>>(
-            dwarf: &read::Dwarf<R>,
+            dwarf: &read::Dwarf<R, R::Endian>,
             line_programs: &mut write::LineProgramTable,
             strings: &mut write::StringTable,
             convert_address: &Fn(u64) -> Option<Address>,
@@ -1123,7 +1123,7 @@ mod convert {
             from_unit: &read::CompilationUnitHeader<R>,
             unit_id: UnitId,
             unit_entry_offsets: &mut HashMap<DebugInfoOffset, (UnitId, UnitEntryId)>,
-            dwarf: &read::Dwarf<R>,
+            dwarf: &read::Dwarf<R, R::Endian>,
             line_programs: &mut write::LineProgramTable,
             strings: &mut write::StringTable,
             convert_address: &Fn(u64) -> Option<Address>,

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1073,7 +1073,7 @@ mod convert {
             let mut units = Vec::new();
             let mut unit_entry_offsets = HashMap::new();
 
-            let mut from_units = dwarf.debug_info.units();
+            let mut from_units = dwarf.units();
             while let Some(ref from_unit) = from_units.next()? {
                 let unit_id = UnitId(units.len());
                 units.push(CompilationUnit::from(
@@ -1471,7 +1471,7 @@ mod tests {
             debug_str: read::DebugStr::new(debug_str.slice(), LittleEndian),
             ..Default::default()
         };
-        let mut read_units = dwarf.debug_info.units();
+        let mut read_units = dwarf.units();
 
         {
             let read_unit1 = read_units.next().unwrap().unwrap();
@@ -1942,7 +1942,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut read_units = dwarf.debug_info.units();
+        let mut read_units = dwarf.units();
         {
             let read_unit1 = read_units.next().unwrap().unwrap();
             assert_eq!(read_unit1.offset(), debug_info_offsets.unit(unit_id1));

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1141,10 +1141,10 @@ mod convert {
                 let from_root = from_root.entry();
                 let comp_dir = from_root
                     .attr(constants::DW_AT_comp_dir)?
-                    .and_then(|attr| attr.string_value(&dwarf.debug_str));
+                    .and_then(|attr| dwarf.attr_string(&attr));
                 let comp_file = from_root
                     .attr(constants::DW_AT_name)?
-                    .and_then(|attr| attr.string_value(&dwarf.debug_str));
+                    .and_then(|attr| dwarf.attr_string(&attr));
                 if let Some(read::AttributeValue::DebugLineRef(offset)) =
                     from_root.attr_value(constants::DW_AT_stmt_list)?
                 {
@@ -1496,13 +1496,7 @@ mod tests {
                 };
                 assert_eq!(producer, b"root");
                 let read_producer = read_root.attr(constants::DW_AT_producer).unwrap().unwrap();
-                assert_eq!(
-                    read_producer
-                        .string_value(&dwarf.debug_str)
-                        .unwrap()
-                        .slice(),
-                    producer
-                );
+                assert_eq!(dwarf.attr_string(&read_producer).unwrap().slice(), producer);
             }
 
             let mut children = root.children().cloned();
@@ -1523,10 +1517,7 @@ mod tests {
                 let name = strings.get(name);
                 assert_eq!(name, b"child1");
                 let read_name = read_child.attr(constants::DW_AT_name).unwrap().unwrap();
-                assert_eq!(
-                    read_name.string_value(&dwarf.debug_str).unwrap().slice(),
-                    name
-                );
+                assert_eq!(dwarf.attr_string(&read_name).unwrap().slice(), name);
             }
 
             {
@@ -1545,10 +1536,7 @@ mod tests {
                 let name = strings.get(name);
                 assert_eq!(name, b"child2");
                 let read_name = read_child.attr(constants::DW_AT_name).unwrap().unwrap();
-                assert_eq!(
-                    read_name.string_value(&dwarf.debug_str).unwrap().slice(),
-                    name
-                );
+                assert_eq!(dwarf.attr_string(&read_name).unwrap().slice(), name);
             }
 
             assert!(read_entries.next_dfs().unwrap().is_none());

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1132,7 +1132,7 @@ mod convert {
             let address_size = from_unit.address_size();
             let format = from_unit.format();
             let mut entries = Vec::new();
-            let abbreviations = from_unit.abbreviations(&dwarf.debug_abbrev)?;
+            let abbreviations = dwarf.abbreviations(from_unit)?;
             let mut from_tree = from_unit.entries_tree(&abbreviations, None)?;
             let from_root = from_tree.root()?;
             let mut line_program = None;
@@ -1480,7 +1480,7 @@ mod tests {
             assert_eq!(unit1.address_size(), read_unit1.address_size());
             assert_eq!(unit1.format(), read_unit1.format());
 
-            let abbrevs = read_unit1.abbreviations(&dwarf.debug_abbrev).unwrap();
+            let abbrevs = dwarf.abbreviations(&read_unit1).unwrap();
             let mut read_entries = read_unit1.entries(&abbrevs);
 
             let root = unit1.get(unit1.root());
@@ -1561,7 +1561,7 @@ mod tests {
             assert_eq!(unit2.address_size(), read_unit2.address_size());
             assert_eq!(unit2.format(), read_unit2.format());
 
-            let abbrevs = read_unit2.abbreviations(&dwarf.debug_abbrev).unwrap();
+            let abbrevs = dwarf.abbreviations(&read_unit2).unwrap();
             let mut read_entries = read_unit2.entries(&abbrevs);
 
             {
@@ -1582,7 +1582,7 @@ mod tests {
             assert_eq!(unit3.address_size(), read_unit3.address_size());
             assert_eq!(unit3.format(), read_unit3.format());
 
-            let abbrevs = read_unit3.abbreviations(&dwarf.debug_abbrev).unwrap();
+            let abbrevs = dwarf.abbreviations(&read_unit3).unwrap();
             let mut read_entries = read_unit3.entries(&abbrevs);
 
             {
@@ -1959,7 +1959,7 @@ mod tests {
             let read_unit1 = read_units.next().unwrap().unwrap();
             assert_eq!(read_unit1.offset(), debug_info_offsets.unit(unit_id1));
 
-            let abbrevs = read_unit1.abbreviations(&dwarf.debug_abbrev).unwrap();
+            let abbrevs = dwarf.abbreviations(&read_unit1).unwrap();
             let mut read_entries = read_unit1.entries(&abbrevs);
             {
                 let (_, _read_root) = read_entries.next_dfs().unwrap().unwrap();
@@ -1988,7 +1988,7 @@ mod tests {
             let read_unit2 = read_units.next().unwrap().unwrap();
             assert_eq!(read_unit2.offset(), debug_info_offsets.unit(unit_id2));
 
-            let abbrevs = read_unit2.abbreviations(&dwarf.debug_abbrev).unwrap();
+            let abbrevs = dwarf.abbreviations(&read_unit2).unwrap();
             let mut read_entries = read_unit2.entries(&abbrevs);
             {
                 let (_, _read_root) = read_entries.next_dfs().unwrap().unwrap();

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1046,7 +1046,7 @@ mod convert {
     use write::{self, ConvertError, ConvertResult};
 
     pub(crate) struct ConvertUnitContext<'a, R: Reader<Offset = usize> + 'a> {
-        pub debug_str: &'a read::DebugStr<R>,
+        pub dwarf: &'a read::Dwarf<R>,
         pub strings: &'a mut write::StringTable,
         pub convert_address: &'a Fn(u64) -> Option<Address>,
         pub line_program: Option<(DebugLineOffset, LineProgramId)>,
@@ -1065,10 +1065,7 @@ mod convert {
         /// responsibility to determine the symbol and addend corresponding to the address
         /// and return `Address::Relative { symbol, addend }`.
         pub fn from<R: Reader<Offset = usize>>(
-            debug_abbrev: &read::DebugAbbrev<R>,
-            debug_info: &read::DebugInfo<R>,
-            debug_line: &read::DebugLine<R>,
-            debug_str: &read::DebugStr<R>,
+            dwarf: &read::Dwarf<R>,
             line_programs: &mut write::LineProgramTable,
             strings: &mut write::StringTable,
             convert_address: &Fn(u64) -> Option<Address>,
@@ -1076,16 +1073,14 @@ mod convert {
             let mut units = Vec::new();
             let mut unit_entry_offsets = HashMap::new();
 
-            let mut from_units = debug_info.units();
+            let mut from_units = dwarf.debug_info.units();
             while let Some(ref from_unit) = from_units.next()? {
                 let unit_id = UnitId(units.len());
                 units.push(CompilationUnit::from(
                     from_unit,
                     unit_id,
                     &mut unit_entry_offsets,
-                    debug_abbrev,
-                    debug_line,
-                    debug_str,
+                    dwarf,
                     line_programs,
                     strings,
                     convert_address,
@@ -1128,9 +1123,7 @@ mod convert {
             from_unit: &read::CompilationUnitHeader<R>,
             unit_id: UnitId,
             unit_entry_offsets: &mut HashMap<DebugInfoOffset, (UnitId, UnitEntryId)>,
-            debug_abbrev: &read::DebugAbbrev<R>,
-            debug_line: &read::DebugLine<R>,
-            debug_str: &read::DebugStr<R>,
+            dwarf: &read::Dwarf<R>,
             line_programs: &mut write::LineProgramTable,
             strings: &mut write::StringTable,
             convert_address: &Fn(u64) -> Option<Address>,
@@ -1139,7 +1132,7 @@ mod convert {
             let address_size = from_unit.address_size();
             let format = from_unit.format();
             let mut entries = Vec::new();
-            let abbreviations = from_unit.abbreviations(debug_abbrev)?;
+            let abbreviations = from_unit.abbreviations(&dwarf.debug_abbrev)?;
             let mut from_tree = from_unit.entries_tree(&abbreviations, None)?;
             let from_root = from_tree.root()?;
             let mut line_program = None;
@@ -1148,22 +1141,24 @@ mod convert {
                 let from_root = from_root.entry();
                 let comp_dir = from_root
                     .attr(constants::DW_AT_comp_dir)?
-                    .and_then(|attr| attr.string_value(debug_str));
+                    .and_then(|attr| attr.string_value(&dwarf.debug_str));
                 let comp_file = from_root
                     .attr(constants::DW_AT_name)?
-                    .and_then(|attr| attr.string_value(debug_str));
+                    .and_then(|attr| attr.string_value(&dwarf.debug_str));
                 if let Some(read::AttributeValue::DebugLineRef(offset)) =
                     from_root.attr_value(constants::DW_AT_stmt_list)?
                 {
                     let from_program =
-                        debug_line.program(offset, address_size, comp_dir, comp_file)?;
+                        dwarf
+                            .debug_line
+                            .program(offset, address_size, comp_dir, comp_file)?;
                     let (program, files) = LineProgram::from(from_program, convert_address)?;
                     line_program = Some((offset, line_programs.add(program)));
                     line_program_files = files;
                 }
             }
             let mut context = ConvertUnitContext {
-                debug_str,
+                dwarf,
                 strings,
                 convert_address,
                 line_program,
@@ -1304,7 +1299,7 @@ mod convert {
                 read::AttributeValue::RangeListsRef(val) => AttributeValue::RangeListsRef(val),
                 read::AttributeValue::DebugTypesRef(val) => AttributeValue::DebugTypesRef(val),
                 read::AttributeValue::DebugStrRef(offset) => {
-                    let r = context.debug_str.get_str(offset)?;
+                    let r = context.dwarf.debug_str.get_str(offset)?;
                     let id = context.strings.add(r.to_slice()?);
                     AttributeValue::StringRef(id)
                 }
@@ -1469,11 +1464,14 @@ mod tests {
         println!("{:?}", debug_info);
         println!("{:?}", debug_abbrev);
 
-        let read_debug_abbrev = read::DebugAbbrev::new(debug_abbrev.slice(), LittleEndian);
-        let read_debug_info = read::DebugInfo::new(debug_info.slice(), LittleEndian);
-        let read_debug_line = read::DebugLine::new(&[], LittleEndian);
-        let read_debug_str = read::DebugStr::new(debug_str.slice(), LittleEndian);
-        let mut read_units = read_debug_info.units();
+        let dwarf = read::Dwarf {
+            debug_abbrev: read::DebugAbbrev::new(debug_abbrev.slice(), LittleEndian),
+            debug_info: read::DebugInfo::new(debug_info.slice(), LittleEndian),
+            debug_line: read::DebugLine::new(&[], LittleEndian),
+            debug_str: read::DebugStr::new(debug_str.slice(), LittleEndian),
+            ..Default::default()
+        };
+        let mut read_units = dwarf.debug_info.units();
 
         {
             let read_unit1 = read_units.next().unwrap().unwrap();
@@ -1482,7 +1480,7 @@ mod tests {
             assert_eq!(unit1.address_size(), read_unit1.address_size());
             assert_eq!(unit1.format(), read_unit1.format());
 
-            let abbrevs = read_unit1.abbreviations(&read_debug_abbrev).unwrap();
+            let abbrevs = read_unit1.abbreviations(&dwarf.debug_abbrev).unwrap();
             let mut read_entries = read_unit1.entries(&abbrevs);
 
             let root = unit1.get(unit1.root());
@@ -1499,7 +1497,10 @@ mod tests {
                 assert_eq!(producer, b"root");
                 let read_producer = read_root.attr(constants::DW_AT_producer).unwrap().unwrap();
                 assert_eq!(
-                    read_producer.string_value(&read_debug_str).unwrap().slice(),
+                    read_producer
+                        .string_value(&dwarf.debug_str)
+                        .unwrap()
+                        .slice(),
                     producer
                 );
             }
@@ -1523,7 +1524,7 @@ mod tests {
                 assert_eq!(name, b"child1");
                 let read_name = read_child.attr(constants::DW_AT_name).unwrap().unwrap();
                 assert_eq!(
-                    read_name.string_value(&read_debug_str).unwrap().slice(),
+                    read_name.string_value(&dwarf.debug_str).unwrap().slice(),
                     name
                 );
             }
@@ -1545,7 +1546,7 @@ mod tests {
                 assert_eq!(name, b"child2");
                 let read_name = read_child.attr(constants::DW_AT_name).unwrap().unwrap();
                 assert_eq!(
-                    read_name.string_value(&read_debug_str).unwrap().slice(),
+                    read_name.string_value(&dwarf.debug_str).unwrap().slice(),
                     name
                 );
             }
@@ -1560,7 +1561,7 @@ mod tests {
             assert_eq!(unit2.address_size(), read_unit2.address_size());
             assert_eq!(unit2.format(), read_unit2.format());
 
-            let abbrevs = read_unit2.abbreviations(&read_debug_abbrev).unwrap();
+            let abbrevs = read_unit2.abbreviations(&dwarf.debug_abbrev).unwrap();
             let mut read_entries = read_unit2.entries(&abbrevs);
 
             {
@@ -1581,7 +1582,7 @@ mod tests {
             assert_eq!(unit3.address_size(), read_unit3.address_size());
             assert_eq!(unit3.format(), read_unit3.format());
 
-            let abbrevs = read_unit3.abbreviations(&read_debug_abbrev).unwrap();
+            let abbrevs = read_unit3.abbreviations(&dwarf.debug_abbrev).unwrap();
             let mut read_entries = read_unit3.entries(&abbrevs);
 
             {
@@ -1600,10 +1601,7 @@ mod tests {
         let mut convert_line_programs = LineProgramTable::default();
         let mut convert_strings = StringTable::default();
         let convert_units = UnitTable::from(
-            &read_debug_abbrev,
-            &read_debug_info,
-            &read_debug_line,
-            &read_debug_str,
+            &dwarf,
             &mut convert_line_programs,
             &mut convert_strings,
             &|address| Some(Address::Absolute(address)),
@@ -1854,8 +1852,13 @@ mod tests {
                         };
                         assert_eq!(read_value, expect_value);
 
+                        let dwarf = read::Dwarf {
+                            debug_str: read_debug_str.clone(),
+                            ..Default::default()
+                        };
+
                         let mut context = convert::ConvertUnitContext {
-                            debug_str: &read_debug_str,
+                            dwarf: &dwarf,
                             strings: &mut strings,
                             convert_address: &|address| Some(Address::Absolute(address)),
                             line_program: None,
@@ -1943,16 +1946,20 @@ mod tests {
         println!("{:?}", debug_info);
         println!("{:?}", debug_abbrev);
 
-        let read_debug_abbrev = read::DebugAbbrev::new(debug_abbrev.slice(), LittleEndian);
-        let read_debug_info = read::DebugInfo::new(debug_info.slice(), LittleEndian);
-        let read_debug_line = read::DebugLine::new(&[], LittleEndian);
-        let read_debug_str = read::DebugStr::new(&[], LittleEndian);
-        let mut read_units = read_debug_info.units();
+        let dwarf = read::Dwarf {
+            debug_abbrev: read::DebugAbbrev::new(debug_abbrev.slice(), LittleEndian),
+            debug_info: read::DebugInfo::new(debug_info.slice(), LittleEndian),
+            debug_line: read::DebugLine::new(&[], LittleEndian),
+            debug_str: read::DebugStr::new(&[], LittleEndian),
+            ..Default::default()
+        };
+
+        let mut read_units = dwarf.debug_info.units();
         {
             let read_unit1 = read_units.next().unwrap().unwrap();
             assert_eq!(read_unit1.offset(), debug_info_offsets.unit(unit_id1));
 
-            let abbrevs = read_unit1.abbreviations(&read_debug_abbrev).unwrap();
+            let abbrevs = read_unit1.abbreviations(&dwarf.debug_abbrev).unwrap();
             let mut read_entries = read_unit1.entries(&abbrevs);
             {
                 let (_, _read_root) = read_entries.next_dfs().unwrap().unwrap();
@@ -1981,7 +1988,7 @@ mod tests {
             let read_unit2 = read_units.next().unwrap().unwrap();
             assert_eq!(read_unit2.offset(), debug_info_offsets.unit(unit_id2));
 
-            let abbrevs = read_unit2.abbreviations(&read_debug_abbrev).unwrap();
+            let abbrevs = read_unit2.abbreviations(&dwarf.debug_abbrev).unwrap();
             let mut read_entries = read_unit2.entries(&abbrevs);
             {
                 let (_, _read_root) = read_entries.next_dfs().unwrap().unwrap();
@@ -2010,10 +2017,7 @@ mod tests {
         let mut convert_line_programs = LineProgramTable::default();
         let mut convert_strings = StringTable::default();
         let convert_units = UnitTable::from(
-            &read_debug_abbrev,
-            &read_debug_info,
-            &read_debug_line,
-            &read_debug_str,
+            &dwarf,
             &mut convert_line_programs,
             &mut convert_strings,
             &|address| Some(Address::Absolute(address)),
@@ -2261,8 +2265,13 @@ mod tests {
                         };
                         assert_eq!(read_value, expect_value);
 
+                        let dwarf = read::Dwarf {
+                            debug_str: read_debug_str.clone(),
+                            ..Default::default()
+                        };
+
                         let mut context = convert::ConvertUnitContext {
-                            debug_str: &read_debug_str,
+                            dwarf: &dwarf,
                             strings: &mut strings,
                             convert_address: &|address| Some(Address::Absolute(address)),
                             line_program: Some((line_program_offset, line_program_id)),

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -41,17 +41,19 @@ fn test_convert_debug_info() {
     let debug_str = read_section("debug_str");
     let debug_str = read::DebugStr::new(&debug_str, LittleEndian);
 
+    let dwarf = read::Dwarf {
+        debug_abbrev,
+        debug_info,
+        debug_line,
+        debug_str,
+        ..Default::default()
+    };
+
     let mut strings = write::StringTable::default();
     let mut line_programs = write::LineProgramTable::default();
-    let units = write::UnitTable::from(
-        &debug_abbrev,
-        &debug_info,
-        &debug_line,
-        &debug_str,
-        &mut line_programs,
-        &mut strings,
-        &|address| Some(Address::Absolute(address)),
-    )
+    let units = write::UnitTable::from(&dwarf, &mut line_programs, &mut strings, &|address| {
+        Some(Address::Absolute(address))
+    })
     .expect("Should convert compilation units");
     assert_eq!(units.count(), 23);
     let entries: usize = (0..units.count())
@@ -98,17 +100,19 @@ fn test_convert_debug_info() {
     let debug_line = read::DebugLine::new(debug_line_data, LittleEndian);
     let debug_str = read::DebugStr::new(debug_str_data, LittleEndian);
 
+    let dwarf = read::Dwarf {
+        debug_abbrev,
+        debug_info,
+        debug_line,
+        debug_str,
+        ..Default::default()
+    };
+
     let mut line_programs = write::LineProgramTable::default();
     let mut strings = write::StringTable::default();
-    let units = write::UnitTable::from(
-        &debug_abbrev,
-        &debug_info,
-        &debug_line,
-        &debug_str,
-        &mut line_programs,
-        &mut strings,
-        &|address| Some(Address::Absolute(address)),
-    )
+    let units = write::UnitTable::from(&dwarf, &mut line_programs, &mut strings, &|address| {
+        Some(Address::Absolute(address))
+    })
     .expect("Should convert compilation units");
     assert_eq!(units.count(), 23);
     let entries: usize = (0..units.count())


### PR DESCRIPTION
The motivation is to reduce the long parameter lists containing section readers, which is only going to get worse as we implement the new DWARF 5 sections.

Currently I'm only including the sections used when parsing `.debug_info`, which is the section that contains the most references to other sections. There will only be one of these structs per file, so it's probably not a problem to add other sections too if needed.