### PR TITLE
write: improve high level API

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -146,3 +146,12 @@ impl<T> From<T> for EhFrameOffset<T> {
         EhFrameOffset(o)
     }
 }
+
+/// An offset into the `.debug_info` or `.debug_types` sections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum UnitSectionOffset<T = usize> {
+    /// An offset into the `.debug_info` section.
+    DebugInfoOffset(DebugInfoOffset<T>),
+    /// An offset into the `.debug_types` section.
+    DebugTypesOffset(DebugTypesOffset<T>),
+}

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -2,6 +2,7 @@ use common::{
     DebugAddrBase, DebugAddrIndex, DebugInfoOffset, DebugLineStrOffset, DebugLocListsBase,
     DebugLocListsIndex, DebugRngListsBase, DebugRngListsIndex, DebugStrOffset, DebugStrOffsetsBase,
     DebugStrOffsetsIndex, DebugTypesOffset, Encoding, LocationListsOffset, RangeListsOffset,
+    UnitSectionOffset,
 };
 use constants;
 use read::{
@@ -458,15 +459,6 @@ impl<R: Reader> Unit<R> {
     pub fn entries_tree(&self, offset: Option<UnitOffset<R::Offset>>) -> Result<EntriesTree<R>> {
         self.header.entries_tree(&self.abbreviations, offset)
     }
-}
-
-/// An offset into the `.debug_info` or `.debug_types` sections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum UnitSectionOffset<T = usize> {
-    /// An offset into the `.debug_info` section.
-    DebugInfoOffset(DebugInfoOffset<T>),
-    /// An offset into the `.debug_types` section.
-    DebugTypesOffset(DebugTypesOffset<T>),
 }
 
 impl<T: ReaderOffset> UnitSectionOffset<T> {

--- a/src/write/dwarf.rs
+++ b/src/write/dwarf.rs
@@ -1,0 +1,132 @@
+use vec::Vec;
+
+use common::Encoding;
+use write::{
+    AbbreviationTable, LineProgram, LineStringTable, Result, Sections, StringTable, Unit,
+    UnitTable, Writer,
+};
+
+/// Writable DWARF information for more than one unit.
+#[derive(Debug, Default)]
+pub struct Dwarf {
+    /// A table of units. These are primarily stored in the `.debug_info` section,
+    /// but they also contain information that is stored in other sections.
+    pub units: UnitTable,
+
+    /// Extra line number programs that are not associated with a unit.
+    ///
+    /// These should only be used when generating DWARF5 line-only debug
+    /// information.
+    pub line_programs: Vec<LineProgram>,
+
+    /// A table of strings that will be stored in the `.debug_line_str` section.
+    pub line_strings: LineStringTable,
+
+    /// A table of strings that will be stored in the `.debug_str` section.
+    pub strings: StringTable,
+}
+
+impl Dwarf {
+    /// Write the DWARF information to the given sections.
+    pub fn write<W: Writer>(&self, sections: &mut Sections<W>) -> Result<()> {
+        let line_strings = self.line_strings.write(&mut sections.debug_line_str)?;
+        let strings = self.strings.write(&mut sections.debug_str)?;
+        self.units.write(sections, &line_strings, &strings)?;
+        for line_program in &self.line_programs {
+            line_program.write(
+                &mut sections.debug_line,
+                line_program.encoding(),
+                &line_strings,
+                &strings,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Writable DWARF information for a single unit.
+#[derive(Debug)]
+pub struct DwarfUnit {
+    /// A unit. This is primarily stored in the `.debug_info` section,
+    /// but also contains information that is stored in other sections.
+    pub unit: Unit,
+
+    /// A table of strings that will be stored in the `.debug_line_str` section.
+    pub line_strings: LineStringTable,
+
+    /// A table of strings that will be stored in the `.debug_str` section.
+    pub strings: StringTable,
+}
+
+impl DwarfUnit {
+    /// Create a new `DwarfUnit`.
+    ///
+    /// Note: you should set `self.unit.line_program` after creation.
+    /// This cannot be done earlier because it may need to reference
+    /// `self.line_strings`.
+    pub fn new(encoding: Encoding) -> Self {
+        let unit = Unit::new(encoding, LineProgram::none());
+        DwarfUnit {
+            unit,
+            line_strings: LineStringTable::default(),
+            strings: StringTable::default(),
+        }
+    }
+
+    /// Write the DWARf information to the given sections.
+    pub fn write<W: Writer>(&self, sections: &mut Sections<W>) -> Result<()> {
+        let line_strings = self.line_strings.write(&mut sections.debug_line_str)?;
+        let strings = self.strings.write(&mut sections.debug_str)?;
+
+        let abbrev_offset = sections.debug_abbrev.offset();
+        let mut abbrevs = AbbreviationTable::default();
+
+        let mut debug_info_refs = Vec::new();
+        self.unit.write(
+            sections,
+            abbrev_offset,
+            &mut abbrevs,
+            &line_strings,
+            &strings,
+            &mut debug_info_refs,
+        )?;
+        // None should exist because we didn't give out any UnitId.
+        assert!(debug_info_refs.is_empty());
+
+        abbrevs.write(&mut sections.debug_abbrev)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "read")]
+pub(crate) mod convert {
+    use super::*;
+    use read::{self, Reader};
+    use write::{Address, ConvertResult};
+
+    impl Dwarf {
+        /// Create a `write::Dwarf` by converting a `read::Dwarf`.
+        ///
+        /// `convert_address` is a function to convert read addresses into the `Address`
+        /// type. For non-relocatable addresses, this function may simply return
+        /// `Address::Absolute(address)`. For relocatable addresses, it is the caller's
+        /// responsibility to determine the symbol and addend corresponding to the address
+        /// and return `Address::Relative { symbol, addend }`.
+        pub fn from<R: Reader<Offset = usize>>(
+            dwarf: &read::Dwarf<R>,
+            convert_address: &Fn(u64) -> Option<Address>,
+        ) -> ConvertResult<Dwarf> {
+            let mut line_strings = LineStringTable::default();
+            let mut strings = StringTable::default();
+            let units = UnitTable::from(dwarf, &mut line_strings, &mut strings, convert_address)?;
+            // TODO: convert the line programs that were not referenced by a unit.
+            let line_programs = Vec::new();
+            Ok(Dwarf {
+                units,
+                line_programs,
+                line_strings,
+                strings,
+            })
+        }
+    }
+}

--- a/src/write/dwarf.rs
+++ b/src/write/dwarf.rs
@@ -28,7 +28,7 @@ pub struct Dwarf {
 
 impl Dwarf {
     /// Write the DWARF information to the given sections.
-    pub fn write<W: Writer>(&self, sections: &mut Sections<W>) -> Result<()> {
+    pub fn write<W: Writer>(&mut self, sections: &mut Sections<W>) -> Result<()> {
         let line_strings = self.line_strings.write(&mut sections.debug_line_str)?;
         let strings = self.strings.write(&mut sections.debug_str)?;
         self.units.write(sections, &line_strings, &strings)?;
@@ -74,7 +74,7 @@ impl DwarfUnit {
     }
 
     /// Write the DWARf information to the given sections.
-    pub fn write<W: Writer>(&self, sections: &mut Sections<W>) -> Result<()> {
+    pub fn write<W: Writer>(&mut self, sections: &mut Sections<W>) -> Result<()> {
         let line_strings = self.line_strings.write(&mut sections.debug_line_str)?;
         let strings = self.strings.write(&mut sections.debug_str)?;
 

--- a/src/write/endian_vec.rs
+++ b/src/write/endian_vec.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use vec::Vec;
 
 use endianity::Endianity;
@@ -35,6 +36,13 @@ where
     /// Convert into a `Vec<u8>`.
     pub fn into_vec(self) -> Vec<u8> {
         self.vec
+    }
+
+    /// Take any written data out of the `EndianVec`, leaving an empty `Vec` in its place.
+    pub fn take(&mut self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        mem::swap(&mut self.vec, &mut vec);
+        vec
     }
 }
 

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -496,6 +496,10 @@ impl LineProgram {
     }
 
     /// Write the line number program to the given section.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.is_none()`.
     pub fn write<W: Writer>(
         &self,
         w: &mut DebugLine<W>,
@@ -503,9 +507,7 @@ impl LineProgram {
         debug_line_str_offsets: &DebugLineStrOffsets,
         debug_str_offsets: &DebugStrOffsets,
     ) -> Result<DebugLineOffset> {
-        if self.none {
-            return Err(Error::CannotWriteEmptyLineProgram);
-        }
+        assert!(!self.is_none());
 
         if encoding.version < self.version()
             || encoding.format != self.format()

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -6,75 +6,9 @@ use common::{DebugLineOffset, Encoding, Format};
 use constants;
 use leb128;
 use write::{
-    Address, BaseId, DebugLineStrOffsets, DebugStrOffsets, Error, LineStringId, LineStringTable,
-    Result, Section, SectionId, StringId, Writer,
+    Address, DebugLineStrOffsets, DebugStrOffsets, Error, LineStringId, LineStringTable, Result,
+    Section, SectionId, StringId, Writer,
 };
-
-/// A table of line number programs that will be stored in a `.debug_line` section.
-#[derive(Debug, Default)]
-pub struct LineProgramTable {
-    base_id: BaseId,
-    programs: Vec<LineProgram>,
-}
-
-impl LineProgramTable {
-    /// Add a line number program to the table.
-    pub fn add(&mut self, program: LineProgram) -> LineProgramId {
-        let id = LineProgramId::new(self.base_id, self.programs.len());
-        self.programs.push(program);
-        id
-    }
-
-    /// Return the number of line number programs in the table.
-    #[inline]
-    pub fn count(&self) -> usize {
-        self.programs.len()
-    }
-
-    /// Get a reference to a line number program.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `id` is invalid.
-    #[inline]
-    pub fn get(&self, id: LineProgramId) -> &LineProgram {
-        debug_assert_eq!(self.base_id, id.base_id);
-        &self.programs[id.index]
-    }
-
-    /// Get a mutable reference to a line number program.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `id` is invalid.
-    #[inline]
-    pub fn get_mut(&mut self, id: LineProgramId) -> &mut LineProgram {
-        debug_assert_eq!(self.base_id, id.base_id);
-        &mut self.programs[id.index]
-    }
-
-    /// Write the line number programs to the given section.
-    pub fn write<W: Writer>(
-        &self,
-        debug_line: &mut DebugLine<W>,
-        debug_line_str_offsets: &DebugLineStrOffsets,
-        debug_str_offsets: &DebugStrOffsets,
-    ) -> Result<DebugLineOffsets> {
-        let mut offsets = Vec::new();
-        for program in &self.programs {
-            offsets.push(program.write(debug_line, debug_line_str_offsets, debug_str_offsets)?);
-        }
-        Ok(DebugLineOffsets {
-            base_id: self.base_id,
-            offsets,
-        })
-    }
-}
-
-define_id!(
-    LineProgramId,
-    "An identifier for a `LineProgram` in a `LineProgramTable`."
-);
 
 /// The initial value of the `is_statement` register.
 //
@@ -518,9 +452,17 @@ impl LineProgram {
     pub fn write<W: Writer>(
         &self,
         w: &mut DebugLine<W>,
+        encoding: Encoding,
         debug_line_str_offsets: &DebugLineStrOffsets,
         debug_str_offsets: &DebugStrOffsets,
     ) -> Result<DebugLineOffset> {
+        if encoding.version < self.version()
+            || encoding.format != self.format()
+            || encoding.address_size != self.address_size()
+        {
+            return Err(Error::IncompatibleLineProgramEncoding);
+        }
+
         let offset = w.offset();
 
         let length_offset = w.write_initial_length(self.format())?;
@@ -965,11 +907,6 @@ define_section!(
     "A writable `.debug_line` section."
 );
 
-define_offsets!(
-    DebugLineOffsets: LineProgramId => DebugLineOffset,
-    "The section offsets of all line number programs within a `.debug_line` section."
-);
-
 #[cfg(feature = "read")]
 mod convert {
     use super::*;
@@ -1162,8 +1099,7 @@ mod tests {
         let dir2 = LineString::String(b"dir2".to_vec());
         let file2 = LineString::String(b"file2".to_vec());
 
-        let mut programs = LineProgramTable::default();
-        let mut program_ids = Vec::new();
+        let mut programs = Vec::new();
         for &version in &[2, 3, 4, 5] {
             for &address_size in &[4, 8] {
                 for &format in &[Format::Dwarf32, Format::Dwarf64] {
@@ -1172,12 +1108,10 @@ mod tests {
                         version,
                         address_size,
                     };
-                    let program =
+                    let mut program =
                         LineProgram::new(encoding, 1, 1, -5, 14, dir1.clone(), file1.clone(), None);
-                    let program_id = programs.add(program);
 
                     {
-                        let program = programs.get_mut(program_id);
                         assert_eq!(&dir1, program.get_directory(program.default_directory()));
                         program.file_has_timestamp = true;
                         program.file_has_size = true;
@@ -1212,29 +1146,37 @@ mod tests {
                         );
                         assert_eq!(file_info, *program.get_file_info(file_id));
 
-                        program_ids.push((program_id, file_id, encoding));
+                        programs.push((program, file_id, encoding));
                     }
                 }
             }
         }
 
-        assert_eq!(programs.count(), program_ids.len());
-
         let debug_line_str_offsets = DebugLineStrOffsets::none();
         let debug_str_offsets = DebugStrOffsets::none();
         let mut debug_line = DebugLine::from(EndianVec::new(LittleEndian));
-        let debug_line_offsets = programs
-            .write(&mut debug_line, &debug_line_str_offsets, &debug_str_offsets)
-            .unwrap();
-        assert_eq!(debug_line_offsets.count(), program_ids.len());
+        let mut debug_line_offsets = Vec::new();
+        for (program, _, encoding) in &programs {
+            debug_line_offsets.push(
+                program
+                    .write(
+                        &mut debug_line,
+                        *encoding,
+                        &debug_line_str_offsets,
+                        &debug_str_offsets,
+                    )
+                    .unwrap(),
+            );
+        }
 
         let read_debug_line = read::DebugLine::new(debug_line.slice(), LittleEndian);
 
         let convert_address = &|address| Some(Address::Absolute(address));
-        for (program_id, file_id, encoding) in program_ids.iter() {
+        for ((program, file_id, encoding), offset) in programs.iter().zip(debug_line_offsets.iter())
+        {
             let read_program = read_debug_line
                 .program(
-                    debug_line_offsets.get(*program_id),
+                    *offset,
                     encoding.address_size,
                     Some(read::EndianSlice::new(b"dir1", LittleEndian)),
                     Some(read::EndianSlice::new(b"file1", LittleEndian)),
@@ -1252,7 +1194,6 @@ mod tests {
                 convert_address,
             )
             .unwrap();
-            let program = programs.get(*program_id);
             assert_eq!(convert_program.version(), program.version());
             assert_eq!(convert_program.address_size(), program.address_size());
             assert_eq!(convert_program.format(), program.format());
@@ -1537,19 +1478,21 @@ mod tests {
                         );
 
                         // Test LineProgram::from().
-                        let mut programs = LineProgramTable::default();
-                        let program_id = programs.add(program);
-
                         let mut debug_line = DebugLine::from(EndianVec::new(LittleEndian));
-                        let debug_line_offsets = programs
-                            .write(&mut debug_line, &debug_line_str_offsets, &debug_str_offsets)
+                        let debug_line_offset = program
+                            .write(
+                                &mut debug_line,
+                                encoding,
+                                &debug_line_str_offsets,
+                                &debug_str_offsets,
+                            )
                             .unwrap();
 
                         let read_debug_line =
                             read::DebugLine::new(debug_line.slice(), LittleEndian);
                         let read_program = read_debug_line
                             .program(
-                                debug_line_offsets.get(program_id),
+                                debug_line_offset,
                                 address_size,
                                 Some(read::EndianSlice::new(dir1, LittleEndian)),
                                 Some(read::EndianSlice::new(file1, LittleEndian)),
@@ -1671,21 +1614,24 @@ mod tests {
                         ),
                     ][..]
                     {
-                        let mut programs = LineProgramTable::default();
                         let mut program = program.clone();
                         program.instructions.push(*inst);
-                        let program_id = programs.add(program);
 
                         let mut debug_line = DebugLine::from(EndianVec::new(LittleEndian));
-                        let debug_line_offsets = programs
-                            .write(&mut debug_line, &debug_line_str_offsets, &debug_str_offsets)
+                        let debug_line_offset = program
+                            .write(
+                                &mut debug_line,
+                                encoding,
+                                &debug_line_str_offsets,
+                                &debug_str_offsets,
+                            )
                             .unwrap();
 
                         let read_debug_line =
                             read::DebugLine::new(debug_line.slice(), LittleEndian);
                         let read_program = read_debug_line
                             .program(
-                                debug_line_offsets.get(program_id),
+                                debug_line_offset,
                                 address_size,
                                 Some(read::EndianSlice::new(dir1, LittleEndian)),
                                 Some(read::EndianSlice::new(file1, LittleEndian)),
@@ -1755,18 +1701,21 @@ mod tests {
                             program.end_sequence(address_offset);
                         }
 
-                        let mut programs = LineProgramTable::default();
-                        let program_id = programs.add(program);
                         let mut debug_line = DebugLine::from(EndianVec::new(LittleEndian));
-                        let debug_line_offsets = programs
-                            .write(&mut debug_line, &debug_line_str_offsets, &debug_str_offsets)
+                        let debug_line_offset = program
+                            .write(
+                                &mut debug_line,
+                                encoding,
+                                &debug_line_str_offsets,
+                                &debug_str_offsets,
+                            )
                             .unwrap();
 
                         let read_debug_line =
                             read::DebugLine::new(debug_line.slice(), LittleEndian);
                         let read_program = read_debug_line
                             .program(
-                                debug_line_offsets.get(program_id),
+                                debug_line_offset,
                                 8,
                                 Some(read::EndianSlice::new(dir1, LittleEndian)),
                                 Some(read::EndianSlice::new(file1, LittleEndian)),
@@ -1846,7 +1795,6 @@ mod tests {
                         ),
                     ),
                 ] {
-                    let mut programs = LineProgramTable::default();
                     let program = LineProgram::new(
                         encoding,
                         1,
@@ -1857,16 +1805,20 @@ mod tests {
                         file,
                         None,
                     );
-                    let program_id = programs.add(program);
 
                     let mut debug_line = DebugLine::from(EndianVec::new(LittleEndian));
-                    let debug_line_offsets = programs
-                        .write(&mut debug_line, &debug_line_str_offsets, &debug_str_offsets)
+                    let debug_line_offset = program
+                        .write(
+                            &mut debug_line,
+                            encoding,
+                            &debug_line_str_offsets,
+                            &debug_str_offsets,
+                        )
                         .unwrap();
 
                     let read_debug_line = read::DebugLine::new(debug_line.slice(), LittleEndian);
                     let read_program = read_debug_line
-                        .program(debug_line_offsets.get(program_id), address_size, None, None)
+                        .program(debug_line_offset, address_size, None, None)
                         .unwrap();
                     let read_header = read_program.header();
                     assert_eq!(read_header.file(0).unwrap().path_name(), expect_file);

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -117,8 +117,6 @@ pub enum Error {
     InvalidRange,
     /// The line number program encoding is incompatible with the unit encoding.
     IncompatibleLineProgramEncoding,
-    /// The line number program has no settings and cannot be written.
-    CannotWriteEmptyLineProgram,
 }
 
 impl fmt::Display for Error {
@@ -151,10 +149,6 @@ impl fmt::Display for Error {
             Error::IncompatibleLineProgramEncoding => write!(
                 f,
                 "The line number program encoding is incompatible with the unit encoding."
-            ),
-            Error::CannotWriteEmptyLineProgram => write!(
-                f,
-                "The line number program has no settings and cannot be written."
             ),
         }
     }

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -156,6 +156,8 @@ pub enum Error {
     InvalidRange,
     /// The line number program encoding is incompatible with the unit encoding.
     IncompatibleLineProgramEncoding,
+    /// The line number program has no settings and cannot be written.
+    CannotWriteEmptyLineProgram,
 }
 
 impl fmt::Display for Error {
@@ -188,6 +190,10 @@ impl fmt::Display for Error {
             Error::IncompatibleLineProgramEncoding => write!(
                 f,
                 "The line number program encoding is incompatible with the unit encoding."
+            ),
+            Error::CannotWriteEmptyLineProgram => write!(
+                f,
+                "The line number program has no settings and cannot be written."
             ),
         }
     }

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -72,6 +72,9 @@ macro_rules! define_offsets {
     };
 }
 
+mod dwarf;
+pub use self::dwarf::*;
+
 mod abbrev;
 pub use self::abbrev::*;
 

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -154,6 +154,8 @@ pub enum Error {
     LineStringFormMismatch,
     /// The range is empty or otherwise invalid.
     InvalidRange,
+    /// The line number program encoding is incompatible with the unit encoding.
+    IncompatibleLineProgramEncoding,
 }
 
 impl fmt::Display for Error {
@@ -183,6 +185,10 @@ impl fmt::Display for Error {
                 write!(f, "Strings in line number program have mismatched forms.")
             }
             Error::InvalidRange => write!(f, "The range is empty or otherwise invalid."),
+            Error::IncompatibleLineProgramEncoding => write!(
+                f,
+                "The line number program encoding is incompatible with the unit encoding."
+            ),
         }
     }
 }

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -387,7 +387,7 @@ mod tests {
                         ranges: &mut ranges,
                         convert_address: &|address| Some(Address::Absolute(address)),
                         base_address: Address::Absolute(0),
-                        line_program: None,
+                        line_program_offset: None,
                         line_program_files: Vec::new(),
                     };
                     let convert_range_list = RangeList::from(read_range_list, &context).unwrap();

--- a/src/write/section.rs
+++ b/src/write/section.rs
@@ -1,0 +1,181 @@
+use std::ops::DerefMut;
+use std::result;
+
+use write::{
+    DebugAbbrev, DebugInfo, DebugLine, DebugLineStr, DebugRanges, DebugRngLists, DebugStr, Writer,
+};
+
+macro_rules! define_section {
+    ($name:ident, $offset:ident, $docs:expr) => {
+        #[doc=$docs]
+        #[derive(Debug, Default)]
+        pub struct $name<W: Writer>(pub W);
+
+        impl<W: Writer> $name<W> {
+            /// Return the offset of the next write.
+            pub fn offset(&self) -> $offset {
+                $offset(self.len())
+            }
+        }
+
+        impl<W: Writer> From<W> for $name<W> {
+            #[inline]
+            fn from(w: W) -> Self {
+                $name(w)
+            }
+        }
+
+        impl<W: Writer> Deref for $name<W> {
+            type Target = W;
+
+            #[inline]
+            fn deref(&self) -> &W {
+                &self.0
+            }
+        }
+
+        impl<W: Writer> DerefMut for $name<W> {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut W {
+                &mut self.0
+            }
+        }
+
+        impl<W: Writer> Section<W> for $name<W> {
+            #[inline]
+            fn id(&self) -> SectionId {
+                SectionId::$name
+            }
+        }
+    };
+}
+
+/// An identifier for a DWARF section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionId {
+    /// The `.debug_abbrev` section.
+    DebugAbbrev,
+    /// The `.debug_info` section.
+    DebugInfo,
+    /// The `.debug_line` section.
+    DebugLine,
+    /// The `.debug_line_str` section.
+    DebugLineStr,
+    /// The `.debug_loc` section.
+    DebugLoc,
+    /// The `.debug_loclists` section.
+    DebugLocLists,
+    /// The `.debug_macinfo` section.
+    DebugMacinfo,
+    /// The `.debug_ranges` section.
+    DebugRanges,
+    /// The `.debug_rnglists` section.
+    DebugRngLists,
+    /// The `.debug_str` section.
+    DebugStr,
+}
+
+impl SectionId {
+    /// Returns the ELF section name for this kind.
+    pub fn name(self) -> &'static str {
+        match self {
+            SectionId::DebugAbbrev => ".debug_abbrev",
+            SectionId::DebugInfo => ".debug_info",
+            SectionId::DebugLine => ".debug_line",
+            SectionId::DebugLineStr => ".debug_line_str",
+            SectionId::DebugLoc => ".debug_loc",
+            SectionId::DebugLocLists => ".debug_loclists",
+            SectionId::DebugMacinfo => ".debug_macinfo",
+            SectionId::DebugRanges => ".debug_ranges",
+            SectionId::DebugRngLists => ".debug_rnglists",
+            SectionId::DebugStr => ".debug_str",
+        }
+    }
+}
+
+/// Functionality common to all writable DWARF sections.
+pub trait Section<W: Writer>: DerefMut<Target = W> {
+    /// Returns the DWARF section kind for this type.
+    fn id(&self) -> SectionId;
+
+    /// Returns the ELF section name for this type.
+    fn name(&self) -> &'static str {
+        self.id().name()
+    }
+}
+
+/// All of the writable DWARF sections.
+#[derive(Debug, Default)]
+pub struct Sections<W: Writer> {
+    /// The `.debug_abbrev` section.
+    pub debug_abbrev: DebugAbbrev<W>,
+    /// The `.debug_info` section.
+    pub debug_info: DebugInfo<W>,
+    /// The `.debug_line` section.
+    pub debug_line: DebugLine<W>,
+    /// The `.debug_line_str` section.
+    pub debug_line_str: DebugLineStr<W>,
+    /// The `.debug_ranges` section.
+    pub debug_ranges: DebugRanges<W>,
+    /// The `.debug_rnglists` section.
+    pub debug_rnglists: DebugRngLists<W>,
+    /// The `.debug_str` section.
+    pub debug_str: DebugStr<W>,
+}
+
+impl<W: Writer + Clone> Sections<W> {
+    /// Create a new `Sections` using clones of the given `section`.
+    pub fn new(section: W) -> Self {
+        Sections {
+            debug_abbrev: DebugAbbrev(section.clone()),
+            debug_info: DebugInfo(section.clone()),
+            debug_line: DebugLine(section.clone()),
+            debug_line_str: DebugLineStr(section.clone()),
+            debug_ranges: DebugRanges(section.clone()),
+            debug_rnglists: DebugRngLists(section.clone()),
+            debug_str: DebugStr(section.clone()),
+        }
+    }
+}
+
+impl<W: Writer> Sections<W> {
+    /// For each section, call `f` once with a shared reference.
+    pub fn for_each<F, E>(&self, mut f: F) -> result::Result<(), E>
+    where
+        F: FnMut(SectionId, &W) -> result::Result<(), E>,
+    {
+        macro_rules! f {
+            ($s:expr) => {
+                f($s.id(), &$s)
+            };
+        }
+        f!(self.debug_abbrev)?;
+        f!(self.debug_info)?;
+        f!(self.debug_line)?;
+        f!(self.debug_line_str)?;
+        f!(self.debug_ranges)?;
+        f!(self.debug_rnglists)?;
+        f!(self.debug_str)?;
+        Ok(())
+    }
+
+    /// For each section, call `f` once with a mutable reference.
+    pub fn for_each_mut<F, E>(&mut self, mut f: F) -> result::Result<(), E>
+    where
+        F: FnMut(SectionId, &mut W) -> result::Result<(), E>,
+    {
+        macro_rules! f {
+            ($s:expr) => {
+                f($s.id(), &mut $s)
+            };
+        }
+        f!(self.debug_abbrev)?;
+        f!(self.debug_info)?;
+        f!(self.debug_line)?;
+        f!(self.debug_line_str)?;
+        f!(self.debug_ranges)?;
+        f!(self.debug_rnglists)?;
+        f!(self.debug_str)?;
+        Ok(())
+    }
+}

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -264,7 +264,7 @@ impl Unit {
     }
 
     /// Write the unit to the given sections.
-    fn write<W: Writer>(
+    pub(crate) fn write<W: Writer>(
         &self,
         sections: &mut Sections<W>,
         abbrev_offset: DebugAbbrevOffset,
@@ -1129,7 +1129,7 @@ impl DebugInfoOffsets {
 
 /// The section offsets of all elements of a unit within a `.debug_info` section.
 #[derive(Debug)]
-struct UnitOffsets {
+pub(crate) struct UnitOffsets {
     base_id: BaseId,
     unit: DebugInfoOffset,
     entries: Vec<DebugInfoOffset>,

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -248,6 +248,9 @@ impl Unit {
 
     /// Return true if `self.line_program` is used by a DIE.
     fn line_program_in_use(&self) -> bool {
+        if self.line_program.is_none() {
+            return false;
+        }
         if !self.line_program.is_empty() {
             return true;
         }

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -82,26 +82,18 @@ fn test_convert_debug_info() {
     assert_eq!(debug_str_offsets.count(), 3921);
     assert_eq!(debug_str_data.len(), 144_731);
 
-    let mut write_debug_abbrev = write::DebugAbbrev::from(EndianVec::new(LittleEndian));
-    let mut write_debug_info = write::DebugInfo::from(EndianVec::new(LittleEndian));
-    let mut write_debug_line = write::DebugLine::from(EndianVec::new(LittleEndian));
-    let mut write_debug_ranges = write::DebugRanges::from(EndianVec::new(LittleEndian));
-    let mut write_debug_rnglists = write::DebugRngLists::from(EndianVec::new(LittleEndian));
+    let mut write_sections = write::Sections::new(EndianVec::new(LittleEndian));
     units
         .write(
-            &mut write_debug_abbrev,
-            &mut write_debug_info,
-            &mut write_debug_line,
-            &mut write_debug_ranges,
-            &mut write_debug_rnglists,
+            &mut write_sections,
             &debug_line_str_offsets,
             &debug_str_offsets,
         )
         .expect("Should write units");
-    let debug_info_data = write_debug_info.slice();
-    let debug_abbrev_data = write_debug_abbrev.slice();
-    let debug_line_data = write_debug_line.slice();
-    let debug_ranges_data = write_debug_ranges.slice();
+    let debug_info_data = write_sections.debug_info.slice();
+    let debug_abbrev_data = write_sections.debug_abbrev.slice();
+    let debug_line_data = write_sections.debug_line.slice();
+    let debug_ranges_data = write_sections.debug_ranges.slice();
     assert_eq!(debug_info_data.len(), 394_930);
     assert_eq!(debug_abbrev_data.len(), 1282);
     assert_eq!(debug_line_data.len(), 105_797);

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -57,7 +57,7 @@ fn test_convert_debug_info() {
         ..Default::default()
     };
 
-    let dwarf = write::Dwarf::from(&dwarf, &|address| Some(Address::Absolute(address)))
+    let mut dwarf = write::Dwarf::from(&dwarf, &|address| Some(Address::Absolute(address)))
         .expect("Should convert DWARF information");
 
     assert_eq!(dwarf.units.count(), 23);


### PR DESCRIPTION
Notably, there is now `Dwarf` (for multiple units) and `DwarfUnit` (for single units), and we write to `Sections`. Also `LineProgramTable` is gone.