### PR TITLE
Add a simple example

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -989,18 +989,9 @@ fn dump_entries<R: Reader, W: Write>(
         depth += delta_depth;
         assert!(depth >= 0);
         let mut indent = depth as usize * 2 + 2;
-        write!(
-            w,
-            "<{}{}>",
-            if depth < 10 { " " } else { "" },
-            depth)?;
+        write!(w, "<{}{}>", if depth < 10 { " " } else { "" }, depth)?;
         write_offset(w, &unit, entry.offset(), flags)?;
-        writeln!(
-            w,
-            "{}{}",
-            spaces(&mut spaces_buf, indent),
-            entry.tag()
-        )?;
+        writeln!(w, "{}{}", spaces(&mut spaces_buf, indent), entry.tag())?;
 
         indent += 18;
         if flags.goff {
@@ -1134,11 +1125,11 @@ fn dump_attr_value<R: Reader, W: Write>(
                 UnitSectionOffset::DebugInfoOffset(o) => {
                     write!(w, "<.debug_info+")?;
                     o.0
-                },
+                }
                 UnitSectionOffset::DebugTypesOffset(o) => {
                     write!(w, "<.debug_types+")?;
                     o.0
-                },
+                }
             };
             writeln!(w, "0x{:08x}>", goff)?;
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,62 @@
+use object::Object;
+use std::{borrow, env, fs};
+
+fn main() {
+    for path in env::args() {
+        let file = fs::File::open(&path).unwrap();
+        let mmap = unsafe { memmap::Mmap::map(&file).unwrap() };
+        let object = object::File::parse(&*mmap).unwrap();
+        let endian = if object.is_little_endian() {
+            gimli::RunTimeEndian::Little
+        } else {
+            gimli::RunTimeEndian::Big
+        };
+        dump_file(&object, endian).unwrap();
+    }
+}
+
+fn dump_file(object: &object::File, endian: gimli::RunTimeEndian) -> Result<(), gimli::Error> {
+    // Load a section and return as `Cow<[u8]>`.
+    let load_section = |id: gimli::SectionId| -> Result<borrow::Cow<[u8]>, gimli::Error> {
+        Ok(object
+            .section_data_by_name(id.name())
+            .unwrap_or(borrow::Cow::Borrowed(&[][..])))
+    };
+    // Load a supplementary section. We don't have a supplementary object file,
+    // so always return an empty slice.
+    let load_section_sup = |_| Ok(borrow::Cow::Borrowed(&[][..]));
+
+    // Load all of the sections.
+    let dwarf_cow = gimli::Dwarf::load(&load_section, &load_section_sup)?;
+
+    // Borrow a `Cow<[u8]>` to create an `EndianSlice`.
+    let borrow_section: &dyn for<'a> Fn(
+        &'a borrow::Cow<[u8]>,
+    ) -> gimli::EndianSlice<'a, gimli::RunTimeEndian> =
+        &|section| gimli::EndianSlice::new(&*section, endian);
+
+    // Create `EndianSlice`s for all of the sections.
+    let dwarf = dwarf_cow.borrow(&borrow_section);
+
+    // Iterate over the compilation units.
+    let mut iter = dwarf.units();
+    while let Some(header) = iter.next()? {
+        println!("Unit at <.debug_info+0x{:x}>", header.offset().0);
+        let unit = dwarf.unit(header)?;
+
+        // Iterate over the Debugging Information Entries (DIEs) in the unit.
+        let mut depth = 0;
+        let mut entries = unit.entries();
+        while let Some((delta_depth, entry)) = entries.next_dfs()? {
+            depth += delta_depth;
+            println!("<{}><{:x}> {}", depth, entry.offset().0, entry.tag());
+
+            // Iterate over the attributes in the DIE.
+            let mut attrs = entry.attrs();
+            while let Some(attr) = attrs.next()? {
+                println!("   {}: {:?}", attr.name(), attr.value());
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -59,6 +59,10 @@ impl<T> Dwarf<T> {
     /// `section` loads a DWARF section from the main object file.
     /// `sup` loads a DWARF sections from the supplementary object file.
     /// These functions should return an empty section if the section does not exist.
+    ///
+    /// The provided callback functions may either directly return a `Reader` instance
+    /// (such as `EndianSlice`), or they may return some other type and then convert
+    /// that type into a `Reader` using `Dwarf::borrow`.
     pub fn load<F1, F2, E>(mut section: F1, mut sup: F2) -> std::result::Result<Self, E>
     where
         F1: FnMut(SectionId) -> std::result::Result<T, E>,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -11,9 +11,12 @@
 //! ```rust,no_run
 //! # fn example() -> Result<(), gimli::Error> {
 //! # type R = gimli::EndianSlice<'static, gimli::LittleEndian>;
-//! # let loader = |name| -> Result<R, gimli::Error> { unimplemented!() };
-//! # let sup_loader = |name| { unimplemented!() };
+//! # let get_file_section_reader = |name| -> Result<R, gimli::Error> { unimplemented!() };
+//! # let get_sup_file_section_reader = |name| -> Result<R, gimli::Error> { unimplemented!() };
 //! // Read the DWARF sections with whatever object loader you're using.
+//! // These closures should return a `Reader` instance (e.g. `EndianSlice`).
+//! let loader = |section: gimli::SectionId| { get_file_section_reader(section.name()) };
+//! let sup_loader = |section: gimli::SectionId| { get_sup_file_section_reader(section.name()) };
 //! let dwarf = gimli::Dwarf::load(loader, sup_loader)?;
 //!
 //! // Iterate over all compilation units.
@@ -36,6 +39,8 @@
 //! ```
 //!
 //! Full example programs:
+//!
+//!   * [A simple parser](https://github.com/gimli-rs/gimli/blob/master/examples/simple.rs)
 //!
 //!   * [A `dwarfdump`
 //!     clone](https://github.com/gimli-rs/gimli/blob/master/examples/dwarfdump.rs)


### PR DESCRIPTION
because the dwarfdump example is no longer simple.

Also expand the `Dwarf::load` documentation slightly.