### PR TITLE
read: improved UnexpectedEof errors

### DIFF
--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -82,6 +82,10 @@ impl<R> Section<R> for DebugAbbrev<R> {
     fn id() -> SectionId {
         SectionId::DebugAbbrev
     }
+
+    fn reader(&self) -> &R {
+        &self.debug_abbrev_section
+    }
 }
 
 impl<R> From<R> for DebugAbbrev<R> {
@@ -774,7 +778,7 @@ pub mod tests {
         let buf = &mut EndianSlice::new(&*buf, LittleEndian);
 
         match Abbreviation::parse(buf) {
-            Err(Error::UnexpectedEof) => {}
+            Err(Error::UnexpectedEof(_)) => {}
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         }
     }

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -68,6 +68,10 @@ impl<R> Section<R> for DebugAddr<R> {
     fn id() -> SectionId {
         SectionId::DebugAddr
     }
+
+    fn reader(&self) -> &R {
+        &self.section
+    }
 }
 
 impl<R> From<R> for DebugAddr<R> {

--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -224,6 +224,10 @@ impl<R: Reader> Section<R> for DebugAranges<R> {
     fn id() -> SectionId {
         SectionId::DebugAranges
     }
+
+    fn reader(&self) -> &R {
+        self.0.reader()
+    }
 }
 
 impl<R: Reader> From<R> for DebugAranges<R> {

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -108,6 +108,10 @@ impl<R> Section<R> for DebugLine<R> {
     fn id() -> SectionId {
         SectionId::DebugLine
     }
+
+    fn reader(&self) -> &R {
+        &self.debug_line_section
+    }
 }
 
 impl<R> From<R> for DebugLine<R> {
@@ -2049,7 +2053,7 @@ mod tests {
         let input = &mut EndianSlice::new(&buf, LittleEndian);
 
         match LineProgramHeader::parse(input, DebugLineOffset(0), 4, None, None) {
-            Err(Error::UnexpectedEof) => return,
+            Err(Error::UnexpectedEof(_)) => return,
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         }
     }
@@ -2110,7 +2114,7 @@ mod tests {
         let input = &mut EndianSlice::new(&buf, LittleEndian);
 
         match LineProgramHeader::parse(input, DebugLineOffset(0), 4, None, None) {
-            Err(Error::UnexpectedEof) => return,
+            Err(Error::UnexpectedEof(_)) => return,
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         }
     }

--- a/src/read/lookup.rs
+++ b/src/read/lookup.rs
@@ -62,6 +62,10 @@ where
             remaining_input: self.input_buffer.clone(),
         }
     }
+
+    pub fn reader(&self) -> &R {
+        &self.input_buffer
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -1862,6 +1862,18 @@ mod tests {
         }
     }
 
+    fn check_op_parse_eof(input: &[u8], encoding: Encoding) {
+        let buf = EndianSlice::new(input, LittleEndian);
+        let mut pc = buf;
+        match Operation::parse(&mut pc, &buf, encoding) {
+            Err(Error::UnexpectedEof(id)) => {
+                assert!(buf.lookup_offset_id(id).is_some());
+            }
+
+            _ => panic!("Unexpected result"),
+        }
+    }
+
     fn check_op_parse<F>(
         input: F,
         expect: &Operation<EndianSlice<LittleEndian>>,
@@ -1873,7 +1885,7 @@ mod tests {
             .get_contents()
             .unwrap();
         for i in 1..input.len() {
-            check_op_parse_failure(&input[..i], Error::UnexpectedEof, encoding);
+            check_op_parse_eof(&input[..i], encoding);
         }
         check_op_parse_simple(&input, expect, encoding);
     }
@@ -2000,7 +2012,7 @@ mod tests {
         ];
 
         let input = [];
-        check_op_parse_failure(&input[..], Error::UnexpectedEof, encoding);
+        check_op_parse_eof(&input[..], encoding);
 
         for item in inputs.iter() {
             let (opcode, ref result) = *item;

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -100,6 +100,10 @@ impl<R: Reader> Section<R> for DebugPubNames<R> {
     fn id() -> SectionId {
         SectionId::DebugPubNames
     }
+
+    fn reader(&self) -> &R {
+        self.0.reader()
+    }
 }
 
 impl<R: Reader> From<R> for DebugPubNames<R> {

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -100,6 +100,10 @@ impl<R: Reader> Section<R> for DebugPubTypes<R> {
     fn id() -> SectionId {
         SectionId::DebugPubTypes
     }
+
+    fn reader(&self) -> &R {
+        self.0.reader()
+    }
 }
 
 impl<R: Reader> From<R> for DebugPubTypes<R> {

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -8,6 +8,14 @@ use crate::endianity::Endianity;
 use crate::leb128;
 use crate::read::{Error, Result};
 
+/// An identifier for an offset within a section reader.
+///
+/// This is used for error reporting. The meaning of this value is specific to
+/// each reader implementation. The values should be chosen to be unique amongst
+/// all readers. If values are not unique then errors may point to the wrong reader.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReaderOffsetId(pub u64);
+
 /// A trait for offsets with a DWARF section.
 ///
 /// This allows consumers to choose a size that is appropriate for their address space.
@@ -221,6 +229,13 @@ pub trait Reader: Debug + Clone {
     /// May panic if this reader's data is not contained within the given
     /// base reader's data.
     fn offset_from(&self, base: &Self) -> Self::Offset;
+
+    /// Return an identifier for the current reader offset.
+    fn offset_id(&self) -> ReaderOffsetId;
+
+    /// Return the offset corresponding to the given `id` if
+    /// it is associated with this reader.
+    fn lookup_offset_id(&self, id: ReaderOffsetId) -> Option<Self::Offset>;
 
     /// Find the index of the first occurence of the given byte.
     /// The offset of the reader is not changed.

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -83,6 +83,10 @@ impl<R> Section<R> for DebugStr<R> {
     fn id() -> SectionId {
         SectionId::DebugStr
     }
+
+    fn reader(&self) -> &R {
+        &self.debug_str_section
+    }
 }
 
 impl<R> From<R> for DebugStr<R> {
@@ -157,6 +161,10 @@ impl<R> Section<R> for DebugStrOffsets<R> {
     fn id() -> SectionId {
         SectionId::DebugStrOffsets
     }
+
+    fn reader(&self) -> &R {
+        &self.section
+    }
 }
 
 impl<R> From<R> for DebugStrOffsets<R> {
@@ -208,6 +216,10 @@ impl<T> DebugLineStr<T> {
 impl<R> Section<R> for DebugLineStr<R> {
     fn id() -> SectionId {
         SectionId::DebugLineStr
+    }
+
+    fn reader(&self) -> &R {
+        &self.section
     }
 }
 

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -178,6 +178,10 @@ impl<R> Section<R> for DebugInfo<R> {
     fn id() -> SectionId {
         SectionId::DebugInfo
     }
+
+    fn reader(&self) -> &R {
+        &self.debug_info_section
+    }
 }
 
 impl<R> From<R> for DebugInfo<R> {
@@ -2814,6 +2818,10 @@ impl<R> Section<R> for DebugTypes<R> {
     fn id() -> SectionId {
         SectionId::DebugTypes
     }
+
+    fn reader(&self) -> &R {
+        &self.debug_types_section
+    }
 }
 
 impl<R> From<R> for DebugTypes<R> {
@@ -3281,7 +3289,7 @@ mod tests {
         let buf = &mut EndianSlice::new(&buf, LittleEndian);
 
         match parse_debug_abbrev_offset(buf, Format::Dwarf32) {
-            Err(Error::UnexpectedEof) => assert!(true),
+            Err(Error::UnexpectedEof(_)) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }
@@ -3305,7 +3313,7 @@ mod tests {
         let buf = &mut EndianSlice::new(&buf, LittleEndian);
 
         match parse_debug_abbrev_offset(buf, Format::Dwarf64) {
-            Err(Error::UnexpectedEof) => assert!(true),
+            Err(Error::UnexpectedEof(_)) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }
@@ -3328,7 +3336,7 @@ mod tests {
         let buf = &mut EndianSlice::new(&buf, LittleEndian);
 
         match parse_debug_info_offset(buf, Format::Dwarf32) {
-            Err(Error::UnexpectedEof) => assert!(true),
+            Err(Error::UnexpectedEof(_)) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }
@@ -3352,7 +3360,7 @@ mod tests {
         let buf = &mut EndianSlice::new(&buf, LittleEndian);
 
         match parse_debug_info_offset(buf, Format::Dwarf64) {
-            Err(Error::UnexpectedEof) => assert!(true),
+            Err(Error::UnexpectedEof(_)) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }
@@ -3425,7 +3433,7 @@ mod tests {
         let rest = &mut EndianSlice::new(&buf, LittleEndian);
 
         match parse_unit_header(rest) {
-            Err(Error::UnexpectedEof) => assert!(true),
+            Err(Error::UnexpectedEof(_)) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }
@@ -3564,7 +3572,7 @@ mod tests {
         let rest = &mut EndianSlice::new(&buf, LittleEndian);
 
         match parse_type_offset(rest, Format::Dwarf32) {
-            Err(Error::UnexpectedEof) => assert!(true),
+            Err(Error::UnexpectedEof(_)) => assert!(true),
             otherwise => panic!("Unexpected result: {:?}", otherwise),
         };
     }


### PR DESCRIPTION
Stores a (hopefully) unique `ReaderOffsetId` in the error, which can be converted back to a section+offset for display.

This can be expanded to more error variants as needed.

The `ReaderOffsetId` is a little hacky: for slices it is a cast of the pointer to a `u64`, but this is only unique if the slice is backed by its own memory allocation. I think this is good enough though? To do better I think we need to add a unique id field to every base reader (but which is preserved by clones), and I'd prefer not to do that just for this. Users can define their own reader which does this if required.