### PR TITLE
Implement indexed values for DWARF 5

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -294,6 +294,9 @@ fn bench_parsing_debug_ranges(b: &mut test::Bencher) {
     let debug_abbrev = read_section("debug_abbrev");
     let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
+    let debug_addr = DebugAddr::from(EndianSlice::new(&[], LittleEndian));
+    let debug_addr_base = DebugAddrBase(0);
+
     let debug_ranges = read_section("debug_ranges");
     let debug_ranges = DebugRanges::new(&debug_ranges, LittleEndian);
     let debug_rnglists = DebugRngLists::new(&[], LittleEndian);
@@ -336,7 +339,14 @@ fn bench_parsing_debug_ranges(b: &mut test::Bencher) {
     b.iter(|| {
         for &(offset, version, address_size, base_address) in &*offsets {
             let mut ranges = rnglists
-                .ranges(offset, version, address_size, base_address)
+                .ranges(
+                    offset,
+                    version,
+                    address_size,
+                    base_address,
+                    &debug_addr,
+                    debug_addr_base,
+                )
                 .expect("Should parse ranges OK");
             while let Some(range) = ranges.next().expect("Should parse next range") {
                 test::black_box(range);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -1536,6 +1536,12 @@ fn dump_op<R: Reader, W: Write>(
         gimli::Operation::Address { address } => {
             write!(w, " 0x{:08x}", address)?;
         }
+        gimli::Operation::AddressIndex { index } => {
+            write!(w, " 0x{:08x}", index.0)?;
+        }
+        gimli::Operation::ConstantIndex { index } => {
+            write!(w, " 0x{:08x}", index.0)?;
+        }
         gimli::Operation::TypedLiteral { base_type, value } => {
             write!(w, " type 0x{:08x} contents 0x", base_type.0)?;
             for byte in value.to_slice()?.iter() {

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -324,11 +324,8 @@ impl<'a, R: gimli::Reader<Offset = usize>> gimli::Reader for Relocate<'a, R> {
     }
 
     #[inline]
-    fn read_u8_array<A>(&mut self) -> gimli::Result<A>
-    where
-        A: Sized + Default + AsMut<[u8]>,
-    {
-        self.reader.read_u8_array()
+    fn read_slice(&mut self, buf: &mut [u8]) -> gimli::Result<()> {
+        self.reader.read_slice(buf)
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -59,6 +59,14 @@ pub struct DebugLineOffset<T = usize>(pub T);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LocationListsOffset<T = usize>(pub T);
 
+/// An offset to a set of location list offsets in the `.debug_loclists` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugLocListsBase<T = usize>(pub T);
+
+/// An index into a set of location list offsets in the `.debug_loclists` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugLocListsIndex<T = usize>(pub T);
+
 /// An offset into the `.debug_macinfo` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DebugMacinfoOffset<T = usize>(pub T);
@@ -67,6 +75,14 @@ pub struct DebugMacinfoOffset<T = usize>(pub T);
 /// depending on the version of the unit the offset was contained in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RangeListsOffset<T = usize>(pub T);
+
+/// An offset to a set of range list offsets in the `.debug_rnglists` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugRngListsBase<T = usize>(pub T);
+
+/// An index into a set of range list offsets in the `.debug_rnglists` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugRngListsIndex<T = usize>(pub T);
 
 /// An offset into the `.debug_str` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -38,6 +38,14 @@ pub struct Register(pub u16);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DebugAbbrevOffset<T = usize>(pub T);
 
+/// An offset to a set of entries in the `.debug_addr` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugAddrBase<T = usize>(pub T);
+
+/// An index into a set of addresses in the `.debug_addr` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugAddrIndex<T = usize>(pub T);
+
 /// An offset into the `.debug_info` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct DebugInfoOffset<T = usize>(pub T);

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,6 +64,14 @@ pub struct RangeListsOffset<T = usize>(pub T);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DebugStrOffset<T = usize>(pub T);
 
+/// An offset to a set of entries in the `.debug_str_offsets` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugStrOffsetsBase<T = usize>(pub T);
+
+/// An index into a set of entries in the `.debug_str_offsets` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugStrOffsetsIndex<T = usize>(pub T);
+
 /// An offset into the `.debug_types` section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DebugTypesOffset<T = usize>(pub T);

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -57,6 +57,20 @@ pub trait Endianity: Debug + Default + Clone + Copy + PartialEq + Eq {
         }
     }
 
+    /// Read an unsigned n-bytes integer u64.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() < 1` or `buf.len() > 8`.
+    #[inline]
+    fn read_uint(&mut self, buf: &[u8]) -> u64 {
+        if self.is_big_endian() {
+            byteorder::BigEndian::read_uint(buf, buf.len())
+        } else {
+            byteorder::LittleEndian::read_uint(buf, buf.len())
+        }
+    }
+
     /// Reads a signed 16 bit integer from `buf`.
     ///
     /// # Panics

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -1,0 +1,53 @@
+use common::{DebugAddrBase, DebugAddrIndex};
+use read::{Reader, ReaderOffset, Result, Section};
+
+/// The raw contents of the `.debug_addr` section.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DebugAddr<R: Reader> {
+    section: R,
+}
+
+impl<R: Reader> DebugAddr<R> {
+    // TODO: add an iterator over the sets of addresses in the section.
+    // This is not needed for common usage of the section though.
+
+    /// Returns the address at the given `base` and `index`.
+    ///
+    /// A set of addresses in the `.debug_addr` section consists of a header
+    /// followed by a series of addresses.
+    ///
+    /// The `base` must be the `DW_AT_addr_base` value from the compilation unit DIE.
+    /// This is an offset that points to the first address following the header.
+    ///
+    /// The `index` is the value of a `DW_FORM_addrx` attribute.
+    ///
+    /// The `address_size` must be the size of the address for the compilation unit.
+    /// This value must also match the header. However, note that we do not parse the
+    /// header to validate this, since locating the header is unreliable, and the GNU
+    /// extensions do not emit it.
+    pub fn get_address(
+        &self,
+        address_size: u8,
+        base: DebugAddrBase<R::Offset>,
+        index: DebugAddrIndex<R::Offset>,
+    ) -> Result<u64> {
+        let input = &mut self.section.clone();
+        input.skip(base.0)?;
+        input.skip(R::Offset::from_u64(
+            index.0.into_u64() * u64::from(address_size),
+        )?)?;
+        input.read_address(address_size)
+    }
+}
+
+impl<R: Reader> Section<R> for DebugAddr<R> {
+    fn section_name() -> &'static str {
+        ".debug_addr"
+    }
+}
+
+impl<R: Reader> From<R> for DebugAddr<R> {
+    fn from(section: R) -> Self {
+        DebugAddr { section }
+    }
+}

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -64,8 +64,8 @@ mod tests {
 
     #[test]
     fn test_get_address() {
-        for format in [Format::Dwarf32, Format::Dwarf64].iter().cloned() {
-            for address_size in [4, 8].iter().cloned() {
+        for format in vec![Format::Dwarf32, Format::Dwarf64] {
+            for address_size in vec![4, 8] {
                 let zero = Label::new();
                 let length = Label::new();
                 let start = Label::new();

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,7 +1,7 @@
 use constants;
 use read::{
     Abbreviations, Attribute, AttributeValue, CompilationUnitHeader, CompilationUnitHeadersIter,
-    DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugStrOffsets, DebugTypes, Error,
+    DebugAbbrev, DebugAddr, DebugInfo, DebugLine, DebugStr, DebugStrOffsets, DebugTypes, Error,
     IncompleteLineNumberProgram, LocationLists, RangeLists, Reader, Result, TypeUnitHeader,
     TypeUnitHeadersIter,
 };
@@ -20,6 +20,9 @@ where
 
     /// The `.debug_abbrev` section.
     pub debug_abbrev: DebugAbbrev<R>,
+
+    /// The `.debug_addr` section.
+    pub debug_addr: DebugAddr<R>,
 
     /// The `.debug_info` section.
     pub debug_info: DebugInfo<R>,

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,8 +1,9 @@
 use constants;
 use read::{
     Abbreviations, Attribute, AttributeValue, CompilationUnitHeader, CompilationUnitHeadersIter,
-    DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugTypes, Error, IncompleteLineNumberProgram,
-    LocationLists, RangeLists, Reader, Result, TypeUnitHeader, TypeUnitHeadersIter,
+    DebugAbbrev, DebugInfo, DebugLine, DebugStr, DebugStrOffsets, DebugTypes, Error,
+    IncompleteLineNumberProgram, LocationLists, RangeLists, Reader, Result, TypeUnitHeader,
+    TypeUnitHeadersIter,
 };
 use Endianity;
 
@@ -28,6 +29,9 @@ where
 
     /// The `.debug_str` section.
     pub debug_str: DebugStr<R>,
+
+    /// The `.debug_str_offsets` section.
+    pub debug_str_offsets: DebugStrOffsets<R>,
 
     /// The `.debug_str` section for a supplementary object file.
     pub debug_str_sup: DebugStr<R>,

--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -4,7 +4,6 @@ use borrow::Cow;
 use rc::Rc;
 use stable_deref_trait::CloneStableDeref;
 use std::fmt::Debug;
-use std::mem;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 use std::slice;
 use std::str;
@@ -441,15 +440,10 @@ where
     }
 
     #[inline]
-    fn read_u8_array<A>(&mut self) -> Result<A>
-    where
-        A: Sized + Default + AsMut<[u8]>,
-    {
-        let len = mem::size_of::<A>();
-        let slice = self.range.read_slice(len)?;
-        let mut val = Default::default();
-        <A as AsMut<[u8]>>::as_mut(&mut val).clone_from_slice(slice);
-        Ok(val)
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<()> {
+        let slice = self.range.read_slice(buf.len())?;
+        buf.clone_from_slice(slice);
+        Ok(())
     }
 }
 

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -1,7 +1,6 @@
 //! Working with byte slices that have an associated endianity.
 
 use borrow::Cow;
-use std::mem;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 use std::str;
 use string::String;
@@ -286,15 +285,10 @@ where
     }
 
     #[inline]
-    fn read_u8_array<A>(&mut self) -> Result<A>
-    where
-        A: Sized + Default + AsMut<[u8]>,
-    {
-        let len = mem::size_of::<A>();
-        let slice = self.read_slice(len)?;
-        let mut val = Default::default();
-        <A as AsMut<[u8]>>::as_mut(&mut val).clone_from_slice(slice);
-        Ok(val)
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<()> {
+        let slice = self.read_slice(buf.len())?;
+        buf.clone_from_slice(slice);
+        Ok(())
     }
 }
 

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -1331,7 +1331,7 @@ mod tests {
 
     #[test]
     fn test_get_offset() {
-        for format in [Format::Dwarf32, Format::Dwarf64].iter().cloned() {
+        for format in vec![Format::Dwarf32, Format::Dwarf64] {
             let zero = Label::new();
             let length = Label::new();
             let start = Label::new();

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -8,8 +8,7 @@ use read::{
     Section,
 };
 
-/// The `DebugLoc` struct represents the DWARF strings
-/// found in the `.debug_loc` section.
+/// The raw contents of the `.debug_loc` section.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DebugLoc<R: Reader> {
     pub(crate) debug_loc_section: R,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -8,6 +8,9 @@ use std::{error, io};
 use common::Register;
 use constants;
 
+mod addr;
+pub use self::addr::*;
+
 mod cfi;
 pub use self::cfi::*;
 

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -261,7 +261,7 @@ pub trait Reader: Debug + Clone {
     /// Does not advance the reader.
     fn to_string_lossy(&self) -> Result<Cow<str>>;
 
-    /// Read a u8 slice.
+    /// Read exactly `buf.len()` bytes into `buf`.
     fn read_slice(&mut self, buf: &mut [u8]) -> Result<()>;
 
     /// Read a u8 array.

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -261,10 +261,19 @@ pub trait Reader: Debug + Clone {
     /// Does not advance the reader.
     fn to_string_lossy(&self) -> Result<Cow<str>>;
 
+    /// Read a u8 slice.
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<()>;
+
     /// Read a u8 array.
+    #[inline]
     fn read_u8_array<A>(&mut self) -> Result<A>
     where
-        A: Sized + Default + AsMut<[u8]>;
+        A: Sized + Default + AsMut<[u8]>,
+    {
+        let mut val = Default::default();
+        self.read_slice(<A as AsMut<[u8]>>::as_mut(&mut val))?;
+        Ok(val)
+    }
 
     /// Return true if the number of bytes remaining is zero.
     #[inline]
@@ -340,6 +349,18 @@ pub trait Reader: Debug + Clone {
     fn read_f64(&mut self) -> Result<f64> {
         let a: [u8; 8] = self.read_u8_array()?;
         Ok(self.endian().read_f64(&a))
+    }
+
+    /// Read an unsigned n-bytes integer u64.
+    ///
+    /// # Panics
+    ///
+    /// Panics when nbytes < 1 or nbytes > 8
+    #[inline]
+    fn read_uint(&mut self, n: usize) -> Result<u64> {
+        let mut buf = [0; 8];
+        self.read_slice(&mut buf[..n])?;
+        Ok(self.endian().read_uint(&buf[..n]))
     }
 
     /// Read a null-terminated slice, and return it (excluding the null).

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -1068,4 +1068,43 @@ mod tests {
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         }
     }
+
+    #[test]
+    fn test_get_offset() {
+        for format in [Format::Dwarf32, Format::Dwarf64].iter().cloned() {
+            let zero = Label::new();
+            let length = Label::new();
+            let start = Label::new();
+            let first = Label::new();
+            let end = Label::new();
+            let mut section = Section::with_endian(Endian::Little)
+                .mark(&zero)
+                .initial_length(format, &length, &start)
+                .D16(5)
+                .D8(4)
+                .D8(0)
+                .D32(20)
+                .mark(&first);
+            for i in 0..20 {
+                section = section.word(format.word_size(), 1000 + i);
+            }
+            section = section.mark(&end);
+            length.set_const((&end - &start) as u64);
+            let section = section.get_contents().unwrap();
+
+            let debug_ranges = DebugRanges::from(EndianSlice::new(&[], LittleEndian));
+            let debug_rnglists = DebugRngLists::from(EndianSlice::new(&section, LittleEndian));
+            let ranges = RangeLists::new(debug_ranges, debug_rnglists).unwrap();
+
+            let base = DebugRngListsBase((&first - &zero) as usize);
+            assert_eq!(
+                ranges.get_offset(base, DebugRngListsIndex(0)),
+                Ok(RangeListsOffset(base.0 + 1000))
+            );
+            assert_eq!(
+                ranges.get_offset(base, DebugRngListsIndex(19)),
+                Ok(RangeListsOffset(base.0 + 1019))
+            );
+        }
+    }
 }

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -1254,7 +1254,7 @@ mod tests {
 
     #[test]
     fn test_get_offset() {
-        for format in [Format::Dwarf32, Format::Dwarf64].iter().cloned() {
+        for format in vec![Format::Dwarf32, Format::Dwarf64] {
             let zero = Label::new();
             let length = Label::new();
             let start = Label::new();

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -9,8 +9,7 @@ use read::{EndianSlice, Error, Reader, ReaderOffset, Result, Section};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AddressIndex(pub u64);
 
-/// The `DebugRanges` struct represents the DWARF strings
-/// found in the `.debug_ranges` section.
+/// The raw contents of the `.debug_ranges` section.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DebugRanges<R: Reader> {
     pub(crate) debug_ranges_section: R,

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_get_str_offset() {
-        for format in [Format::Dwarf32, Format::Dwarf64].iter().cloned() {
+        for format in vec![Format::Dwarf32, Format::Dwarf64] {
             let zero = Label::new();
             let length = Label::new();
             let start = Label::new();

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -1,6 +1,7 @@
-use common::DebugStrOffset;
+use common::{DebugStrOffset, DebugStrOffsetsBase, DebugStrOffsetsIndex};
 use endianity::Endianity;
-use read::{EndianSlice, Reader, Result, Section};
+use read::{EndianSlice, Reader, ReaderOffset, Result, Section};
+use Format;
 
 /// The `DebugStr` struct represents the DWARF strings
 /// found in the `.debug_str` section.
@@ -61,5 +62,55 @@ impl<R: Reader> Section<R> for DebugStr<R> {
 impl<R: Reader> From<R> for DebugStr<R> {
     fn from(debug_str_section: R) -> Self {
         DebugStr { debug_str_section }
+    }
+}
+
+/// The raw contents of the `.debug_str_offsets` section.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DebugStrOffsets<R: Reader> {
+    section: R,
+}
+
+impl<R: Reader> DebugStrOffsets<R> {
+    // TODO: add an iterator over the sets of entries in the section.
+    // This is not needed for common usage of the section though.
+
+    /// Returns the `.debug_str` offset at the given `base` and `index`.
+    ///
+    /// A set of entries in the `.debug_str_offsets` section consists of a header
+    /// followed by a series of string table offsets.
+    ///
+    /// The `base` must be the `DW_AT_str_offsets_base` value from the compilation unit DIE.
+    /// This is an offset that points to the first entry following the header.
+    ///
+    /// The `index` is the value of a `DW_FORM_strx` attribute.
+    ///
+    /// The `format` must be the DWARF format of the compilation unit. This format must
+    /// match the header. However, note that we do not parse the header to validate this,
+    /// since locating the header is unreliable, and the GNU extensions do not emit it.
+    pub fn get_str_offset(
+        &self,
+        format: Format,
+        base: DebugStrOffsetsBase<R::Offset>,
+        index: DebugStrOffsetsIndex<R::Offset>,
+    ) -> Result<DebugStrOffset<R::Offset>> {
+        let input = &mut self.section.clone();
+        input.skip(base.0)?;
+        input.skip(R::Offset::from_u64(
+            index.0.into_u64() * u64::from(format.word_size()),
+        )?)?;
+        input.read_offset(format).map(DebugStrOffset)
+    }
+}
+
+impl<R: Reader> Section<R> for DebugStrOffsets<R> {
+    fn section_name() -> &'static str {
+        ".debug_str_offsets"
+    }
+}
+
+impl<R: Reader> From<R> for DebugStrOffsets<R> {
+    fn from(section: R) -> Self {
+        DebugStrOffsets { section }
     }
 }

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -3511,6 +3511,38 @@ mod tests {
                 AttributeValue::Data8(([8, 7, 6, 5, 4, 3, 2, 1], endian)),
                 AttributeValue::Udata(0x0102_0304_0506_0708),
             ),
+            (
+                4,
+                constants::DW_AT_str_offsets_base,
+                constants::DW_FORM_sec_offset,
+                data4,
+                AttributeValue::SecOffset(0x0102_0304),
+                AttributeValue::DebugStrOffsetsBase(DebugStrOffsetsBase(0x0102_0304)),
+            ),
+            (
+                4,
+                constants::DW_AT_addr_base,
+                constants::DW_FORM_sec_offset,
+                data4,
+                AttributeValue::SecOffset(0x0102_0304),
+                AttributeValue::DebugAddrBase(DebugAddrBase(0x0102_0304)),
+            ),
+            (
+                4,
+                constants::DW_AT_rnglists_base,
+                constants::DW_FORM_sec_offset,
+                data4,
+                AttributeValue::SecOffset(0x0102_0304),
+                AttributeValue::DebugRngListsBase(DebugRngListsBase(0x0102_0304)),
+            ),
+            (
+                4,
+                constants::DW_AT_loclists_base,
+                constants::DW_FORM_sec_offset,
+                data4,
+                AttributeValue::SecOffset(0x0102_0304),
+                AttributeValue::DebugLocListsBase(DebugLocListsBase(0x0102_0304)),
+            ),
         ];
 
         for test in tests.iter() {
@@ -4024,6 +4056,138 @@ mod tests {
         let form = constants::DW_FORM_GNU_strp_alt;
         let value = AttributeValue::DebugStrRefSup(DebugStrOffset(0x0807_0605_0403_0201));
         test_parse_attribute(&buf, 8, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_strx() {
+        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        let bytes_written = {
+            let mut writable = &mut buf[..];
+            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
+        };
+
+        let unit = test_parse_attribute_unit_default();
+        let form = constants::DW_FORM_strx;
+        let value = AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(4097));
+        test_parse_attribute(&buf, bytes_written, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_strx1() {
+        let buf = [0x01, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_strx1;
+        let value = AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(0x01));
+        test_parse_attribute(&buf, 1, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_strx2() {
+        let buf = [0x01, 0x02, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_strx2;
+        let value = AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(0x0201));
+        test_parse_attribute(&buf, 2, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_strx3() {
+        let buf = [0x01, 0x02, 0x03, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_strx3;
+        let value = AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(0x03_0201));
+        test_parse_attribute(&buf, 3, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_strx4() {
+        let buf = [0x01, 0x02, 0x03, 0x04, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_strx4;
+        let value = AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(0x0403_0201));
+        test_parse_attribute(&buf, 4, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_addrx() {
+        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        let bytes_written = {
+            let mut writable = &mut buf[..];
+            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
+        };
+
+        let unit = test_parse_attribute_unit_default();
+        let form = constants::DW_FORM_addrx;
+        let value = AttributeValue::DebugAddrIndex(DebugAddrIndex(4097));
+        test_parse_attribute(&buf, bytes_written, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_addrx1() {
+        let buf = [0x01, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_addrx1;
+        let value = AttributeValue::DebugAddrIndex(DebugAddrIndex(0x01));
+        test_parse_attribute(&buf, 1, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_addrx2() {
+        let buf = [0x01, 0x02, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_addrx2;
+        let value = AttributeValue::DebugAddrIndex(DebugAddrIndex(0x0201));
+        test_parse_attribute(&buf, 2, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_addrx3() {
+        let buf = [0x01, 0x02, 0x03, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_addrx3;
+        let value = AttributeValue::DebugAddrIndex(DebugAddrIndex(0x03_0201));
+        test_parse_attribute(&buf, 3, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_addrx4() {
+        let buf = [0x01, 0x02, 0x03, 0x04, 0x99, 0x99];
+        let unit = test_parse_attribute_unit(4, Format::Dwarf64, LittleEndian);
+        let form = constants::DW_FORM_addrx4;
+        let value = AttributeValue::DebugAddrIndex(DebugAddrIndex(0x0403_0201));
+        test_parse_attribute(&buf, 4, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_loclistx() {
+        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        let bytes_written = {
+            let mut writable = &mut buf[..];
+            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
+        };
+
+        let unit = test_parse_attribute_unit_default();
+        let form = constants::DW_FORM_loclistx;
+        let value = AttributeValue::DebugLocListsIndex(DebugLocListsIndex(4097));
+        test_parse_attribute(&buf, bytes_written, &unit, form, value);
+    }
+
+    #[test]
+    fn test_parse_attribute_rnglistx() {
+        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        let bytes_written = {
+            let mut writable = &mut buf[..];
+            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
+        };
+
+        let unit = test_parse_attribute_unit_default();
+        let form = constants::DW_FORM_rnglistx;
+        let value = AttributeValue::DebugRngListsIndex(DebugRngListsIndex(4097));
+        test_parse_attribute(&buf, bytes_written, &unit, form, value);
     }
 
     #[test]

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -1877,7 +1877,10 @@ pub(crate) fn parse_attribute<'unit, 'abbrev, R: Reader>(
                 let index = input.read_u16().map(R::Offset::from_u16)?;
                 AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(index))
             }
-            // TODO: constants::DW_FORM_strx3
+            constants::DW_FORM_strx3 => {
+                let index = input.read_uint(3).and_then(R::Offset::from_u64)?;
+                AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(index))
+            }
             constants::DW_FORM_strx4 => {
                 let index = input.read_u32().map(R::Offset::from_u32)?;
                 AttributeValue::DebugStrOffsetsIndex(DebugStrOffsetsIndex(index))
@@ -1894,7 +1897,10 @@ pub(crate) fn parse_attribute<'unit, 'abbrev, R: Reader>(
                 let index = input.read_u16().map(R::Offset::from_u16)?;
                 AttributeValue::DebugAddrIndex(DebugAddrIndex(index))
             }
-            // TODO: constants::DW_FORM_addrx3
+            constants::DW_FORM_addrx3 => {
+                let index = input.read_uint(3).and_then(R::Offset::from_u64)?;
+                AttributeValue::DebugAddrIndex(DebugAddrIndex(index))
+            }
             constants::DW_FORM_addrx4 => {
                 let index = input.read_u32().map(R::Offset::from_u32)?;
                 AttributeValue::DebugAddrIndex(DebugAddrIndex(index))

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -4,41 +4,15 @@ extern crate test_assembler;
 
 use vec::Vec;
 
-use self::test_assembler::{Endian, Section, ToLabelOrNum};
+use self::test_assembler::Section;
 use leb128;
 
 pub trait GimliSectionMethods {
-    fn e32<'a, T>(self, endian: Endian, val: T) -> Self
-    where
-        T: ToLabelOrNum<'a, u32>;
-    fn e64<'a, T>(self, endian: Endian, val: T) -> Self
-    where
-        T: ToLabelOrNum<'a, u64>;
     fn sleb(self, val: i64) -> Self;
     fn uleb(self, val: u64) -> Self;
 }
 
 impl GimliSectionMethods for Section {
-    fn e32<'a, T>(self, endian: Endian, val: T) -> Self
-    where
-        T: ToLabelOrNum<'a, u32>,
-    {
-        match endian {
-            Endian::Little => self.L32(val),
-            Endian::Big => self.B32(val),
-        }
-    }
-
-    fn e64<'a, T>(self, endian: Endian, val: T) -> Self
-    where
-        T: ToLabelOrNum<'a, u64>,
-    {
-        match endian {
-            Endian::Little => self.L64(val),
-            Endian::Big => self.B64(val),
-        }
-    }
-
     fn sleb(self, val: i64) -> Self {
         let mut buf = Vec::new();
         let written = leb128::write::signed(&mut buf, val).unwrap();

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -4,12 +4,15 @@ extern crate test_assembler;
 
 use vec::Vec;
 
-use self::test_assembler::Section;
+use self::test_assembler::{Label, Section};
 use leb128;
+use Format;
 
 pub trait GimliSectionMethods {
     fn sleb(self, val: i64) -> Self;
     fn uleb(self, val: u64) -> Self;
+    fn initial_length(self, format: Format, length: &Label, start: &Label) -> Self;
+    fn word(self, size: u8, val: u64) -> Self;
 }
 
 impl GimliSectionMethods for Section {
@@ -23,5 +26,20 @@ impl GimliSectionMethods for Section {
         let mut buf = Vec::new();
         let written = leb128::write::unsigned(&mut buf, val).unwrap();
         self.append_bytes(&buf[0..written])
+    }
+
+    fn initial_length(self, format: Format, length: &Label, start: &Label) -> Self {
+        match format {
+            Format::Dwarf32 => self.D32(length).mark(start),
+            Format::Dwarf64 => self.D32(0xffff_ffff).D64(length).mark(start),
+        }
+    }
+
+    fn word(self, size: u8, val: u64) -> Self {
+        match size {
+            4 => self.D32(val as u32),
+            8 => self.D64(val),
+            _ => panic!("unsupported word size"),
+        }
     }
 }

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -239,6 +239,9 @@ fn test_parse_self_debug_ranges() {
     let debug_abbrev = read_section("debug_abbrev");
     let debug_abbrev = DebugAbbrev::new(&debug_abbrev, LittleEndian);
 
+    let debug_addr = DebugAddr::from(EndianSlice::new(&[], LittleEndian));
+    let debug_addr_base = DebugAddrBase(0);
+
     let debug_ranges = read_section("debug_ranges");
     let debug_ranges = DebugRanges::new(&debug_ranges, LittleEndian);
     let debug_rnglists = DebugRngLists::new(&[], LittleEndian);
@@ -271,7 +274,14 @@ fn test_parse_self_debug_ranges() {
             while let Some(attr) = attrs.next().expect("Should parse entry's attribute") {
                 if let AttributeValue::RangeListsRef(offset) = attr.value() {
                     let mut ranges = rnglists
-                        .ranges(offset, unit.version(), unit.address_size(), low_pc)
+                        .ranges(
+                            offset,
+                            unit.version(),
+                            unit.address_size(),
+                            low_pc,
+                            &debug_addr,
+                            debug_addr_base,
+                        )
                         .expect("Should parse ranges OK");
                     while let Some(range) = ranges.next().expect("Should parse next range") {
                         assert!(range.begin <= range.end);


### PR DESCRIPTION
This covers:
- addresses in `.debug_addr`
- string offsets in `.debug_str_offsets`
- range list offsets in `.debug_rnglists`
- location list offsets in `.debug_loclists`
- indexed forms (`DW_FORM_strx*`, `DW_FORM_addrx*`, `DW_FORM_rnglistx`, `DW_FORM_loclistx`)
- indexed operations (`DW_OP_addrx`, `DW_OP_constx`)
- indexed addresses in range list entries
- indexed addresses in location list entries