### PR TITLE
Fix various warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ os:
 osx_image: xcode7.1
 
 rust:
+- 1.32.0
 - nightly
 - beta
 - stable

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Add this to your `Cargo.toml`:
 gimli = "0.17.0"
 ```
 
+The minimum supported rust version is 1.32.0.
+
 ## Documentation
 
 * [Documentation on docs.rs](https://docs.rs/gimli/)

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,7 +1,7 @@
 use crate::common::Register;
 
 macro_rules! registers {
-    ($struct_name:ident, { $($name:ident = ($val:expr, $disp:expr)),+ }) => {
+    ($struct_name:ident, { $($name:ident = ($val:expr, $disp:expr)),+ $(,)? }) => {
         #[allow(missing_docs)]
         impl $struct_name {
             $(
@@ -20,10 +20,6 @@ macro_rules! registers {
                 }
             }
         }
-    };
-    // Handle trailing comma
-    ($struct_name:ident, { $($name:ident = ($val:expr, $disp:expr)),+, }) => {
-        registers!($struct_name, { $($name = ($val, $disp)),+ });
     };
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -56,7 +56,8 @@ use std::fmt;
 //         }
 //     }
 macro_rules! dw {
-    ($struct_name:ident($struct_type:ty) { $($name:ident = $val:expr),+ $(,)? }) => {
+    ($(#[$meta:meta])* $struct_name:ident($struct_type:ty) { $($name:ident = $val:expr),+ $(,)? }) => {
+        $(#[$meta])*
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub struct $struct_name(pub $struct_type);
 
@@ -89,9 +90,11 @@ macro_rules! dw {
     };
 }
 
+dw!(
 /// The unit type field in a unit header.
+///
 /// See Section 7.5.1, Table 7.2.
-dw!(DwUt(u8) {
+DwUt(u8) {
     DW_UT_compile = 0x01,
     DW_UT_type = 0x02,
     DW_UT_partial = 0x03,
@@ -102,13 +105,15 @@ dw!(DwUt(u8) {
     DW_UT_hi_user = 0xff,
 });
 
-/// Section 7.24:
+dw!(
+/// The opcode for a call frame instruction.
 ///
+/// Section 7.24:
 /// > Call frame instructions are encoded in one or more bytes. The primary
 /// > opcode is encoded in the high order two bits of the first byte (that is,
 /// > opcode = byte >> 6). An operand or extended opcode may be encoded in the
 /// > low order 6 bits. Additional operands are encoded in subsequent bytes.
-dw!(DwCfa(u8) {
+DwCfa(u8) {
     DW_CFA_advance_loc = 0x01 << 6,
     DW_CFA_offset = 0x02 << 6,
     DW_CFA_restore = 0x03 << 6,
@@ -145,16 +150,20 @@ dw!(DwCfa(u8) {
     DW_CFA_GNU_negative_offset_extended = 0x2f,
 });
 
+dw!(
 /// The child determination encodings for DIE attributes.
+///
 /// See Section 7.5.3, Table 7.4.
-dw!(DwChildren(u8) {
+DwChildren(u8) {
     DW_CHILDREN_no = 0,
     DW_CHILDREN_yes = 1,
 });
 
+dw!(
 /// The tag encodings for DIE attributes.
+///
 /// See Section 7.5.3, Table 7.3.
-dw!(DwTag(u64) {
+DwTag(u64) {
     DW_TAG_null = 0x00,
 
     DW_TAG_array_type = 0x01,
@@ -295,9 +304,11 @@ dw!(DwTag(u64) {
     DW_TAG_BORLAND_Delphi_variant = 0xb004,
 });
 
+dw!(
 /// The attribute encodings for DIE attributes.
+///
 /// See Section 7.5.4, Table 7.5.
-dw!(DwAt(u64) {
+DwAt(u64) {
     DW_AT_null = 0x00,
 
     DW_AT_sibling = 0x01,
@@ -600,9 +611,11 @@ dw!(DwAt(u64) {
     DW_AT_APPLE_property = 0x3fed
 });
 
+dw!(
 /// The attribute form encodings for DIE attributes.
+///
 /// See Section 7.5.6, Table 7.6.
-dw!(DwForm(u64) {
+DwForm(u64) {
     DW_FORM_null = 0x00,
 
     DW_FORM_addr = 0x01,
@@ -662,9 +675,11 @@ dw!(DwForm(u64) {
     DW_FORM_GNU_strp_alt = 0x1f21
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_encoding` attribute.
+///
 /// See Section 7.8, Table 7.11.
