### PR TITLE
update fallible-iterator to version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ coveralls = { repository = "gimli-rs/gimli" }
 [dependencies]
 arrayvec = { version = "0.4.6", default-features = false }
 byteorder = { version = "1.0", default-features = false }
-fallible-iterator = { version = "0.1.4", default-features = false }
+fallible-iterator = { version = "0.2.0", default-features = false }
 indexmap = { version = "1.0", optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -649,7 +649,7 @@ mod cfi {
         fde: &FrameDescriptionEntry<R>,
     ) -> usize {
         fde.instructions(eh_frame, bases)
-            .fold(0, |count, _| count + 1)
+            .fold(0, |count, _| Ok(count + 1))
             .expect("fold over instructions OK")
     }
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -148,17 +148,17 @@
 //! ```
 //! // Use the `FallibleIterator` trait so its methods are in scope!
 //! use fallible_iterator::FallibleIterator;
-//! use gimli::{DebugAranges, EndianBuf, LittleEndian};
+//! use gimli::{DebugAranges, EndianSlice, LittleEndian};
 //!
-//! fn find_sum_of_address_range_lengths(aranges: DebugAranges<EndianBuf<LittleEndian>>)
+//! fn find_sum_of_address_range_lengths(aranges: DebugAranges<EndianSlice<LittleEndian>>)
 //!     -> gimli::Result<u64>
 //! {
 //!     // `DebugAranges::items` returns a `FallibleIterator`!
 //!     aranges.items()
 //!         // `map` is provided by `FallibleIterator`!
-//!         .map(|arange| arange.length())
+//!         .map(|arange| Ok(arange.length()))
 //!         // `fold` is provided by `FallibleIterator`!
-//!         .fold(0, |sum, len| sum + len)
+//!         .fold(0, |sum, len| Ok(sum + len))
 //! }
 //!
 //! # fn main() {}


### PR DESCRIPTION
This updates the `fallible-iterator` dependency to version 0.2.0 :slightly_smiling_face: Was running into some weird problems when resolving https://github.com/rustwasm/twiggy/pull/263, and afaict it seems to be because of some changes that happened regarding adaptors' closures in the new `fallible-iterator` version, noted in the changelog [here](https://github.com/sfackler/rust-fallible-iterator/blob/master/CHANGELOG.md).