### PR TITLE
cfi: various cleanups

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -561,7 +561,7 @@ mod cfi {
                     }
                     CieOrFde::Fde(partial) => {
                         let fde = partial
-                            .parse(|offset| eh_frame.cie_from_offset(&bases, offset))
+                            .parse(EhFrame::cie_from_offset)
                             .expect("Should be able to get CIE for FED");
                         test::black_box(fde);
                     }
@@ -594,7 +594,7 @@ mod cfi {
                     }
                     CieOrFde::Fde(partial) => {
                         let fde = partial
-                            .parse(|offset| eh_frame.cie_from_offset(&bases, offset))
+                            .parse(EhFrame::cie_from_offset)
                             .expect("Should be able to get CIE for FED");
                         let mut instrs = fde.instructions();
                         while let Some(i) =
@@ -627,7 +627,7 @@ mod cfi {
                     CieOrFde::Cie(_) => {}
                     CieOrFde::Fde(partial) => {
                         let fde = partial
-                            .parse(|offset| eh_frame.cie_from_offset(&bases, offset))
+                            .parse(EhFrame::cie_from_offset)
                             .expect("Should be able to get CIE for FED");
                         let mut table = fde
                             .rows(&mut ctx)
@@ -665,7 +665,7 @@ mod cfi {
                 CieOrFde::Cie(_) => {}
                 CieOrFde::Fde(partial) => {
                     let fde = partial
-                        .parse(|offset| eh_frame.cie_from_offset(&bases, offset))
+                        .parse(EhFrame::cie_from_offset)
                         .expect("Should be able to get CIE for FED");
 
                     let this_len = instrs_len(&fde);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -642,10 +642,10 @@ fn dump_eh_frame<R: Reader, W: Write>(
             }
             Some(gimli::CieOrFde::Fde(partial)) => {
                 let mut offset = None;
-                let fde = partial.parse(|o| {
+                let fde = partial.parse(|_, bases, o| {
                     offset = Some(o);
                     cies.entry(o)
-                        .or_insert_with(|| eh_frame.cie_from_offset(&bases, o))
+                        .or_insert_with(|| eh_frame.cie_from_offset(bases, o))
                         .clone()
                 })?;
 

--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -365,6 +365,30 @@ impl<'a, R: Reader + 'a> EhHdrTable<'a, R> {
     {
         self.fde_for_address(frame, bases, address, get_cie)
     }
+
+    /// Returns the frame unwind information for the given address,
+    /// or `NoUnwindInfoForAddress` if there are none.
+    ///
+    /// You must provide a function to get the associated CIE. See
+    /// `PartialFrameDescriptionEntry::parse` for more information.
+    pub fn unwind_info_for_address<F>(
+        &self,
+        frame: EhFrame<R>,
+        bases: &BaseAddresses,
+        ctx: &mut UninitializedUnwindContext<R>,
+        address: u64,
+        get_cie: F,
+    ) -> Result<UnwindTableRow<R>>
+    where
+        F: FnMut(
+            &EhFrame<R>,
+            &BaseAddresses,
+            EhFrameOffset<R::Offset>,
+        ) -> Result<CommonInformationEntry<R>>,
+    {
+        let fde = self.fde_for_address(frame, bases, address, get_cie)?;
+        fde.unwind_info_for_address(ctx, address)
+    }
 }
 
 /// `EhFrame` contains the frame unwinding information needed during exception

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -391,7 +391,7 @@ fn test_parse_self_eh_frame() {
             }
             CieOrFde::Fde(partial) => {
                 let fde = partial
-                    .parse(|offset| eh_frame.cie_from_offset(&bases, offset))
+                    .parse(UnwindSection::cie_from_offset)
                     .expect("Should be able to get CIE for FDE");
 
                 let mut instrs = fde.instructions();


### PR DESCRIPTION
Try to simplify and makes things more consistent. I was looking into this as part of seeing if we could do more for #296, but I didn't come up with anything significant.

The commit I'm most unsure about is eeae767 (Change callbacks to match UnwindSection::cie_from_offset).

There are minor performance improvements:

```
 name                                                       before ns/iter  after ns/iter  diff ns/iter  diff %  speedup 
 cfi::eval_longest_fde_instructions_new_ctx_everytime       532             546                      14   2.63%   x 0.97 
 cfi::eval_longest_fde_instructions_same_ctx                353             329                     -24  -6.80%   x 1.07 
 cfi::iterate_entries_and_do_not_parse_any_fde              63,038          57,991               -5,047  -8.01%   x 1.09 
 cfi::iterate_entries_and_parse_every_fde                   490,942         450,314             -40,628  -8.28%   x 1.09 
 cfi::iterate_entries_and_parse_every_fde_and_instructions  1,065,654       1,013,824           -51,830  -4.86%   x 1.05 
 cfi::iterate_entries_evaluate_every_fde                    1,376,872       1,327,763           -49,109  -3.57%   x 1.04 
 cfi::parse_longest_fde_instructions                        224             222                      -2  -0.89%   x 1.01 
```