### PR TITLE
fix .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 target
 Cargo.lock
-**.bk
+*.bk


### PR DESCRIPTION
This makes tools that are based on ripgrep fail (including ripgrep itself).

Noticed that when I tried to run fastmod:

```
WithPath { path: "/Users/mitsuhiko/Development/gimli/.gitignore", err: WithLineNumber { line: 3, err: Glob { glob: Some("**.bk"), err: "invalid use of **; must be one path component" } } }
```