### PR TITLE
Added LLVM_source attributes to line programs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -998,6 +998,9 @@ DwLnct(u16) {
     DW_LNCT_MD5 = 0x5,
     DW_LNCT_lo_user = 0x2000,
     DW_LNCT_hi_user = 0x3fff,
+
+// LLVM project extensions.
+    DW_LNCT_LLVM_source = 0x2001,
 });
 
 dw!(


### PR DESCRIPTION
WIP implementation for #431.

Annoyingly due to how these form descriptors work it means that all files need to have the same format. I wonder if it makes sense to just write an empty string in such cases. Effectively something similar happens with md5 hashes already.

Second issue is that this change required to remove a `Copy` bound :(