-dw!(DwAte(u8) {
+DwAte(u8) {
     DW_ATE_address = 0x01,
     DW_ATE_boolean = 0x02,
     DW_ATE_complex_float = 0x03,
@@ -692,9 +707,11 @@ dw!(DwAte(u8) {
     DW_ATE_hi_user = 0xff,
 });
 
+dw!(
 /// The encodings of the constants used in location list entries.
+///
 /// See Section 7.7.3, Table 7.10.
-dw!(DwLle(u8) {
+DwLle(u8) {
     DW_LLE_end_of_list = 0x00,
     DW_LLE_base_addressx = 0x01,
     DW_LLE_startx_endx = 0x02,
@@ -706,9 +723,11 @@ dw!(DwLle(u8) {
     DW_LLE_start_length = 0x08,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_decimal_sign` attribute.
+///
 /// See Section 7.8, Table 7.12.
-dw!(DwDs(u8) {
+DwDs(u8) {
     DW_DS_unsigned = 0x01,
     DW_DS_leading_overpunch = 0x02,
     DW_DS_trailing_overpunch = 0x03,
@@ -716,9 +735,11 @@ dw!(DwDs(u8) {
     DW_DS_trailing_separate = 0x05,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_endianity` attribute.
+///
 /// See Section 7.8, Table 7.13.
-dw!(DwEnd(u8) {
+DwEnd(u8) {
     DW_END_default = 0x00,
     DW_END_big = 0x01,
     DW_END_little = 0x02,
@@ -726,33 +747,41 @@ dw!(DwEnd(u8) {
     DW_END_hi_user = 0xff,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_accessibility` attribute.
+///
 /// See Section 7.9, Table 7.14.
-dw!(DwAccess(u8) {
+DwAccess(u8) {
     DW_ACCESS_public = 0x01,
     DW_ACCESS_protected = 0x02,
     DW_ACCESS_private = 0x03,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_visibility` attribute.
+///
 /// See Section 7.10, Table 7.15.
-dw!(DwVis(u8) {
+DwVis(u8) {
     DW_VIS_local = 0x01,
     DW_VIS_exported = 0x02,
     DW_VIS_qualified = 0x03,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_virtuality` attribute.
+///
 /// See Section 7.11, Table 7.16.
-dw!(DwVirtuality(u8) {
+DwVirtuality(u8) {
     DW_VIRTUALITY_none = 0x00,
     DW_VIRTUALITY_virtual = 0x01,
     DW_VIRTUALITY_pure_virtual = 0x02,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_language` attribute.
+///
 /// See Section 7.12, Table 7.17.
-dw!(DwLang(u16) {
+DwLang(u16) {
     DW_LANG_C89 = 0x0001,
     DW_LANG_C = 0x0002,
     DW_LANG_Ada83 = 0x0003,
@@ -837,25 +866,31 @@ impl DwLang {
     }
 }
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_address_class` attribute.
+///
 /// There is only one value that is common to all target architectures.
 /// See Section 7.13.
-dw!(DwAddr(u64) {
+DwAddr(u64) {
     DW_ADDR_none = 0x00,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_identifier_case` attribute.
+///
 /// See Section 7.14, Table 7.18.
-dw!(DwId(u8) {
+DwId(u8) {
     DW_ID_case_sensitive = 0x00,
     DW_ID_up_case = 0x01,
     DW_ID_down_case = 0x02,
     DW_ID_case_insensitive = 0x03,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_calling_convention` attribute.
+///
 /// See Section 7.15, Table 7.19.
-dw!(DwCc(u8) {
+DwCc(u8) {
     DW_CC_normal = 0x01,
     DW_CC_program = 0x02,
     DW_CC_nocall = 0x03,
@@ -865,32 +900,40 @@ dw!(DwCc(u8) {
     DW_CC_hi_user = 0xff,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_inline` attribute.
+///
 /// See Section 7.16, Table 7.20.
-dw!(DwInl(u8) {
+DwInl(u8) {
     DW_INL_not_inlined = 0x00,
     DW_INL_inlined = 0x01,
     DW_INL_declared_not_inlined = 0x02,
     DW_INL_declared_inlined = 0x03,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_ordering` attribute.
+///
 /// See Section 7.17, Table 7.17.
-dw!(DwOrd(u8) {
+DwOrd(u8) {
     DW_ORD_row_major = 0x00,
     DW_ORD_col_major = 0x01,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_discr_list` attribute.
+///
 /// See Section 7.18, Table 7.22.
-dw!(DwDsc(u8) {
+DwDsc(u8) {
     DW_DSC_label = 0x00,
     DW_DSC_range = 0x01,
 });
 
+dw!(
 /// Name index attribute encodings.
+///
 /// See Section 7.19, Table 7.23.
-dw!(DwIdx(u16) {
+DwIdx(u16) {
     DW_IDX_compile_unit = 1,
     DW_IDX_type_unit = 2,
     DW_IDX_die_offset = 3,
@@ -900,17 +943,21 @@ dw!(DwIdx(u16) {
     DW_IDX_hi_user = 0x3fff,
 });
 
+dw!(
 /// The encodings of the constants used in the `DW_AT_defaulted` attribute.
+///
 /// See Section 7.20, Table 7.24.
-dw!(DwDefaulted(u8) {
+DwDefaulted(u8) {
     DW_DEFAULTED_no = 0x00,
     DW_DEFAULTED_in_class = 0x01,
     DW_DEFAULTED_out_of_class = 0x02,
 });
 
+dw!(
 /// The encodings for the standard opcodes for line number information.
+///
 /// See Section 7.22, Table 7.25.
-dw!(DwLns(u8) {
+DwLns(u8) {
     DW_LNS_copy = 0x01,
     DW_LNS_advance_pc = 0x02,
     DW_LNS_advance_line = 0x03,
@@ -925,9 +972,11 @@ dw!(DwLns(u8) {
     DW_LNS_set_isa = 0x0c,
 });
 
+dw!(
 /// The encodings for the extended opcodes for line number information.
+///
 /// See Section 7.22, Table 7.26.
-dw!(DwLne(u8) {
+DwLne(u8) {
     DW_LNE_end_sequence = 0x01,
     DW_LNE_set_address = 0x02,
     DW_LNE_define_file = 0x03,
@@ -937,9 +986,11 @@ dw!(DwLne(u8) {
     DW_LNE_hi_user = 0xff,
 });
 
+dw!(
 /// The encodings for the line number header entry formats.
+///
 /// See Section 7.22, Table 7.27.
-dw!(DwLnct(u16) {
+DwLnct(u16) {
     DW_LNCT_path = 0x1,
     DW_LNCT_directory_index = 0x2,
     DW_LNCT_timestamp = 0x3,
@@ -949,9 +1000,11 @@ dw!(DwLnct(u16) {
     DW_LNCT_hi_user = 0x3fff,
 });
 
+dw!(
 /// The encodings for macro information entry types.
+///
 /// See Section 7.23, Table 7.28.
-dw!(DwMacro(u8) {
+DwMacro(u8) {
     DW_MACRO_define = 0x01,
     DW_MACRO_undef = 0x02,
     DW_MACRO_start_file = 0x03,
@@ -968,9 +1021,11 @@ dw!(DwMacro(u8) {
     DW_MACRO_hi_user = 0xff,
 });
 
+dw!(
 /// Range list entry encoding values.
+///
 /// See Section 7.25, Table 7.30.
-dw!(DwRle(u8) {
+DwRle(u8) {
     DW_RLE_end_of_list = 0x00,
     DW_RLE_base_addressx = 0x01,
     DW_RLE_startx_endx = 0x02,
@@ -981,9 +1036,11 @@ dw!(DwRle(u8) {
     DW_RLE_start_length = 0x07,
 });
 
+dw!(
 /// The encodings for DWARF expression operations.
+///
 /// See Section 7.7.1, Table 7.9.
-dw!(DwOp(u8) {
+DwOp(u8) {
     DW_OP_addr = 0x03,
     DW_OP_deref = 0x06,
     DW_OP_const1u = 0x08,
@@ -1161,12 +1218,15 @@ dw!(DwOp(u8) {
     DW_OP_GNU_parameter_ref = 0xfa,
 });
 
-/// Pointer encoding used by `.eh_frame`. The four lower bits describe the
+dw!(
+/// Pointer encoding used by `.eh_frame`.
+///
+/// The four lower bits describe the
 /// format of the pointer, the upper four bits describe how the encoding should
 /// be applied.
 ///
 /// Defined in http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/dwarfext.html
-dw!(DwEhPe(u8) {
+DwEhPe(u8) {
 // Format of pointer encoding.
 
 // "Unsigned value is encoded using the Little Endian Base 128"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -56,7 +56,7 @@ use std::fmt;
 //         }
 //     }
 macro_rules! dw {
-    ($struct_name:ident($struct_type:ty) { $($name:ident = $val:expr),+ }) => {
+    ($struct_name:ident($struct_type:ty) { $($name:ident = $val:expr),+ $(,)? }) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub struct $struct_name(pub $struct_type);
 
@@ -86,10 +86,6 @@ macro_rules! dw {
                 }
             }
         }
-    };
-    // Handle trailing comma
-    ($struct_name:ident($struct_type:ty) { $($name:ident = $val:expr),+, }) => {
-        dw!($struct_name($struct_type) { $($name = $val),+ });
     };
 }
 

--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -454,7 +454,7 @@ pub mod tests {
     fn test_debug_abbrev_ok() {
         let extra_start = [1, 2, 3, 4];
         let expected_rest = [5, 6, 7, 8];
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = Section::new()
             .append_bytes(&extra_start)
             .abbrev(2, constants::DW_TAG_subprogram, constants::DW_CHILDREN_no)
@@ -605,7 +605,7 @@ pub mod tests {
     #[test]
     fn test_parse_abbreviations_ok() {
         let expected_rest = [1, 2, 3, 4];
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = Section::new()
             .abbrev(2, constants::DW_TAG_subprogram, constants::DW_CHILDREN_no)
                 .abbrev_attr(constants::DW_AT_name, constants::DW_FORM_string)
@@ -658,7 +658,7 @@ pub mod tests {
     #[test]
     fn test_parse_abbreviations_duplicate() {
         let expected_rest = [1, 2, 3, 4];
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = Section::new()
             .abbrev(1, constants::DW_TAG_subprogram, constants::DW_CHILDREN_no)
                 .abbrev_attr(constants::DW_AT_name, constants::DW_FORM_string)

--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_parse_header_ok() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = [
             // 32-bit length = 32.
             0x20, 0x00, 0x00, 0x00,
@@ -370,7 +370,7 @@ mod tests {
             offset: DebugInfoOffset(0),
             segment_size: 8,
         };
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = [
             // Segment.
             0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
@@ -407,7 +407,7 @@ mod tests {
             offset: DebugInfoOffset(0),
             segment_size: 0,
         };
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = [
             // Zero tuple.
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -395,6 +395,7 @@ impl<R: Reader> Dwarf<R> {
     ///
     /// This uses information from the DWARF sections to provide more information in some cases.
     pub fn format_error(&self, err: Error) -> String {
+        #[allow(clippy::single_match)]
         match err {
             Error::UnexpectedEof(id) => match self.lookup_offset_id(id) {
                 Some((sup, section, offset)) => {
@@ -410,7 +411,7 @@ impl<R: Reader> Dwarf<R> {
             },
             _ => {}
         }
-        format!("{}", err.description())
+        err.description().into()
     }
 }
 

--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -412,7 +412,7 @@ where
         self.bytes()
             .iter()
             .position(|x| *x == byte)
-            .ok_or(Error::UnexpectedEof(self.offset_id()))
+            .ok_or_else(|| Error::UnexpectedEof(self.offset_id()))
     }
 
     #[inline]

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -265,7 +265,7 @@ where
     #[inline]
     fn find(&self, byte: u8) -> Result<usize> {
         self.find(byte)
-            .ok_or(Error::UnexpectedEof(self.offset_id()))
+            .ok_or_else(|| Error::UnexpectedEof(self.offset_id()))
     }
 
     #[inline]

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1891,7 +1891,7 @@ mod tests {
 
     #[test]
     fn test_parse_debug_line_32_ok() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = [
             // 32-bit length = 62.
             0x3e, 0x00, 0x00, 0x00,
@@ -1999,7 +1999,7 @@ mod tests {
 
     #[test]
     fn test_parse_debug_line_header_length_too_short() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = [
             // 32-bit length = 62.
             0x3e, 0x00, 0x00, 0x00,
@@ -2060,7 +2060,7 @@ mod tests {
 
     #[test]
     fn test_parse_debug_line_unit_length_too_short() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf = [
             // 32-bit length = 40. TOO SHORT!!!
             0x28, 0x00, 0x00, 0x00,

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -615,7 +615,7 @@ mod tests {
         let start = Label::new();
         let first = Label::new();
         let size = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // Header
             .mark(&start)
@@ -844,7 +844,7 @@ mod tests {
         let start = Label::new();
         let first = Label::new();
         let size = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // Header
             .mark(&start)
@@ -1058,7 +1058,7 @@ mod tests {
     fn test_location_list_32() {
         let start = Label::new();
         let first = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // A location before the offset.
             .mark(&start)
@@ -1188,7 +1188,7 @@ mod tests {
     fn test_location_list_64() {
         let start = Label::new();
         let first = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // A location before the offset.
             .mark(&start)
@@ -1316,7 +1316,7 @@ mod tests {
 
     #[test]
     fn test_locations_invalid() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // An invalid location range.
             .L32(0x20000).L32(0x10000).L16(4).L32(1)

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -1896,7 +1896,7 @@ mod tests {
         let encoding = encoding4();
 
         // Test all single-byte opcodes.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let inputs = [
             (
                 constants::DW_OP_deref,
@@ -2784,7 +2784,7 @@ mod tests {
         let done = 0;
         let fail = 1;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_const1u), U8(23),
             Op(DW_OP_const1s), U8((-23i8) as u8),
@@ -2955,7 +2955,7 @@ mod tests {
         let done = 0;
         let fail = 1;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_const8u), U64(0x1111_2222_3333_4444),
             Op(DW_OP_const8s), U64((-0x1111_2222_3333_4444i64) as u64),
@@ -3030,7 +3030,7 @@ mod tests {
         let done = 0;
         let fail = 1;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             // Comparisons are signed.
             Op(DW_OP_const1s), U8(1),
@@ -3093,7 +3093,7 @@ mod tests {
         use self::AssemblerEntry::*;
         use crate::constants::*;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_lit17),                // -- 17
             Op(DW_OP_dup),                  // -- 17 17
@@ -3192,7 +3192,7 @@ mod tests {
         let done = 0;
         let fail = 1;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_addr), U32(0x7fff_ffff),
             Op(DW_OP_deref),
@@ -3316,7 +3316,7 @@ mod tests {
         use crate::constants::*;
 
         for i in 0..32 {
-            #[cfg_attr(rustfmt, rustfmt_skip)]
+            #[rustfmt::skip]
             let program = [
                 Op(DwOp(DW_OP_reg0.0 + i)),
                 // Included only in the "bad" run.
@@ -3339,7 +3339,7 @@ mod tests {
             );
         }
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_regx), Uleb(0x1234)
         ];
@@ -3363,7 +3363,7 @@ mod tests {
         use crate::constants::*;
 
         // Test `frame_base` and `call_frame_cfa` callbacks.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_fbreg), Sleb((-8i8) as u64),
             Op(DW_OP_call_frame_cfa),
@@ -3401,7 +3401,7 @@ mod tests {
         );
 
         // Test `evaluate_entry_value` callback.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_entry_value), Uleb(8), U64(0x1234_5678),
             Op(DW_OP_stack_value)
@@ -3434,7 +3434,7 @@ mod tests {
         );
 
         // Test missing `object_address` field.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_push_object_address),
         ];
@@ -3450,7 +3450,7 @@ mod tests {
         );
 
         // Test `object_address` field.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_push_object_address),
             Op(DW_OP_stack_value),
@@ -3475,7 +3475,7 @@ mod tests {
         );
 
         // Test `initial_value` field.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
         ];
 
@@ -3505,7 +3505,7 @@ mod tests {
         use self::AssemblerEntry::*;
         use crate::constants::*;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_stack_value)
         ];
@@ -3520,7 +3520,7 @@ mod tests {
         use self::AssemblerEntry::*;
         use crate::constants::*;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_lit23),
             Op(DW_OP_call2), U16(0x7755),
@@ -3621,7 +3621,7 @@ mod tests {
         use crate::constants::*;
 
         // Example from DWARF 2.6.1.3.
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_reg3),
             Op(DW_OP_piece), Uleb(4),
@@ -3650,7 +3650,7 @@ mod tests {
 
         // Example from DWARF 2.6.1.3 (but hacked since dealing with fbreg
         // in the tests is a pain).
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_reg0),
             Op(DW_OP_piece), Uleb(4),
@@ -3702,7 +3702,7 @@ mod tests {
             },
         );
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_implicit_value), Uleb(5),
             U8(23), U8(24), U8(25), U8(26), U8(0),
@@ -3720,7 +3720,7 @@ mod tests {
 
         check_eval(&program, Ok(&result), encoding4());
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_lit7),
             Op(DW_OP_stack_value),
@@ -3745,7 +3745,7 @@ mod tests {
 
         check_eval(&program, Ok(&result), encoding4());
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_lit7),
         ];
@@ -3758,7 +3758,7 @@ mod tests {
 
         check_eval(&program, Ok(&result), encoding4());
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_implicit_pointer), U32(0x1234_5678), Sleb(0x123),
         ];
@@ -3774,7 +3774,7 @@ mod tests {
 
         check_eval(&program, Ok(&result), encoding4());
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_reg3),
             Op(DW_OP_piece), Uleb(4),
@@ -3783,7 +3783,7 @@ mod tests {
 
         check_eval(&program, Err(Error::InvalidPiece), encoding4());
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Op(DW_OP_reg3),
             Op(DW_OP_piece), Uleb(4),
@@ -3800,7 +3800,7 @@ mod tests {
         use self::AssemblerEntry::*;
         use crate::constants::*;
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let program = [
             Mark(1),
             Op(DW_OP_skip), Branch(1),
@@ -3830,7 +3830,7 @@ mod tests {
         ];
 
         // TODO: convert, reinterpret
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let tests = [
             (
                 &[

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -623,7 +623,7 @@ mod tests {
         let start = Label::new();
         let first = Label::new();
         let size = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // Header
             .mark(&start)
@@ -815,7 +815,7 @@ mod tests {
         let start = Label::new();
         let first = Label::new();
         let size = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // Header
             .mark(&start)
@@ -1025,7 +1025,7 @@ mod tests {
     fn test_ranges_32() {
         let start = Label::new();
         let first = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // A range before the offset.
             .mark(&start)
@@ -1137,7 +1137,7 @@ mod tests {
     fn test_ranges_64() {
         let start = Label::new();
         let first = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // A range before the offset.
             .mark(&start)
@@ -1247,7 +1247,7 @@ mod tests {
 
     #[test]
     fn test_ranges_invalid() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             // An invalid range.
             .L32(0x20000).L32(0x10000)

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -4726,7 +4726,7 @@ mod tests {
     }
 
     fn entries_cursor_tests_abbrev_buf() -> Vec<u8> {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             .abbrev(1, DW_TAG_subprogram, DW_CHILDREN_yes)
                 .abbrev_attr(DW_AT_name, DW_FORM_string)
@@ -4736,7 +4736,7 @@ mod tests {
     }
 
     fn entries_cursor_tests_debug_info_buf() -> Vec<u8> {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             .die(1, |s| s.attr_string("001"))
                 .die(1, |s| s.attr_string("002"))
@@ -4780,7 +4780,7 @@ mod tests {
 
     #[test]
     fn test_cursor_next_entry_incomplete() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             .die(1, |s| s.attr_string("001"))
                 .die(1, |s| s.attr_string("002"))
@@ -5024,7 +5024,7 @@ mod tests {
     }
 
     fn entries_cursor_sibling_abbrev_buf() -> Vec<u8> {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             .abbrev(1, DW_TAG_subprogram, DW_CHILDREN_yes)
                 .abbrev_attr(DW_AT_name, DW_FORM_string)
@@ -5044,7 +5044,7 @@ mod tests {
         let sibling009_ref = Label::new();
         let sibling009 = Label::new();
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             .mark(&start)
             .die(2, |s| s.attr_string("001"))
@@ -5230,8 +5230,8 @@ mod tests {
     }
 
     fn entries_tree_tests_debug_abbrevs_buf() -> Vec<u8> {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        Section::with_endian(Endian::Little)
+        #[rustfmt::skip]
+        let section = Section::with_endian(Endian::Little)
             .abbrev(1, DW_TAG_subprogram, DW_CHILDREN_yes)
                 .abbrev_attr(DW_AT_name, DW_FORM_string)
                 .abbrev_attr_null()
@@ -5240,13 +5240,14 @@ mod tests {
                 .abbrev_attr_null()
             .abbrev_null()
             .get_contents()
-            .unwrap()
+            .unwrap();
+        section
     }
 
     fn entries_tree_tests_debug_info_buf(header_size: usize) -> (Vec<u8>, UnitOffset) {
         let start = Label::new();
         let entry2 = Label::new();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let section = Section::with_endian(Endian::Little)
             .mark(&start)
             .die(1, |s| s.attr_string("root"))

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -914,7 +914,7 @@ mod tests {
     };
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn valuetype_from_encoding() {
         let encoding = Encoding {
             format: Format::Dwarf32,
@@ -1007,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_reinterpret() {
         let addr_mask = !0 >> 32;
         for &(v, t, result) in &[
@@ -1045,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_abs() {
         let addr_mask = 0xffff_ffff;
         for &(v, result) in &[
@@ -1066,7 +1066,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_neg() {
         let addr_mask = 0xffff_ffff;
         for &(v, result) in &[
@@ -1087,7 +1087,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_add() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1109,7 +1109,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_sub() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1131,7 +1131,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_mul() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1153,7 +1153,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_div() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1190,7 +1190,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_rem() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1225,7 +1225,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_not() {
         let addr_mask = 0xffff_ffff;
         for &(v, result) in &[
@@ -1246,7 +1246,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_and() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1268,7 +1268,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_or() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1290,7 +1290,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_xor() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1312,7 +1312,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_shl() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1351,7 +1351,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_shr() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[
@@ -1386,7 +1386,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn value_shra() {
         let addr_mask = 0xffff_ffff;
         for &(v1, v2, result) in &[

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -113,7 +113,7 @@ impl LineProgram {
             line_encoding,
             directories: IndexSet::new(),
             files: IndexMap::new(),
-            comp_file: (comp_file, comp_file_info.unwrap_or(FileInfo::default())),
+            comp_file: (comp_file, comp_file_info.unwrap_or_default()),
             prev_row: LineRow::initial_state(line_encoding),
             row: LineRow::initial_state(line_encoding),
             instructions: Vec::new(),
@@ -570,7 +570,7 @@ impl LineProgram {
             w.write_u8(1)?;
             w.write_uleb128(u64::from(constants::DW_LNCT_path.0))?;
             let dir_form = self.directories.get_index(0).unwrap().form();
-            w.write_uleb128(u64::from(dir_form.0))?;
+            w.write_uleb128(dir_form.0)?;
 
             // Directory entries.
             w.write_uleb128(self.directories.len() as u64)?;
@@ -592,20 +592,20 @@ impl LineProgram {
             w.write_u8(count)?;
             w.write_uleb128(u64::from(constants::DW_LNCT_path.0))?;
             let file_form = self.comp_file.0.form();
-            w.write_uleb128(u64::from(file_form.0))?;
+            w.write_uleb128(file_form.0)?;
             w.write_uleb128(u64::from(constants::DW_LNCT_directory_index.0))?;
-            w.write_uleb128(u64::from(constants::DW_FORM_udata.0))?;
+            w.write_uleb128(constants::DW_FORM_udata.0)?;
             if self.file_has_timestamp {
                 w.write_uleb128(u64::from(constants::DW_LNCT_timestamp.0))?;
-                w.write_uleb128(u64::from(constants::DW_FORM_udata.0))?;
+                w.write_uleb128(constants::DW_FORM_udata.0)?;
             }
             if self.file_has_size {
                 w.write_uleb128(u64::from(constants::DW_LNCT_size.0))?;
-                w.write_uleb128(u64::from(constants::DW_FORM_udata.0))?;
+                w.write_uleb128(constants::DW_FORM_udata.0)?;
             }
             if self.file_has_md5 {
                 w.write_uleb128(u64::from(constants::DW_LNCT_MD5.0))?;
-                w.write_uleb128(u64::from(constants::DW_FORM_data16.0))?;
+                w.write_uleb128(constants::DW_FORM_data16.0)?;
             }
 
             // File name entries.

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -265,7 +265,7 @@ struct BaseId(usize);
 impl Default for BaseId {
     fn default() -> Self {
         use std::sync::atomic;
-        static BASE_ID: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
+        static BASE_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
         BaseId(BASE_ID.fetch_add(1, atomic::Ordering::Relaxed))
     }
 }

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -622,6 +622,7 @@ impl Attribute {
 
     /// Write the attribute to the given sections.
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn write<W: Writer>(
         &self,
         w: &mut DebugInfo<W>,
@@ -891,7 +892,7 @@ impl AttributeValue {
     }
 
     /// Write the attribute value to the given sections.
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cyclomatic_complexity, clippy::too_many_arguments)]
     fn write<W: Writer>(
         &self,
         w: &mut DebugInfo<W>,

--- a/src/write/writer.rs
+++ b/src/write/writer.rs
@@ -262,7 +262,7 @@ mod tests {
         w.write_u16(0x2233).unwrap();
         w.write_u32(0x4455_6677).unwrap();
         w.write_u64(0x8081_8283_8485_8687).unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         assert_eq!(w.slice(), &[
             0x11,
             0x33, 0x22,
@@ -273,7 +273,7 @@ mod tests {
         w.write_u16_at(12, 0x2233).unwrap();
         w.write_u32_at(8, 0x4455_6677).unwrap();
         w.write_u64_at(0, 0x8081_8283_8485_8687).unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         assert_eq!(w.slice(), &[
             0x87, 0x86, 0x85, 0x84, 0x83, 0x82, 0x81, 0x80,
             0x77, 0x66, 0x55, 0x44,
@@ -286,7 +286,7 @@ mod tests {
         w.write_u16(0x2233).unwrap();
         w.write_u32(0x4455_6677).unwrap();
         w.write_u64(0x8081_8283_8485_8687).unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         assert_eq!(w.slice(), &[
             0x11,
             0x22, 0x33,
@@ -297,7 +297,7 @@ mod tests {
         w.write_u16_at(12, 0x2233).unwrap();
         w.write_u32_at(8, 0x4455_6677).unwrap();
         w.write_u64_at(0, 0x8081_8283_8485_8687).unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         assert_eq!(w.slice(), &[
             0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
             0x44, 0x55, 0x66, 0x77,
@@ -310,7 +310,7 @@ mod tests {
         w.write_word(0x2233, 2).unwrap();
         w.write_word(0x4455_6677, 4).unwrap();
         w.write_word(0x8081_8283_8485_8687, 8).unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         assert_eq!(w.slice(), &[
             0x11,
             0x33, 0x22,
@@ -325,7 +325,7 @@ mod tests {
         w.write_word_at(12, 0x2233, 2).unwrap();
         w.write_word_at(8, 0x4455_6677, 4).unwrap();
         w.write_word_at(0, 0x8081_8283_8485_8687, 8).unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         assert_eq!(w.slice(), &[
             0x87, 0x86, 0x85, 0x84, 0x83, 0x82, 0x81, 0x80,
             0x77, 0x66, 0x55, 0x44,


### PR DESCRIPTION
Fix both nightly and clippy warnings.

Some of these fixes require rust 1.32.0, so check for that in CI.