### PR TITLE
Replace format/version/address_size with Encoding

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -27,6 +27,23 @@ impl Format {
     }
 }
 
+/// Encoding parameters that are commonly used for multiple DWARF sections.
+///
+/// This is intended to be small enough to pass by value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Encoding {
+    /// Whether the DWARF format is 32- or 64-bit.
+    pub format: Format,
+
+    /// The DWARF version of the header.
+    pub version: u16,
+
+    /// The size of an address.
+    pub address_size: u8,
+    // The size of a segment selector.
+    // TODO: pub segment_size: u8,
+}
+
 /// A DWARF register number.
 ///
 /// The meaning of this value is ABI dependent. This is generally encoded as

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -906,7 +906,7 @@ impl Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::{DebugAbbrevOffset, Format};
+    use common::{DebugAbbrevOffset, Encoding, Format};
     use endianity::LittleEndian;
     use read::{
         Abbreviation, AttributeSpecification, DebuggingInformationEntry, EndianSlice, UnitHeader,
@@ -916,12 +916,15 @@ mod tests {
     #[test]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn valuetype_from_encoding() {
+        let encoding = Encoding {
+            format: Format::Dwarf32,
+            version: 4,
+            address_size: 4,
+        };
         let unit = UnitHeader::new(
+            encoding,
             7,
-            4,
             DebugAbbrevOffset(0),
-            4,
-            Format::Dwarf32,
             EndianSlice::new(&[], LittleEndian),
         );
 

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -98,15 +98,7 @@ fn test_convert_debug_info() {
         .write(
             &mut write_debug_ranges,
             &mut write_debug_rnglists,
-            dwarf.debug_info.units().next().unwrap().unwrap().format(),
-            dwarf.debug_info.units().next().unwrap().unwrap().version(),
-            dwarf
-                .debug_info
-                .units()
-                .next()
-                .unwrap()
-                .unwrap()
-                .address_size(),
+            dwarf.debug_info.units().next().unwrap().unwrap().encoding(),
         )
         .expect("Should write ranges");
 


### PR DESCRIPTION
- reduces number of function parameters
- makes it easier to later add support for segment sizes