### PR TITLE
write: ensure id's are used with the correct table

### DIFF
--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -6,20 +6,21 @@ use common::{DebugLineOffset, Encoding, Format};
 use constants;
 use leb128;
 use write::{
-    Address, DebugLineStrOffsets, DebugStrOffsets, Error, LineStringId, LineStringTable, Result,
-    Section, SectionId, StringId, Writer,
+    Address, BaseId, DebugLineStrOffsets, DebugStrOffsets, Error, LineStringId, LineStringTable,
+    Result, Section, SectionId, StringId, Writer,
 };
 
 /// A table of line number programs that will be stored in a `.debug_line` section.
 #[derive(Debug, Default)]
 pub struct LineProgramTable {
+    base_id: BaseId,
     programs: Vec<LineProgram>,
 }
 
 impl LineProgramTable {
     /// Add a line number program to the table.
     pub fn add(&mut self, program: LineProgram) -> LineProgramId {
-        let id = LineProgramId(self.programs.len());
+        let id = LineProgramId::new(self.base_id, self.programs.len());
         self.programs.push(program);
         id
     }
@@ -37,7 +38,8 @@ impl LineProgramTable {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get(&self, id: LineProgramId) -> &LineProgram {
-        &self.programs[id.0]
+        assert_eq!(self.base_id, id.base_id);
+        &self.programs[id.index]
     }
 
     /// Get a mutable reference to a line number program.
@@ -47,7 +49,8 @@ impl LineProgramTable {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get_mut(&mut self, id: LineProgramId) -> &mut LineProgram {
-        &mut self.programs[id.0]
+        assert_eq!(self.base_id, id.base_id);
+        &mut self.programs[id.index]
     }
 
     /// Write the line number programs to the given section.
@@ -61,13 +64,17 @@ impl LineProgramTable {
         for program in &self.programs {
             offsets.push(program.write(debug_line, debug_line_str_offsets, debug_str_offsets)?);
         }
-        Ok(DebugLineOffsets { offsets })
+        Ok(DebugLineOffsets {
+            base_id: self.base_id,
+            offsets,
+        })
     }
 }
 
-/// An identifier for a `LineProgram` in a `LineProgramTable`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct LineProgramId(pub usize);
+define_id!(
+    LineProgramId,
+    "An identifier for a `LineProgram` in a `LineProgramTable`."
+);
 
 /// The initial value of the `is_statement` register.
 //
@@ -1203,8 +1210,8 @@ mod tests {
 
         assert_eq!(programs.count(), program_ids.len());
 
-        let debug_line_str_offsets = DebugLineStrOffsets::default();
-        let debug_str_offsets = DebugStrOffsets::default();
+        let debug_line_str_offsets = DebugLineStrOffsets::none();
+        let debug_str_offsets = DebugStrOffsets::none();
         let mut debug_line = DebugLine::from(EndianVec::new(LittleEndian));
         let debug_line_offsets = programs
             .write(&mut debug_line, &debug_line_str_offsets, &debug_str_offsets)
@@ -1268,8 +1275,8 @@ mod tests {
         let file2 = &b"file2"[..];
         let convert_address = &|address| Some(Address::Absolute(address));
 
-        let debug_line_str_offsets = DebugLineStrOffsets::default();
-        let debug_str_offsets = DebugStrOffsets::default();
+        let debug_line_str_offsets = DebugLineStrOffsets::none();
+        let debug_str_offsets = DebugStrOffsets::none();
 
         for &version in &[2, 3, 4, 5] {
             for &address_size in &[4, 8] {
@@ -1577,8 +1584,8 @@ mod tests {
         let dir1 = &b"dir1"[..];
         let file1 = &b"file1"[..];
 
-        let debug_line_str_offsets = DebugLineStrOffsets::default();
-        let debug_str_offsets = DebugStrOffsets::default();
+        let debug_line_str_offsets = DebugLineStrOffsets::none();
+        let debug_str_offsets = DebugStrOffsets::none();
 
         for &version in &[2, 3, 4, 5] {
             for &address_size in &[4, 8] {
@@ -1721,8 +1728,8 @@ mod tests {
         let addresses = 0..50;
         let lines = -10..25i64;
 
-        let debug_line_str_offsets = DebugLineStrOffsets::default();
-        let debug_str_offsets = DebugStrOffsets::default();
+        let debug_line_str_offsets = DebugLineStrOffsets::none();
+        let debug_str_offsets = DebugStrOffsets::none();
 
         for minimum_instruction_length in vec![1, 4] {
             for maximum_operations_per_instruction in vec![1, 3] {

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -38,7 +38,7 @@ impl LineProgramTable {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get(&self, id: LineProgramId) -> &LineProgram {
-        assert_eq!(self.base_id, id.base_id);
+        debug_assert_eq!(self.base_id, id.base_id);
         &self.programs[id.index]
     }
 
@@ -49,7 +49,7 @@ impl LineProgramTable {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get_mut(&mut self, id: LineProgramId) -> &mut LineProgram {
-        assert_eq!(self.base_id, id.base_id);
+        debug_assert_eq!(self.base_id, id.base_id);
         &mut self.programs[id.index]
     }
 

--- a/src/write/str.rs
+++ b/src/write/str.rs
@@ -61,7 +61,7 @@ macro_rules! define_string_table {
             ///
             /// Panics if `id` is invalid.
             pub fn get(&self, id: $id) -> &[u8] {
-                assert_eq!(self.base_id, id.base_id);
+                debug_assert_eq!(self.base_id, id.base_id);
                 self.strings.get_index(id.index).map(Vec::as_slice).unwrap()
             }
 

--- a/src/write/str.rs
+++ b/src/write/str.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use vec::Vec;
 
 use common::{DebugLineStrOffset, DebugStrOffset};
-use write::{Result, Section, SectionId, Writer};
+use write::{BaseId, Result, Section, SectionId, Writer};
 
 // Requirements:
 // - values are `[u8]`, null bytes are not allowed
@@ -27,6 +27,7 @@ macro_rules! define_string_table {
         #[doc=$docs]
         #[derive(Debug, Default)]
         pub struct $name {
+            base_id: BaseId,
             strings: IndexSet<Vec<u8>>,
         }
 
@@ -45,7 +46,7 @@ macro_rules! define_string_table {
                 let bytes = bytes.into();
                 assert!(!bytes.contains(&0));
                 let (index, _) = self.strings.insert_full(bytes);
-                $id(index)
+                $id::new(self.base_id, index)
             }
 
             /// Return the number of strings in the table.
@@ -60,7 +61,8 @@ macro_rules! define_string_table {
             ///
             /// Panics if `id` is invalid.
             pub fn get(&self, id: $id) -> &[u8] {
-                self.strings.get_index(id.0).map(Vec::as_slice).unwrap()
+                assert_eq!(self.base_id, id.base_id);
+                self.strings.get_index(id.index).map(Vec::as_slice).unwrap()
             }
 
             /// Write the string table to the `.debug_str` section.
@@ -74,15 +76,16 @@ macro_rules! define_string_table {
                     w.write_u8(0)?;
                 }
 
-                Ok($offsets { offsets })
+                Ok($offsets {
+                    base_id: self.base_id,
+                    offsets,
+                })
             }
         }
     };
 }
 
-/// An identifier for a string in a `StringTable`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct StringId(usize);
+define_id!(StringId, "An identifier for a string in a `StringTable`.");
 
 define_string_table!(
     StringTable,
@@ -99,9 +102,10 @@ define_offsets!(
     "The section offsets of all strings within a `.debug_str` section."
 );
 
-/// An identifier for a string in a `LineStringTable`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct LineStringId(usize);
+define_id!(
+    LineStringId,
+    "An identifier for a string in a `LineStringTable`."
+);
 
 define_string_table!(
     LineStringTable,

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -71,7 +71,7 @@ impl UnitTable {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get(&self, id: UnitId) -> &CompilationUnit {
-        assert_eq!(self.base_id, id.base_id);
+        debug_assert_eq!(self.base_id, id.base_id);
         &self.units[id.index]
     }
 
@@ -82,7 +82,7 @@ impl UnitTable {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get_mut(&mut self, id: UnitId) -> &mut CompilationUnit {
-        assert_eq!(self.base_id, id.base_id);
+        debug_assert_eq!(self.base_id, id.base_id);
         &mut self.units[id.index]
     }
 
@@ -224,7 +224,7 @@ impl CompilationUnit {
     /// Panics if `parent` is invalid.
     #[inline]
     pub fn add(&mut self, parent: UnitEntryId, tag: constants::DwTag) -> UnitEntryId {
-        assert_eq!(self.base_id, parent.base_id);
+        debug_assert_eq!(self.base_id, parent.base_id);
         DebuggingInformationEntry::new(self.base_id, &mut self.entries, Some(parent), tag)
     }
 
@@ -235,7 +235,7 @@ impl CompilationUnit {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get(&self, id: UnitEntryId) -> &DebuggingInformationEntry {
-        assert_eq!(self.base_id, id.base_id);
+        debug_assert_eq!(self.base_id, id.base_id);
         &self.entries[id.index]
     }
 
@@ -246,7 +246,7 @@ impl CompilationUnit {
     /// Panics if `id` is invalid.
     #[inline]
     pub fn get_mut(&mut self, id: UnitEntryId) -> &mut DebuggingInformationEntry {
-        assert_eq!(self.base_id, id.base_id);
+        debug_assert_eq!(self.base_id, id.base_id);
         &mut self.entries[id.index]
     }
 
@@ -369,7 +369,7 @@ impl DebuggingInformationEntry {
             children: Vec::new(),
         });
         if let Some(parent) = parent {
-            assert_eq!(base_id, parent.base_id);
+            debug_assert_eq!(base_id, parent.base_id);
             assert_ne!(parent, id);
             entries[parent.index].children.push(id);
         }
@@ -1089,14 +1089,14 @@ impl DebugInfoOffsets {
     /// Get the `.debug_info` section offset for the given unit.
     #[inline]
     pub fn unit(&self, unit: UnitId) -> DebugInfoOffset {
-        assert_eq!(self.base_id, unit.base_id);
+        debug_assert_eq!(self.base_id, unit.base_id);
         self.units[unit.index].unit
     }
 
     /// Get the `.debug_info` section offset for the given entry.
     #[inline]
     pub fn entry(&self, unit: UnitId, entry: UnitEntryId) -> DebugInfoOffset {
-        assert_eq!(self.base_id, unit.base_id);
+        debug_assert_eq!(self.base_id, unit.base_id);
         self.units[unit.index].entry(entry)
     }
 }
@@ -1112,7 +1112,7 @@ struct UnitOffsets {
 impl UnitOffsets {
     #[inline]
     fn entry(&self, entry: UnitEntryId) -> DebugInfoOffset {
-        assert_eq!(self.base_id, entry.base_id);
+        debug_assert_eq!(self.base_id, entry.base_id);
         self.entries[entry.index]
     }
 }

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -70,14 +70,14 @@ fn test_convert_debug_info() {
     .expect("Should convert compilation units");
     assert_eq!(units.count(), 23);
     let entries: usize = (0..units.count())
-        .map(|id| units.get(write::UnitId(id)).count())
+        .map(|i| units.get(units.id(i)).count())
         .sum();
     assert_eq!(entries, 29_560);
     assert_eq!(line_strings.count(), 0);
     assert_eq!(strings.count(), 3921);
 
     // Write to new sections
-    let debug_line_str_offsets = write::DebugLineStrOffsets::default();
+    let debug_line_str_offsets = write::DebugLineStrOffsets::none();
 
     let mut write_debug_str = write::DebugStr::from(EndianVec::new(LittleEndian));
     let debug_str_offsets = strings
@@ -153,7 +153,7 @@ fn test_convert_debug_info() {
     .expect("Should convert compilation units");
     assert_eq!(units.count(), 23);
     let entries: usize = (0..units.count())
-        .map(|id| units.get(write::UnitId(id)).count())
+        .map(|i| units.get(units.id(i)).count())
         .sum();
     assert_eq!(entries, 29_560);
     assert_eq!(line_programs.count(), 23);


### PR DESCRIPTION
Add a BaseId field to all tables and id types, and check these
match when using the id to access to a table entry.

Makes it easier to diagnose #377 