### PR TITLE
Add Dwarf::load and Dwarf::borrow

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -479,9 +479,9 @@ where
 {
     let arena = (Arena::new(), Arena::new());
 
-    let mut load_section = |name| -> Result<_> {
+    let mut load_section = |id: gimli::SectionId| -> Result<_> {
         let mut relocations = RelocationMap::default();
-        let data = match file.section_by_name(name) {
+        let data = match file.section_by_name(id.name()) {
             Some(ref section) => {
                 add_relocations(&mut relocations, file, section);
                 section.uncompressed_data()

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -2,7 +2,7 @@
 #![allow(unknown_lints)]
 
 use fallible_iterator::FallibleIterator;
-use gimli::{CompilationUnitHeader, UnitOffset, UnwindSection};
+use gimli::{CompilationUnitHeader, Section, UnitOffset, UnwindSection};
 use object::{Object, ObjectSection};
 use regex::bytes::Regex;
 use std::borrow::{Borrow, Cow};
@@ -479,19 +479,9 @@ where
 {
     let arena = (Arena::new(), Arena::new());
 
-    fn load_section<'a, 'file, 'input, S, Endian>(
-        arena: &'a (Arena<Cow<'file, [u8]>>, Arena<RelocationMap>),
-        file: &'file object::File<'input>,
-        endian: Endian,
-    ) -> S
-    where
-        S: gimli::Section<Relocate<'a, gimli::EndianSlice<'a, Endian>>>,
-        Endian: gimli::Endianity + Send + Sync,
-        'file: 'input,
-        'a: 'file,
-    {
+    let mut load_section = |name| -> Result<_> {
         let mut relocations = RelocationMap::default();
-        let data = match file.section_by_name(S::section_name()) {
+        let data = match file.section_by_name(name) {
             Some(ref section) => {
                 add_relocations(&mut relocations, file, section);
                 section.uncompressed_data()
@@ -502,12 +492,12 @@ where
         let reader = gimli::EndianSlice::new(data_ref, endian);
         let section = reader;
         let relocations = (*arena.1.alloc(relocations)).borrow();
-        S::from(Relocate {
+        Ok(Relocate {
             relocations,
             section,
             reader,
         })
-    }
+    };
 
     let no_relocations = (*arena.1.alloc(RelocationMap::default())).borrow();
     let no_reader = Relocate {
@@ -516,37 +506,7 @@ where
         reader: Default::default(),
     };
 
-    // The type of each section variable is inferred from its use below.
-    let debug_abbrev = load_section(&arena, file, endian);
-    let debug_addr = load_section(&arena, file, endian);
-    let debug_info = load_section(&arena, file, endian);
-    let debug_line = load_section(&arena, file, endian);
-    let debug_line_str = load_section(&arena, file, endian);
-    let debug_str = load_section(&arena, file, endian);
-    let debug_str_offsets = load_section(&arena, file, endian);
-    let debug_types = load_section(&arena, file, endian);
-
-    let debug_loc = load_section(&arena, file, endian);
-    let debug_loclists = load_section(&arena, file, endian);
-    let locations = gimli::LocationLists::new(debug_loc, debug_loclists);
-
-    let debug_ranges = load_section(&arena, file, endian);
-    let debug_rnglists = load_section(&arena, file, endian);
-    let ranges = gimli::RangeLists::new(debug_ranges, debug_rnglists);
-
-    let dwarf = gimli::Dwarf {
-        debug_abbrev,
-        debug_addr,
-        debug_info,
-        debug_line,
-        debug_line_str,
-        debug_str,
-        debug_str_offsets,
-        debug_str_sup: no_reader.clone().into(),
-        debug_types,
-        locations,
-        ranges,
-    };
+    let dwarf = gimli::Dwarf::load(&mut load_section, |_| Ok(no_reader.clone())).unwrap();
 
     let out = io::stdout();
     if flags.eh_frame {
@@ -571,7 +531,7 @@ where
             None => Cow::Owned(format!("{}", register.0)),
         };
 
-        let mut eh_frame: gimli::EhFrame<_> = load_section(&arena, file, endian);
+        let mut eh_frame = gimli::EhFrame::load(&mut load_section).unwrap();
         eh_frame.set_address_size(address_size);
         dump_eh_frame(&mut BufWriter::new(out.lock()), &eh_frame, &register_name)?;
     }
@@ -585,15 +545,15 @@ where
         dump_line(w, &dwarf)?;
     }
     if flags.pubnames {
-        let debug_pubnames = &load_section(&arena, file, endian);
+        let debug_pubnames = &gimli::Section::load(&mut load_section).unwrap();
         dump_pubnames(w, debug_pubnames, &dwarf.debug_info)?;
     }
     if flags.aranges {
-        let debug_aranges = &load_section(&arena, file, endian);
+        let debug_aranges = &gimli::Section::load(&mut load_section).unwrap();
         dump_aranges(w, debug_aranges, &dwarf.debug_info)?;
     }
     if flags.pubtypes {
-        let debug_pubtypes = &load_section(&arena, file, endian);
+        let debug_pubtypes = &gimli::Section::load(&mut load_section).unwrap();
         dump_pubtypes(w, debug_pubtypes, &dwarf.debug_info)?;
     }
     Ok(())

--- a/src/common.rs
+++ b/src/common.rs
@@ -188,3 +188,73 @@ pub enum UnitSectionOffset<T = usize> {
     /// An offset into the `.debug_types` section.
     DebugTypesOffset(DebugTypesOffset<T>),
 }
+
+/// An identifier for a DWARF section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionId {
+    /// The `.debug_abbrev` section.
+    DebugAbbrev,
+    /// The `.debug_addr` section.
+    DebugAddr,
+    /// The `.debug_aranges` section.
+    DebugAranges,
+    /// The `.debug_frame` section.
+    DebugFrame,
+    /// The `.eh_frame` section.
+    EhFrame,
+    /// The `.eh_frame_hdr` section.
+    EhFrameHdr,
+    /// The `.debug_info` section.
+    DebugInfo,
+    /// The `.debug_line` section.
+    DebugLine,
+    /// The `.debug_line_str` section.
+    DebugLineStr,
+    /// The `.debug_loc` section.
+    DebugLoc,
+    /// The `.debug_loclists` section.
+    DebugLocLists,
+    /// The `.debug_macinfo` section.
+    DebugMacinfo,
+    /// The `.debug_pubnames` section.
+    DebugPubNames,
+    /// The `.debug_pubtypes` section.
+    DebugPubTypes,
+    /// The `.debug_ranges` section.
+    DebugRanges,
+    /// The `.debug_rnglists` section.
+    DebugRngLists,
+    /// The `.debug_str` section.
+    DebugStr,
+    /// The `.debug_str_offsets` section.
+    DebugStrOffsets,
+    /// The `.debug_types` section.
+    DebugTypes,
+}
+
+impl SectionId {
+    /// Returns the ELF section name for this kind.
+    pub fn name(self) -> &'static str {
+        match self {
+            SectionId::DebugAbbrev => ".debug_abbrev",
+            SectionId::DebugAddr => ".debug_addr",
+            SectionId::DebugAranges => ".debug_aranges",
+            SectionId::DebugFrame => ".debug_frame",
+            SectionId::EhFrame => ".eh_frame",
+            SectionId::EhFrameHdr => ".eh_frame_hdr",
+            SectionId::DebugInfo => ".debug_info",
+            SectionId::DebugLine => ".debug_line",
+            SectionId::DebugLineStr => ".debug_line_str",
+            SectionId::DebugLoc => ".debug_loc",
+            SectionId::DebugLocLists => ".debug_loclists",
+            SectionId::DebugMacinfo => ".debug_macinfo",
+            SectionId::DebugPubNames => ".debug_pubnames",
+            SectionId::DebugPubTypes => ".debug_pubtypes",
+            SectionId::DebugRanges => ".debug_ranges",
+            SectionId::DebugRngLists => ".debug_rnglists",
+            SectionId::DebugStr => ".debug_str",
+            SectionId::DebugStrOffsets => ".debug_str_offsets",
+            SectionId::DebugTypes => ".debug_types",
+        }
+    }
+}

--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -58,6 +58,18 @@ impl<T> DebugAbbrev<T> {
     /// Create a `DebugAbbrev` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugAbbrev<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugAbbrev<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -3,7 +3,7 @@
 use crate::collections::btree_map;
 use crate::vec::Vec;
 
-use crate::common::DebugAbbrevOffset;
+use crate::common::{DebugAbbrevOffset, SectionId};
 use crate::constants;
 use crate::endianity::Endianity;
 use crate::read::{EndianSlice, Error, Reader, Result, Section, UnitHeader};
@@ -67,8 +67,8 @@ impl<T> DebugAbbrev<T> {
 }
 
 impl<R> Section<R> for DebugAbbrev<R> {
-    fn section_name() -> &'static str {
-        ".debug_abbrev"
+    fn id() -> SectionId {
+        SectionId::DebugAbbrev
     }
 }
 

--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -12,7 +12,7 @@ use crate::read::{EndianSlice, Error, Reader, Result, Section, UnitHeader};
 /// `DebuggingInformationEntry`s' attribute names and forms found in the
 /// `.debug_abbrev` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugAbbrev<R: Reader> {
+pub struct DebugAbbrev<R> {
     debug_abbrev_section: R,
 }
 
@@ -54,13 +54,25 @@ impl<R: Reader> DebugAbbrev<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugAbbrev<R> {
+impl<T> DebugAbbrev<T> {
+    /// Create a `DebugAbbrev` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugAbbrev<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.debug_abbrev_section).into()
+    }
+}
+
+impl<R> Section<R> for DebugAbbrev<R> {
     fn section_name() -> &'static str {
         ".debug_abbrev"
     }
 }
 
-impl<R: Reader> From<R> for DebugAbbrev<R> {
+impl<R> From<R> for DebugAbbrev<R> {
     fn from(debug_abbrev_section: R) -> Self {
         DebugAbbrev {
             debug_abbrev_section,

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -3,7 +3,7 @@ use crate::read::{Reader, ReaderOffset, Result, Section};
 
 /// The raw contents of the `.debug_addr` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugAddr<R: Reader> {
+pub struct DebugAddr<R> {
     section: R,
 }
 
@@ -40,13 +40,25 @@ impl<R: Reader> DebugAddr<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugAddr<R> {
+impl<T> DebugAddr<T> {
+    /// Create a `DebugAddr` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugAddr<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.section).into()
+    }
+}
+
+impl<R> Section<R> for DebugAddr<R> {
     fn section_name() -> &'static str {
         ".debug_addr"
     }
 }
 
-impl<R: Reader> From<R> for DebugAddr<R> {
+impl<R> From<R> for DebugAddr<R> {
     fn from(section: R) -> Self {
         DebugAddr { section }
     }

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -1,4 +1,4 @@
-use crate::common::{DebugAddrBase, DebugAddrIndex};
+use crate::common::{DebugAddrBase, DebugAddrIndex, SectionId};
 use crate::read::{Reader, ReaderOffset, Result, Section};
 
 /// The raw contents of the `.debug_addr` section.
@@ -53,8 +53,8 @@ impl<T> DebugAddr<T> {
 }
 
 impl<R> Section<R> for DebugAddr<R> {
-    fn section_name() -> &'static str {
-        ".debug_addr"
+    fn id() -> SectionId {
+        SectionId::DebugAddr
     }
 }
 

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -44,6 +44,18 @@ impl<T> DebugAddr<T> {
     /// Create a `DebugAddr` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugAddr<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugAddr<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -2,7 +2,7 @@ use fallible_iterator::FallibleIterator;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 
-use crate::common::{DebugInfoOffset, Encoding};
+use crate::common::{DebugInfoOffset, Encoding, SectionId};
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugLookup, LookupEntryIter, LookupParser};
 use crate::read::{
@@ -221,8 +221,8 @@ impl<R: Reader> DebugAranges<R> {
 }
 
 impl<R: Reader> Section<R> for DebugAranges<R> {
-    fn section_name() -> &'static str {
-        ".debug_aranges"
+    fn id() -> SectionId {
+        SectionId::DebugAranges
     }
 }
 

--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -5,9 +5,8 @@ use std::cmp::{Ord, Ordering};
 use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::mem;
-use std::str;
 
-use crate::common::{DebugFrameOffset, EhFrameOffset, Format, Register};
+use crate::common::{DebugFrameOffset, EhFrameOffset, Format, Register, SectionId};
 use crate::constants::{self, DwEhPe};
 use crate::endianity::Endianity;
 use crate::read::{EndianSlice, Error, Expression, Reader, ReaderOffset, Result, Section};
@@ -76,8 +75,8 @@ where
 }
 
 impl<R: Reader> Section<R> for DebugFrame<R> {
-    fn section_name() -> &'static str {
-        ".debug_frame"
+    fn id() -> SectionId {
+        SectionId::DebugFrame
     }
 }
 
@@ -171,8 +170,8 @@ impl<R: Reader> EhFrameHdr<R> {
 }
 
 impl<R: Reader> Section<R> for EhFrameHdr<R> {
-    fn section_name() -> &'static str {
-        ".eh_frame_hdr"
+    fn id() -> SectionId {
+        SectionId::EhFrameHdr
     }
 }
 
@@ -432,8 +431,8 @@ where
 }
 
 impl<R: Reader> Section<R> for EhFrame<R> {
-    fn section_name() -> &'static str {
-        ".eh_frame"
+    fn id() -> SectionId {
+        SectionId::EhFrame
     }
 }
 

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -84,6 +84,29 @@ impl<T> Dwarf<T> {
     /// Create a `Dwarf` structure that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// It can be useful to load DWARF sections into owned data structures,
+    /// such as `Vec`. However, we do not implement the `Reader` trait
+    /// for `Vec`, because it would be very inefficient, but this trait
+    /// is required for all of the methods that parse the DWARF data.
+    /// So we first load the DWARF sections into `Vec`s, and then use
+    /// `borrow` to create `Reader`s that reference the data.
+    ///
+    /// ```rust,no_run
+    /// # fn example() -> Result<(), gimli::Error> {
+    /// # let loader = |name| -> Result<_, gimli::Error> { unimplemented!() };
+    /// # let sup_loader = |name| { unimplemented!() };
+    /// // Read the DWARF sections into `Vec`s with whatever object loader you're using.
+    /// let owned_dwarf: gimli::Dwarf<Vec<u8>> = gimli::Dwarf::load(loader, sup_loader)?;
+    /// // Create references to the DWARF sections.
+    /// let dwarf = owned_dwarf.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// # unreachable!()
+    /// # }
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> Dwarf<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -15,7 +15,7 @@ use crate::read::{
 
 /// All of the commonly used DWARF sections, and other common information.
 #[derive(Debug, Default)]
-pub struct Dwarf<R: Reader> {
+pub struct Dwarf<R> {
     /// The `.debug_abbrev` section.
     pub debug_abbrev: DebugAbbrev<R>,
 
@@ -50,7 +50,7 @@ pub struct Dwarf<R: Reader> {
     pub ranges: RangeLists<R>,
 }
 
-impl<R: Reader> Dwarf<R> {
+impl<T> Dwarf<T> {
     /// Try to load the DWARF sections using the given loader functions.
     ///
     /// `section` loads a DWARF section from the main object file.
@@ -58,8 +58,8 @@ impl<R: Reader> Dwarf<R> {
     /// These functions should return an empty section if the section does not exist.
     pub fn load<F1, F2, E>(mut section: F1, mut sup: F2) -> std::result::Result<Self, E>
     where
-        F1: FnMut(&'static str) -> std::result::Result<R, E>,
-        F2: FnMut(&'static str) -> std::result::Result<R, E>,
+        F1: FnMut(&'static str) -> std::result::Result<T, E>,
+        F2: FnMut(&'static str) -> std::result::Result<T, E>,
     {
         // Section types are inferred.
         let debug_loc = Section::load(&mut section)?;
@@ -79,6 +79,28 @@ impl<R: Reader> Dwarf<R> {
             locations: LocationLists::new(debug_loc, debug_loclists),
             ranges: RangeLists::new(debug_ranges, debug_rnglists),
         })
+    }
+
+    /// Create a `Dwarf` structure that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> Dwarf<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        Dwarf {
+            debug_abbrev: self.debug_abbrev.borrow(&mut borrow),
+            debug_addr: self.debug_addr.borrow(&mut borrow),
+            debug_info: self.debug_info.borrow(&mut borrow),
+            debug_line: self.debug_line.borrow(&mut borrow),
+            debug_line_str: self.debug_line_str.borrow(&mut borrow),
+            debug_str: self.debug_str.borrow(&mut borrow),
+            debug_str_offsets: self.debug_str_offsets.borrow(&mut borrow),
+            debug_str_sup: self.debug_str_sup.borrow(&mut borrow),
+            debug_types: self.debug_types.borrow(&mut borrow),
+            locations: self.locations.borrow(&mut borrow),
+            ranges: self.ranges.borrow(&mut borrow),
+        }
     }
 }
 

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -2,7 +2,7 @@ use crate::common::{
     DebugAddrBase, DebugAddrIndex, DebugInfoOffset, DebugLineStrOffset, DebugLocListsBase,
     DebugLocListsIndex, DebugRngListsBase, DebugRngListsIndex, DebugStrOffset, DebugStrOffsetsBase,
     DebugStrOffsetsIndex, DebugTypesOffset, Encoding, LocationListsOffset, RangeListsOffset,
-    UnitSectionOffset,
+    SectionId, UnitSectionOffset,
 };
 use crate::constants;
 use crate::read::{
@@ -58,8 +58,8 @@ impl<T> Dwarf<T> {
     /// These functions should return an empty section if the section does not exist.
     pub fn load<F1, F2, E>(mut section: F1, mut sup: F2) -> std::result::Result<Self, E>
     where
-        F1: FnMut(&'static str) -> std::result::Result<T, E>,
-        F2: FnMut(&'static str) -> std::result::Result<T, E>,
+        F1: FnMut(SectionId) -> std::result::Result<T, E>,
+        F2: FnMut(SectionId) -> std::result::Result<T, E>,
     {
         // Section types are inferred.
         let debug_loc = Section::load(&mut section)?;

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -13,7 +13,7 @@ use crate::read::{AttributeValue, EndianSlice, Error, Reader, ReaderOffset, Resu
 /// The `DebugLine` struct contains the source location to instruction mapping
 /// found in the `.debug_line` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugLine<R: Reader> {
+pub struct DebugLine<R> {
     debug_line_section: R,
 }
 
@@ -80,13 +80,25 @@ impl<R: Reader> DebugLine<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugLine<R> {
+impl<T> DebugLine<T> {
+    /// Create a `DebugLine` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugLine<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.debug_line_section).into()
+    }
+}
+
+impl<R> Section<R> for DebugLine<R> {
     fn section_name() -> &'static str {
         ".debug_line"
     }
 }
 
-impl<R: Reader> From<R> for DebugLine<R> {
+impl<R> From<R> for DebugLine<R> {
     fn from(debug_line_section: R) -> Self {
         DebugLine { debug_line_section }
     }

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -84,6 +84,18 @@ impl<T> DebugLine<T> {
     /// Create a `DebugLine` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugLine<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugLine<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -4,7 +4,7 @@ use std::result;
 
 use crate::common::{
     DebugLineOffset, DebugLineStrOffset, DebugStrOffset, DebugStrOffsetsIndex, Encoding, Format,
-    LineEncoding,
+    LineEncoding, SectionId,
 };
 use crate::constants;
 use crate::endianity::Endianity;
@@ -93,8 +93,8 @@ impl<T> DebugLine<T> {
 }
 
 impl<R> Section<R> for DebugLine<R> {
-    fn section_name() -> &'static str {
-        ".debug_line"
+    fn id() -> SectionId {
+        SectionId::DebugLine
     }
 }
 

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -174,6 +174,18 @@ impl<T> LocationLists<T> {
     /// Create a `LocationLists` that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::LocationLists<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> LocationLists<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -2,7 +2,7 @@ use fallible_iterator::FallibleIterator;
 
 use crate::common::{
     DebugAddrBase, DebugAddrIndex, DebugLocListsBase, DebugLocListsIndex, Encoding, Format,
-    LocationListsOffset,
+    LocationListsOffset, SectionId,
 };
 use crate::constants;
 use crate::endianity::Endianity;
@@ -41,8 +41,8 @@ where
 }
 
 impl<R> Section<R> for DebugLoc<R> {
-    fn section_name() -> &'static str {
-        ".debug_loc"
+    fn id() -> SectionId {
+        SectionId::DebugLoc
     }
 }
 
@@ -83,8 +83,8 @@ where
 }
 
 impl<R> Section<R> for DebugLocLists<R> {
-    fn section_name() -> &'static str {
-        ".debug_loclists"
+    fn id() -> SectionId {
+        SectionId::DebugLocLists
     }
 }
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -550,7 +550,7 @@ pub type Result<T> = result::Result<T, Error>;
 ///
 /// let debug_info: DebugInfo<_> = Section::load(loader).unwrap();
 /// ```
-pub trait Section<R: Reader>: From<R> {
+pub trait Section<R>: From<R> {
     /// Returns the ELF section name for this type.
     fn section_name() -> &'static str;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -10,20 +10,11 @@
 //!
 //! ```rust,no_run
 //! # fn example() -> Result<(), gimli::Error> {
-//! # let debug_info_buf = [];
-//! # let debug_abbrev_buf = [];
-//! # let read_debug_info = || &debug_info_buf;
-//! # let read_debug_abbrev = || &debug_abbrev_buf;
-//! // Read the .debug_info and .debug_abbrev sections with whatever object
-//! // loader you're using.
-//! let endian = gimli::LittleEndian;
-//! let debug_info = gimli::DebugInfo::new(read_debug_info(), endian);
-//! let debug_abbrev = gimli::DebugAbbrev::new(read_debug_abbrev(), endian);
-//! let dwarf = gimli::Dwarf {
-//!     debug_info,
-//!     debug_abbrev,
-//!     ..Default::default()
-//! };
+//! # type R = gimli::EndianSlice<'static, gimli::LittleEndian>;
+//! # let loader = |name| -> Result<R, gimli::Error> { unimplemented!() };
+//! # let sup_loader = |name| { unimplemented!() };
+//! // Read the DWARF sections with whatever object loader you're using.
+//! let dwarf = gimli::Dwarf::load(loader, sup_loader)?;
 //!
 //! // Iterate over all compilation units.
 //! let mut iter = dwarf.units();
@@ -551,23 +542,25 @@ pub type Result<T> = result::Result<T, Error>;
 /// used like:
 ///
 /// ```
-/// use gimli::{DebugInfo, EndianBuf, LittleEndian, Reader, Section};
-///
-/// fn load_section<R, S, F>(loader: F) -> S
-///   where R: Reader, S: Section<R>, F: FnOnce(&'static str) -> R
-/// {
-///   let data = loader(S::section_name());
-///   S::from(data)
-/// }
+/// use gimli::{DebugInfo, EndianSlice, LittleEndian, Reader, Section};
 ///
 /// let buf = [0x00, 0x01, 0x02, 0x03];
-/// let reader = EndianBuf::new(&buf, LittleEndian);
+/// let reader = EndianSlice::new(&buf, LittleEndian);
+/// let loader = |name| -> Result<_, ()> { Ok(reader) };
 ///
-/// let debug_info: DebugInfo<_> = load_section(|_: &'static str| reader);
+/// let debug_info: DebugInfo<_> = Section::load(loader).unwrap();
 /// ```
 pub trait Section<R: Reader>: From<R> {
     /// Returns the ELF section name for this type.
     fn section_name() -> &'static str;
+
+    /// Try to load the section using the given loader function.
+    fn load<F, E>(f: F) -> std::result::Result<Self, E>
+    where
+        F: FnOnce(&'static str) -> std::result::Result<R, E>,
+    {
+        f(Self::section_name()).map(From::from)
+    }
 }
 
 impl Register {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -160,7 +160,7 @@ use std::result;
 #[cfg(feature = "std")]
 use std::{error, io};
 
-use crate::common::Register;
+use crate::common::{Register, SectionId};
 use crate::constants;
 
 mod addr;
@@ -551,15 +551,20 @@ pub type Result<T> = result::Result<T, Error>;
 /// let debug_info: DebugInfo<_> = Section::load(loader).unwrap();
 /// ```
 pub trait Section<R>: From<R> {
+    /// Returns the section id for this type.
+    fn id() -> SectionId;
+
     /// Returns the ELF section name for this type.
-    fn section_name() -> &'static str;
+    fn section_name() -> &'static str {
+        Self::id().name()
+    }
 
     /// Try to load the section using the given loader function.
     fn load<F, E>(f: F) -> std::result::Result<Self, E>
     where
-        F: FnOnce(&'static str) -> std::result::Result<R, E>,
+        F: FnOnce(SectionId) -> std::result::Result<R, E>,
     {
-        f(Self::section_name()).map(From::from)
+        f(Self::id()).map(From::from)
     }
 }
 

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -1,6 +1,6 @@
 use fallible_iterator::FallibleIterator;
 
-use crate::common::DebugInfoOffset;
+use crate::common::{DebugInfoOffset, SectionId};
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugLookup, LookupEntryIter, PubStuffEntry, PubStuffParser};
 use crate::read::{EndianSlice, Error, Reader, Result, Section, UnitOffset};
@@ -97,8 +97,8 @@ impl<R: Reader> DebugPubNames<R> {
 }
 
 impl<R: Reader> Section<R> for DebugPubNames<R> {
-    fn section_name() -> &'static str {
-        ".debug_pubnames"
+    fn id() -> SectionId {
+        SectionId::DebugPubNames
     }
 }
 

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -1,6 +1,6 @@
 use fallible_iterator::FallibleIterator;
 
-use crate::common::DebugInfoOffset;
+use crate::common::{DebugInfoOffset, SectionId};
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugLookup, LookupEntryIter, PubStuffEntry, PubStuffParser};
 use crate::read::{EndianSlice, Error, Reader, Result, Section, UnitOffset};
@@ -97,8 +97,8 @@ impl<R: Reader> DebugPubTypes<R> {
 }
 
 impl<R: Reader> Section<R> for DebugPubTypes<R> {
-    fn section_name() -> &'static str {
-        ".debug_pubtypes"
+    fn id() -> SectionId {
+        SectionId::DebugPubTypes
     }
 }
 

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -172,6 +172,18 @@ impl<T> RangeLists<T> {
     /// Create a `RangeLists` that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::RangeLists<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> RangeLists<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -2,7 +2,7 @@ use fallible_iterator::FallibleIterator;
 
 use crate::common::{
     DebugAddrBase, DebugAddrIndex, DebugRngListsBase, DebugRngListsIndex, Encoding, Format,
-    RangeListsOffset,
+    RangeListsOffset, SectionId,
 };
 use crate::constants;
 use crate::endianity::Endianity;
@@ -38,8 +38,8 @@ where
 }
 
 impl<R> Section<R> for DebugRanges<R> {
-    fn section_name() -> &'static str {
-        ".debug_ranges"
+    fn id() -> SectionId {
+        SectionId::DebugRanges
     }
 }
 
@@ -81,8 +81,8 @@ where
 }
 
 impl<R> Section<R> for DebugRngLists<R> {
-    fn section_name() -> &'static str {
-        ".debug_rnglists"
+    fn id() -> SectionId {
+        SectionId::DebugRngLists
     }
 }
 

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -10,7 +10,7 @@ use crate::read::{DebugAddr, EndianSlice, Error, Reader, ReaderOffset, Result, S
 
 /// The raw contents of the `.debug_ranges` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugRanges<R: Reader> {
+pub struct DebugRanges<R> {
     pub(crate) section: R,
 }
 
@@ -37,13 +37,13 @@ where
     }
 }
 
-impl<R: Reader> Section<R> for DebugRanges<R> {
+impl<R> Section<R> for DebugRanges<R> {
     fn section_name() -> &'static str {
         ".debug_ranges"
     }
 }
 
-impl<R: Reader> From<R> for DebugRanges<R> {
+impl<R> From<R> for DebugRanges<R> {
     fn from(section: R) -> Self {
         DebugRanges { section }
     }
@@ -52,7 +52,7 @@ impl<R: Reader> From<R> for DebugRanges<R> {
 /// The `DebugRngLists` struct represents the contents of the
 /// `.debug_rnglists` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugRngLists<R: Reader> {
+pub struct DebugRngLists<R> {
     section: R,
 }
 
@@ -80,13 +80,13 @@ where
     }
 }
 
-impl<R: Reader> Section<R> for DebugRngLists<R> {
+impl<R> Section<R> for DebugRngLists<R> {
     fn section_name() -> &'static str {
         ".debug_rnglists"
     }
 }
 
-impl<R: Reader> From<R> for DebugRngLists<R> {
+impl<R> From<R> for DebugRngLists<R> {
     fn from(section: R) -> Self {
         DebugRngLists { section }
     }
@@ -152,12 +152,12 @@ fn parse_header<R: Reader>(input: &mut R) -> Result<RngListsHeader> {
 
 /// The DWARF data found in `.debug_ranges` and `.debug_rnglists` sections.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct RangeLists<R: Reader> {
+pub struct RangeLists<R> {
     debug_ranges: DebugRanges<R>,
     debug_rnglists: DebugRngLists<R>,
 }
 
-impl<R: Reader> RangeLists<R> {
+impl<R> RangeLists<R> {
     /// Construct a new `RangeLists` instance from the data in the `.debug_ranges` and
     /// `.debug_rnglists` sections.
     pub fn new(debug_ranges: DebugRanges<R>, debug_rnglists: DebugRngLists<R>) -> RangeLists<R> {
@@ -166,7 +166,24 @@ impl<R: Reader> RangeLists<R> {
             debug_rnglists,
         }
     }
+}
 
+impl<T> RangeLists<T> {
+    /// Create a `RangeLists` that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> RangeLists<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        RangeLists {
+            debug_ranges: borrow(&self.debug_ranges.section).into(),
+            debug_rnglists: borrow(&self.debug_rnglists.section).into(),
+        }
+    }
+}
+
+impl<R: Reader> RangeLists<R> {
     /// Iterate over the `Range` list entries starting at the given offset.
     ///
     /// The `unit_version` and `address_size` must match the compilation unit that the

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    DebugLineStrOffset, DebugStrOffset, DebugStrOffsetsBase, DebugStrOffsetsIndex,
+    DebugLineStrOffset, DebugStrOffset, DebugStrOffsetsBase, DebugStrOffsetsIndex, SectionId,
 };
 use crate::endianity::Endianity;
 use crate::read::{EndianSlice, Reader, ReaderOffset, Result, Section};
@@ -68,8 +68,8 @@ impl<T> DebugStr<T> {
 }
 
 impl<R> Section<R> for DebugStr<R> {
-    fn section_name() -> &'static str {
-        ".debug_str"
+    fn id() -> SectionId {
+        SectionId::DebugStr
     }
 }
 
@@ -130,8 +130,8 @@ impl<T> DebugStrOffsets<T> {
 }
 
 impl<R> Section<R> for DebugStrOffsets<R> {
-    fn section_name() -> &'static str {
-        ".debug_str_offsets"
+    fn id() -> SectionId {
+        SectionId::DebugStrOffsets
     }
 }
 
@@ -170,8 +170,8 @@ impl<T> DebugLineStr<T> {
 }
 
 impl<R> Section<R> for DebugLineStr<R> {
-    fn section_name() -> &'static str {
-        ".debug_line_str"
+    fn id() -> SectionId {
+        SectionId::DebugLineStr
     }
 }
 

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -59,6 +59,18 @@ impl<T> DebugStr<T> {
     /// Create a `DebugStr` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugStr<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugStr<R>
     where
         F: FnMut(&'a T) -> R,
@@ -121,6 +133,18 @@ impl<T> DebugStrOffsets<T> {
     /// Create a `DebugStrOffsets` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugStrOffsets<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugStrOffsets<R>
     where
         F: FnMut(&'a T) -> R,
@@ -161,6 +185,18 @@ impl<T> DebugLineStr<T> {
     /// Create a `DebugLineStr` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugLineStr<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugLineStr<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -8,7 +8,7 @@ use crate::Format;
 /// The `DebugStr` struct represents the DWARF strings
 /// found in the `.debug_str` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugStr<R: Reader> {
+pub struct DebugStr<R> {
     debug_str_section: R,
 }
 
@@ -55,13 +55,25 @@ impl<R: Reader> DebugStr<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugStr<R> {
+impl<T> DebugStr<T> {
+    /// Create a `DebugStr` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugStr<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.debug_str_section).into()
+    }
+}
+
+impl<R> Section<R> for DebugStr<R> {
     fn section_name() -> &'static str {
         ".debug_str"
     }
 }
 
-impl<R: Reader> From<R> for DebugStr<R> {
+impl<R> From<R> for DebugStr<R> {
     fn from(debug_str_section: R) -> Self {
         DebugStr { debug_str_section }
     }
@@ -69,7 +81,7 @@ impl<R: Reader> From<R> for DebugStr<R> {
 
 /// The raw contents of the `.debug_str_offsets` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugStrOffsets<R: Reader> {
+pub struct DebugStrOffsets<R> {
     section: R,
 }
 
@@ -105,13 +117,25 @@ impl<R: Reader> DebugStrOffsets<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugStrOffsets<R> {
+impl<T> DebugStrOffsets<T> {
+    /// Create a `DebugStrOffsets` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugStrOffsets<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.section).into()
+    }
+}
+
+impl<R> Section<R> for DebugStrOffsets<R> {
     fn section_name() -> &'static str {
         ".debug_str_offsets"
     }
 }
 
-impl<R: Reader> From<R> for DebugStrOffsets<R> {
+impl<R> From<R> for DebugStrOffsets<R> {
     fn from(section: R) -> Self {
         DebugStrOffsets { section }
     }
@@ -120,7 +144,7 @@ impl<R: Reader> From<R> for DebugStrOffsets<R> {
 /// The `DebugLineStr` struct represents the DWARF strings
 /// found in the `.debug_line_str` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugLineStr<R: Reader> {
+pub struct DebugLineStr<R> {
     section: R,
 }
 
@@ -133,13 +157,25 @@ impl<R: Reader> DebugLineStr<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugLineStr<R> {
+impl<T> DebugLineStr<T> {
+    /// Create a `DebugLineStr` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugLineStr<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.section).into()
+    }
+}
+
+impl<R> Section<R> for DebugLineStr<R> {
     fn section_name() -> &'static str {
         ".debug_line_str"
     }
 }
 
-impl<R: Reader> From<R> for DebugLineStr<R> {
+impl<R> From<R> for DebugLineStr<R> {
     fn from(section: R) -> Self {
         DebugLineStr { section }
     }

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -84,7 +84,7 @@ impl<T: ReaderOffset> UnitOffset<T> {
 /// The `DebugInfo` struct represents the DWARF debugging information found in
 /// the `.debug_info` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugInfo<R: Reader> {
+pub struct DebugInfo<R> {
     debug_info_section: R,
 }
 
@@ -150,13 +150,25 @@ impl<R: Reader> DebugInfo<R> {
     }
 }
 
-impl<R: Reader> Section<R> for DebugInfo<R> {
+impl<T> DebugInfo<T> {
+    /// Create a `DebugInfo` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugInfo<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.debug_info_section).into()
+    }
+}
+
+impl<R> Section<R> for DebugInfo<R> {
     fn section_name() -> &'static str {
         ".debug_info"
     }
 }
 
-impl<R: Reader> From<R> for DebugInfo<R> {
+impl<R> From<R> for DebugInfo<R> {
     fn from(debug_info_section: R) -> Self {
         DebugInfo { debug_info_section }
     }
@@ -2735,7 +2747,7 @@ fn parse_type_offset<R: Reader>(input: &mut R, format: Format) -> Result<UnitOff
 /// The `DebugTypes` struct represents the DWARF type information
 /// found in the `.debug_types` section.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DebugTypes<R: Reader> {
+pub struct DebugTypes<R> {
     debug_types_section: R,
 }
 
@@ -2762,13 +2774,25 @@ where
     }
 }
 
-impl<R: Reader> Section<R> for DebugTypes<R> {
+impl<T> DebugTypes<T> {
+    /// Create a `DebugTypes` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugTypes<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.debug_types_section).into()
+    }
+}
+
+impl<R> Section<R> for DebugTypes<R> {
     fn section_name() -> &'static str {
         ".debug_types"
     }
 }
 
-impl<R: Reader> From<R> for DebugTypes<R> {
+impl<R> From<R> for DebugTypes<R> {
     fn from(debug_types_section: R) -> Self {
         DebugTypes {
             debug_types_section,

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -10,7 +10,7 @@ use crate::common::{
     DebugLineStrOffset, DebugLocListsBase, DebugLocListsIndex, DebugMacinfoOffset,
     DebugRngListsBase, DebugRngListsIndex, DebugStrOffset, DebugStrOffsetsBase,
     DebugStrOffsetsIndex, DebugTypeSignature, DebugTypesOffset, Encoding, Format,
-    LocationListsOffset, RangeListsOffset,
+    LocationListsOffset, RangeListsOffset, SectionId,
 };
 use crate::constants;
 use crate::endianity::Endianity;
@@ -163,8 +163,8 @@ impl<T> DebugInfo<T> {
 }
 
 impl<R> Section<R> for DebugInfo<R> {
-    fn section_name() -> &'static str {
-        ".debug_info"
+    fn id() -> SectionId {
+        SectionId::DebugInfo
     }
 }
 
@@ -2787,8 +2787,8 @@ impl<T> DebugTypes<T> {
 }
 
 impl<R> Section<R> for DebugTypes<R> {
-    fn section_name() -> &'static str {
-        ".debug_types"
+    fn id() -> SectionId {
+        SectionId::DebugTypes
     }
 }
 

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -154,6 +154,18 @@ impl<T> DebugInfo<T> {
     /// Create a `DebugInfo` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugInfo<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugInfo<R>
     where
         F: FnMut(&'a T) -> R,
@@ -2778,6 +2790,18 @@ impl<T> DebugTypes<T> {
     /// Create a `DebugTypes` section that references the data in `self`.
     ///
     /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```rust,no_run
+    /// # let load_section = || unimplemented!();
+    /// // Read the DWARF section into a `Vec` with whatever object loader you're using.
+    /// let owned_section: gimli::DebugTypes<Vec<u8>> = load_section();
+    /// // Create a reference to the DWARF section.
+    /// let section = owned_section.borrow(|section| {
+    ///     gimli::EndianSlice::new(&section, gimli::LittleEndian)
+    /// });
+    /// ```
     pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugTypes<R>
     where
         F: FnMut(&'a T) -> R,

--- a/src/write/abbrev.rs
+++ b/src/write/abbrev.rs
@@ -2,9 +2,9 @@ use crate::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
-use crate::common::DebugAbbrevOffset;
+use crate::common::{DebugAbbrevOffset, SectionId};
 use crate::constants;
-use crate::write::{Result, Section, SectionId, Writer};
+use crate::write::{Result, Section, Writer};
 
 /// A table of abbreviations that will be stored in a `.debug_abbrev` section.
 // Requirements:

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -2,12 +2,12 @@ use crate::vec::Vec;
 use indexmap::{IndexMap, IndexSet};
 use std::ops::{Deref, DerefMut};
 
-use crate::common::{DebugLineOffset, Encoding, Format, LineEncoding};
+use crate::common::{DebugLineOffset, Encoding, Format, LineEncoding, SectionId};
 use crate::constants;
 use crate::leb128;
 use crate::write::{
     Address, DebugLineStrOffsets, DebugStrOffsets, Error, LineStringId, LineStringTable, Result,
-    Section, SectionId, StringId, Writer,
+    Section, StringId, Writer,
 };
 
 /// The number assigned to the first special opcode.

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -2,8 +2,8 @@ use crate::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
-use crate::common::{Encoding, RangeListsOffset};
-use crate::write::{Address, BaseId, Error, Result, Section, SectionId, Sections, Writer};
+use crate::common::{Encoding, RangeListsOffset, SectionId};
+use crate::write::{Address, BaseId, Error, Result, Section, Sections, Writer};
 
 define_section!(
     DebugRanges,

--- a/src/write/section.rs
+++ b/src/write/section.rs
@@ -1,6 +1,7 @@
 use std::ops::DerefMut;
 use std::result;
 
+use crate::common::SectionId;
 use crate::write::{
     DebugAbbrev, DebugInfo, DebugLine, DebugLineStr, DebugRanges, DebugRngLists, DebugStr, Writer,
 };
@@ -48,49 +49,6 @@ macro_rules! define_section {
             }
         }
     };
-}
-
-/// An identifier for a DWARF section.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SectionId {
-    /// The `.debug_abbrev` section.
-    DebugAbbrev,
-    /// The `.debug_info` section.
-    DebugInfo,
-    /// The `.debug_line` section.
-    DebugLine,
-    /// The `.debug_line_str` section.
-    DebugLineStr,
-    /// The `.debug_loc` section.
-    DebugLoc,
-    /// The `.debug_loclists` section.
-    DebugLocLists,
-    /// The `.debug_macinfo` section.
-    DebugMacinfo,
-    /// The `.debug_ranges` section.
-    DebugRanges,
-    /// The `.debug_rnglists` section.
-    DebugRngLists,
-    /// The `.debug_str` section.
-    DebugStr,
-}
-
-impl SectionId {
-    /// Returns the ELF section name for this kind.
-    pub fn name(self) -> &'static str {
-        match self {
-            SectionId::DebugAbbrev => ".debug_abbrev",
-            SectionId::DebugInfo => ".debug_info",
-            SectionId::DebugLine => ".debug_line",
-            SectionId::DebugLineStr => ".debug_line_str",
-            SectionId::DebugLoc => ".debug_loc",
-            SectionId::DebugLocLists => ".debug_loclists",
-            SectionId::DebugMacinfo => ".debug_macinfo",
-            SectionId::DebugRanges => ".debug_ranges",
-            SectionId::DebugRngLists => ".debug_rnglists",
-            SectionId::DebugStr => ".debug_str",
-        }
-    }
 }
 
 /// Functionality common to all writable DWARF sections.

--- a/src/write/str.rs
+++ b/src/write/str.rs
@@ -2,8 +2,8 @@ use crate::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
-use crate::common::{DebugLineStrOffset, DebugStrOffset};
-use crate::write::{BaseId, Result, Section, SectionId, Writer};
+use crate::common::{DebugLineStrOffset, DebugStrOffset, SectionId};
+use crate::write::{BaseId, Result, Section, Writer};
 
 // Requirements:
 // - values are `[u8]`, null bytes are not allowed

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -4,13 +4,13 @@ use std::{slice, usize};
 
 use crate::common::{
     DebugAbbrevOffset, DebugInfoOffset, DebugLineOffset, DebugMacinfoOffset, DebugStrOffset,
-    DebugTypeSignature, Encoding, Format, LocationListsOffset, UnitSectionOffset,
+    DebugTypeSignature, Encoding, Format, LocationListsOffset, SectionId, UnitSectionOffset,
 };
 use crate::constants;
 use crate::write::{
     Abbreviation, AbbreviationTable, Address, AttributeSpecification, BaseId, DebugLineStrOffsets,
     DebugStrOffsets, Error, FileId, LineProgram, LineStringId, RangeList, RangeListId,
-    RangeListOffsets, RangeListTable, Result, Section, SectionId, Sections, StringId, Writer,
+    RangeListOffsets, RangeListTable, Result, Section, Sections, StringId, Writer,
 };
 
 define_id!(UnitId, "An identifier for a unit in a `UnitTable`.");

--- a/src/write/writer.rs
+++ b/src/write/writer.rs
@@ -1,7 +1,7 @@
+use crate::common::{Format, SectionId};
 use crate::endianity::Endianity;
 use crate::leb128;
-use crate::write::{Address, Error, Result, SectionId};
-use crate::Format;
+use crate::write::{Address, Error, Result};
 
 /// A trait for writing the data to a DWARF section.
 ///


### PR DESCRIPTION
Use `Dwarf::load` in the `read` module example. See #405 for motivation. If users want to avoid loading some sections then they can handle that in the loader callback.

`Dwarf::borrow` can be used when the `Reader` needs to borrow from something else. In the dwarfdump example we use an arena, but instead of that we could first load everything into a `Dwarf<Cow<[u8]>>` and then borrow that to get `Dwarf<EndianSlice<_>>`. Note that this can't use the standard rust `Borrow` trait, and I couldn't come up with a way to define this as a `Section` trait method either (do we need type constructors or something like that?). I didn't update dwarfdump to use this because the arena is still convenient for the sections that aren't in `Dwarf`.