### PR TITLE
Simplify implementation of Ord for ArangeEntry

### DIFF
--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -61,19 +61,9 @@ impl<T: Copy + Ord> PartialOrd for ArangeEntry<T> {
 impl<T: Copy + Ord> Ord for ArangeEntry<T> {
     fn cmp(&self, other: &ArangeEntry<T>) -> Ordering {
         // The expected comparison, but ignore header.
-        match (
-            self.segment.cmp(&other.segment),
-            self.address.cmp(&other.address),
-            self.length.cmp(&other.length),
-        ) {
-            (Ordering::Equal, Ordering::Equal, Ordering::Equal) => Ordering::Equal,
-            (Ordering::Less, _, _)
-            | (Ordering::Equal, Ordering::Less, _)
-            | (Ordering::Equal, Ordering::Equal, Ordering::Less) => Ordering::Less,
-            (Ordering::Greater, _, _)
-            | (Ordering::Equal, Ordering::Greater, _)
-            | (Ordering::Equal, Ordering::Equal, Ordering::Greater) => Ordering::Greater,
-        }
+        self.segment.cmp(&other.segment)
+            .then(self.address.cmp(&other.address))
+            .then(self.length.cmp(&other.length))
     }
 }
 


### PR DESCRIPTION
This PR uses existing `Ordering` API to make the code both more clear and more concise.