### PR TITLE
read: don't use rnglists and loclists header

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -234,7 +234,7 @@ fn bench_parsing_debug_loc(b: &mut test::Bencher) {
     let debug_loc = read_section("debug_loc");
     let debug_loc = DebugLoc::new(&debug_loc, LittleEndian);
     let debug_loclists = DebugLocLists::new(&[], LittleEndian);
-    let loclists = LocationLists::new(debug_loc, debug_loclists).expect("Should parse loclists");
+    let loclists = LocationLists::new(debug_loc, debug_loclists);
 
     let mut offsets = Vec::new();
 
@@ -296,7 +296,7 @@ fn bench_parsing_debug_ranges(b: &mut test::Bencher) {
     let debug_ranges = read_section("debug_ranges");
     let debug_ranges = DebugRanges::new(&debug_ranges, LittleEndian);
     let debug_rnglists = DebugRngLists::new(&[], LittleEndian);
-    let rnglists = RangeLists::new(debug_ranges, debug_rnglists).expect("Should parse rnglists");
+    let rnglists = RangeLists::new(debug_ranges, debug_rnglists);
 
     let mut offsets = Vec::new();
 
@@ -473,7 +473,7 @@ fn bench_parsing_debug_loc_expressions(b: &mut test::Bencher) {
     let debug_loc = read_section("debug_loc");
     let debug_loc = DebugLoc::new(&debug_loc, LittleEndian);
     let debug_loclists = DebugLocLists::new(&[], LittleEndian);
-    let loclists = LocationLists::new(debug_loc, debug_loclists).expect("Should parse loclists");
+    let loclists = LocationLists::new(debug_loc, debug_loclists);
 
     let expressions = debug_loc_expressions(&debug_info, &debug_abbrev, &debug_addr, &loclists);
 
@@ -500,7 +500,7 @@ fn bench_evaluating_debug_loc_expressions(b: &mut test::Bencher) {
     let debug_loc = read_section("debug_loc");
     let debug_loc = DebugLoc::new(&debug_loc, LittleEndian);
     let debug_loclists = DebugLocLists::new(&[], LittleEndian);
-    let loclists = LocationLists::new(debug_loc, debug_loclists).expect("Should parse loclists");
+    let loclists = LocationLists::new(debug_loc, debug_loclists);
 
     let expressions = debug_loc_expressions(&debug_info, &debug_abbrev, &debug_addr, &loclists);
 

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -537,11 +537,11 @@ where
 
     let debug_loc = load_section(&arena, file, endian);
     let debug_loclists = load_section(&arena, file, endian);
-    let locations = gimli::LocationLists::new(debug_loc, debug_loclists)?;
+    let locations = gimli::LocationLists::new(debug_loc, debug_loclists);
 
     let debug_ranges = load_section(&arena, file, endian);
     let debug_rnglists = load_section(&arena, file, endian);
-    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists)?;
+    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists);
 
     let dwarf = gimli::Dwarf {
         endian,
@@ -1231,7 +1231,9 @@ fn dump_attr_value<R: Reader, W: Write>(
             writeln!(w, "<.debug_loclists+0x{:08x}>", base.0)?;
         }
         gimli::AttributeValue::DebugLocListsIndex(index) => {
-            let offset = dwarf.locations.get_offset(unit.loclists_base, index)?;
+            let offset = dwarf
+                .locations
+                .get_offset(unit.encoding, unit.loclists_base, index)?;
             writeln!(w, "0x{:08x}", offset.0)?;
             dump_loc_list(w, offset, unit, dwarf)?;
         }
@@ -1246,7 +1248,9 @@ fn dump_attr_value<R: Reader, W: Write>(
             writeln!(w, "<.debug_rnglists+0x{:08x}>", base.0)?;
         }
         gimli::AttributeValue::DebugRngListsIndex(index) => {
-            let offset = dwarf.ranges.get_offset(unit.rnglists_base, index)?;
+            let offset = dwarf
+                .ranges
+                .get_offset(unit.encoding, unit.rnglists_base, index)?;
             writeln!(w, "0x{:08x}", offset.0)?;
             dump_range_list(w, offset, unit, dwarf)?;
         }

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -381,8 +381,7 @@ mod tests {
                         read::DebugRanges::new(debug_ranges.slice(), LittleEndian);
                     let read_debug_rnglists =
                         read::DebugRngLists::new(debug_rnglists.slice(), LittleEndian);
-                    let read_ranges =
-                        read::RangeLists::new(read_debug_ranges, read_debug_rnglists).unwrap();
+                    let read_ranges = read::RangeLists::new(read_debug_ranges, read_debug_rnglists);
                     // FIXME: range_list_offsets.get()
                     let offset = if encoding.version <= 4 {
                         range_list_offsets.debug_ranges.get(range_list_id)

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1408,10 +1408,11 @@ pub(crate) mod convert {
                     return Ok(None);
                 }
                 read::AttributeValue::DebugLocListsIndex(index) => {
-                    let offset = context
-                        .dwarf
-                        .locations
-                        .get_offset(context.loclists_base, index)?;
+                    let offset = context.dwarf.locations.get_offset(
+                        from_unit.encoding(),
+                        context.loclists_base,
+                        index,
+                    )?;
                     AttributeValue::LocationListsRef(offset)
                 }
                 read::AttributeValue::RangeListsRef(val) => {
@@ -1426,10 +1427,11 @@ pub(crate) mod convert {
                     return Ok(None);
                 }
                 read::AttributeValue::DebugRngListsIndex(index) => {
-                    let offset = context
-                        .dwarf
-                        .ranges
-                        .get_offset(context.rnglists_base, index)?;
+                    let offset = context.dwarf.ranges.get_offset(
+                        from_unit.encoding(),
+                        context.rnglists_base,
+                        index,
+                    )?;
                     let iter = context
                         .dwarf
                         .ranges
@@ -2082,8 +2084,7 @@ mod tests {
                         let dwarf = read::Dwarf {
                             debug_str: read_debug_str.clone(),
                             debug_line_str: read_debug_line_str.clone(),
-                            ranges: read::RangeLists::new(read_debug_ranges, read_debug_rnglists)
-                                .unwrap(),
+                            ranges: read::RangeLists::new(read_debug_ranges, read_debug_rnglists),
                             ..Default::default()
                         };
 

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -60,13 +60,11 @@ fn test_convert_debug_info() {
     let mut line_programs = write::LineProgramTable::default();
     let mut line_strings = write::LineStringTable::default();
     let mut strings = write::StringTable::default();
-    let mut ranges = write::RangeListTable::default();
     let units = write::UnitTable::from(
         &dwarf,
         &mut line_programs,
         &mut line_strings,
         &mut strings,
-        &mut ranges,
         &|address| Some(Address::Absolute(address)),
     )
     .expect("Should convert compilation units");
@@ -101,25 +99,18 @@ fn test_convert_debug_info() {
     assert_eq!(debug_line_offsets.count(), 23);
     assert_eq!(debug_line_data.len(), 105_797);
 
-    let mut write_debug_ranges = write::DebugRanges::from(EndianVec::new(LittleEndian));
-    let mut write_debug_rnglists = write::DebugRngLists::from(EndianVec::new(LittleEndian));
-    let range_list_offsets = ranges
-        .write(
-            &mut write_debug_ranges,
-            &mut write_debug_rnglists,
-            dwarf.debug_info.units().next().unwrap().unwrap().encoding(),
-        )
-        .expect("Should write ranges");
-
     let mut write_debug_abbrev = write::DebugAbbrev::from(EndianVec::new(LittleEndian));
     let mut write_debug_info = write::DebugInfo::from(EndianVec::new(LittleEndian));
+    let mut write_debug_ranges = write::DebugRanges::from(EndianVec::new(LittleEndian));
+    let mut write_debug_rnglists = write::DebugRngLists::from(EndianVec::new(LittleEndian));
     units
         .write(
             &mut write_debug_abbrev,
             &mut write_debug_info,
+            &mut write_debug_ranges,
+            &mut write_debug_rnglists,
             &debug_line_offsets,
             &debug_line_str_offsets,
-            &range_list_offsets,
             &debug_str_offsets,
         )
         .expect("Should write units");
@@ -152,13 +143,11 @@ fn test_convert_debug_info() {
     let mut line_programs = write::LineProgramTable::default();
     let mut line_strings = write::LineStringTable::default();
     let mut strings = write::StringTable::default();
-    let mut ranges = write::RangeListTable::default();
     let units = write::UnitTable::from(
         &dwarf,
         &mut line_programs,
         &mut line_strings,
         &mut strings,
-        &mut ranges,
         &|address| Some(Address::Absolute(address)),
     )
     .expect("Should convert compilation units");

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -46,7 +46,7 @@ fn test_convert_debug_info() {
 
     let debug_rnglists = read::DebugRngLists::new(&[], LittleEndian);
 
-    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists).unwrap();
+    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists);
 
     let dwarf = read::Dwarf {
         debug_abbrev,
@@ -138,7 +138,7 @@ fn test_convert_debug_info() {
     let debug_ranges = read::DebugRanges::new(debug_ranges_data, LittleEndian);
     let debug_rnglists = read::DebugRngLists::new(&[], LittleEndian);
 
-    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists).unwrap();
+    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists);
 
     let dwarf = read::Dwarf {
         debug_abbrev,

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -178,7 +178,7 @@ fn test_parse_self_debug_loc() {
     let debug_loc = read_section("debug_loc");
     let debug_loc = DebugLoc::new(&debug_loc, LittleEndian);
     let debug_loclists = DebugLocLists::new(&[], LittleEndian);
-    let loclists = LocationLists::new(debug_loc, debug_loclists).expect("Should parse loclists");
+    let loclists = LocationLists::new(debug_loc, debug_loclists);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {
@@ -239,7 +239,7 @@ fn test_parse_self_debug_ranges() {
     let debug_ranges = read_section("debug_ranges");
     let debug_ranges = DebugRanges::new(&debug_ranges, LittleEndian);
     let debug_rnglists = DebugRngLists::new(&[], LittleEndian);
-    let rnglists = RangeLists::new(debug_ranges, debug_rnglists).expect("Should parse rnglists");
+    let rnglists = RangeLists::new(debug_ranges, debug_rnglists);
 
     let mut iter = debug_info.units();
     while let Some(unit) = iter.next().expect("Should parse compilation unit") {


### PR DESCRIPTION
These headers don't give information that is required for parsing
range lists or location lists, because the encoding of these lists
must match the encoding of the compilation unit.

Additionally, while the standard seems to indicate that each section
has only one of these headers, in practice this is not true.
Furthermore, when there are multiple headers, they do not have to
each have the same encoding, so our parsing was wrong in this case
because we only used the encoding from the first header.