### PR TITLE
require at least indexmap@1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ coveralls = { repository = "gimli-rs/gimli" }
 arrayvec = { version = "0.4.6", default-features = false }
 byteorder = { version = "1.0", default-features = false }
 fallible-iterator = { version = "0.2.0", default-features = false }
-indexmap = { version = "1.0", optional = true }
+indexmap = { version = "1.0.2", optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
The insert_full is used by gimli, which was added at 1.0.2 -- causing issues when indexmap, e.g. in mozilla-central, at only 1.0.1