### PR TITLE
cfi: fix parsing of function relative pointers

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -661,6 +661,9 @@ fn dump_eh_frame<R: Reader, W: Write>(
                     fde.len(),
                     fde.initial_address() + fde.len()
                 )?;
+                if let Some(gimli::Pointer::Direct(lsda)) = fde.lsda() {
+                    writeln!(w, "          lsda: {:#018x}", lsda)?;
+                }
                 dump_cfi_instructions(w, fde.instructions(), false, register_name)?;
                 writeln!(w)?;
             }


### PR DESCRIPTION
Also move the function base out of `BaseAddresses` so that it's easier to be sure we are setting it correctly.

I wasn't able to find a compiler that generates this, but this behaviour matches gdb and breakpad.

Fixes #398 