### PR TITLE
Abbreviation parsing performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ arrayvec = { version = "0.4.6", default-features = false }
 byteorder = { version = "1.0", default-features = false }
 fallible-iterator = { version = "0.2.0", default-features = false }
 indexmap = { version = "1.0.2", optional = true }
+smallvec = { version = "0.6.10", default-features = false }
 stable_deref_trait = { version = "1.1.0", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ write = ["std", "indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
 alloc = ["fallible-iterator/alloc", "stable_deref_trait/alloc"]
 default = ["read", "write", "std"]
+
+[profile.bench]
+debug = true
+codegen-units = 1

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -163,7 +163,7 @@ dw!(
 /// The tag encodings for DIE attributes.
 ///
 /// See Section 7.5.3, Table 7.3.
-DwTag(u64) {
+DwTag(u16) {
     DW_TAG_null = 0x00,
 
     DW_TAG_array_type = 0x01,
@@ -308,7 +308,7 @@ dw!(
 /// The attribute encodings for DIE attributes.
 ///
 /// See Section 7.5.4, Table 7.5.
-DwAt(u64) {
+DwAt(u16) {
     DW_AT_null = 0x00,
 
     DW_AT_sibling = 0x01,
@@ -617,7 +617,7 @@ dw!(
 /// The attribute form encodings for DIE attributes.
 ///
 /// See Section 7.5.6, Table 7.6.
-DwForm(u64) {
+DwForm(u16) {
     DW_FORM_null = 0x00,
 
     DW_FORM_addr = 0x01,

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1695,7 +1695,7 @@ impl FileEntryFormat {
                 path_count += 1;
             }
 
-            let form = constants::DwForm(input.read_uleb128()?);
+            let form = constants::DwForm(input.read_uleb128_u16()?);
 
             format.push(FileEntryFormat { content_type, form });
         }

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -391,6 +391,11 @@ pub trait Reader: Debug + Clone {
         leb128::read::unsigned(self)
     }
 
+    /// Read an unsigned LEB128 encoded u16.
+    fn read_uleb128_u16(&mut self) -> Result<u16> {
+        leb128::read::u16(self)
+    }
+
     /// Read a signed LEB128 encoded integer.
     fn read_sleb128(&mut self) -> Result<i64> {
         leb128::read::signed(self)

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -1862,7 +1862,7 @@ pub(crate) fn parse_attribute<'unit, 'abbrev, R: Reader>(
     loop {
         let value = match form {
             constants::DW_FORM_indirect => {
-                let dynamic_form = input.read_uleb128()?;
+                let dynamic_form = input.read_uleb128_u16()?;
                 form = constants::DwForm(dynamic_form);
                 continue;
             }
@@ -4416,7 +4416,7 @@ mod tests {
 
         let bytes_written = {
             let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, constants::DW_FORM_udata.0)
+            leb128::write::unsigned(&mut writable, constants::DW_FORM_udata.0.into())
                 .expect("should write udata")
                 + leb128::write::unsigned(&mut writable, 9_999_999).expect("should write value")
         };

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -3128,6 +3128,7 @@ mod tests {
     };
     use crate::test_util::GimliSectionMethods;
     use crate::vec::Vec;
+    use smallvec::smallvec;
     use std;
     use std::cell::Cell;
     use test_assembler::{Endian, Label, LabelMaker, Section};
@@ -4445,7 +4446,7 @@ mod tests {
             42,
             constants::DW_TAG_subprogram,
             constants::DW_CHILDREN_yes,
-            vec![
+            smallvec![
                 AttributeSpecification::new(constants::DW_AT_name, constants::DW_FORM_string, None),
                 AttributeSpecification::new(constants::DW_AT_low_pc, constants::DW_FORM_addr, None),
                 AttributeSpecification::new(
@@ -4556,7 +4557,7 @@ mod tests {
             42,
             constants::DW_TAG_subprogram,
             constants::DW_CHILDREN_yes,
-            vec![
+            smallvec![
                 AttributeSpecification::new(constants::DW_AT_name, constants::DW_FORM_string, None),
                 AttributeSpecification::new(constants::DW_AT_low_pc, constants::DW_FORM_addr, None),
                 AttributeSpecification::new(

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -912,6 +912,7 @@ mod tests {
         Abbreviation, AttributeSpecification, DebuggingInformationEntry, EndianSlice, UnitHeader,
         UnitOffset,
     };
+    use smallvec::smallvec;
 
     #[test]
     #[rustfmt::skip]
@@ -932,7 +933,7 @@ mod tests {
             42,
             constants::DW_TAG_base_type,
             constants::DW_CHILDREN_no,
-            vec![
+            smallvec![
                 AttributeSpecification::new(
                     constants::DW_AT_byte_size,
                     constants::DW_FORM_udata,

--- a/src/write/abbrev.rs
+++ b/src/write/abbrev.rs
@@ -61,7 +61,7 @@ impl Abbreviation {
 
     /// Write the abbreviation to the `.debug_abbrev` section.
     pub fn write<W: Writer>(&self, w: &mut DebugAbbrev<W>) -> Result<()> {
-        w.write_uleb128(self.tag.0)?;
+        w.write_uleb128(self.tag.0.into())?;
         w.write_u8(if self.has_children {
             constants::DW_CHILDREN_yes.0
         } else {
@@ -94,8 +94,8 @@ impl AttributeSpecification {
     /// Write the attribute specification to the `.debug_abbrev` section.
     #[inline]
     pub fn write<W: Writer>(&self, w: &mut DebugAbbrev<W>) -> Result<()> {
-        w.write_uleb128(self.name.0)?;
-        w.write_uleb128(self.form.0)
+        w.write_uleb128(self.name.0.into())?;
+        w.write_uleb128(self.form.0.into())
     }
 }
 

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -574,7 +574,7 @@ impl LineProgram {
             w.write_u8(1)?;
             w.write_uleb128(u64::from(constants::DW_LNCT_path.0))?;
             let dir_form = self.directories.get_index(0).unwrap().form();
-            w.write_uleb128(dir_form.0)?;
+            w.write_uleb128(dir_form.0.into())?;
 
             // Directory entries.
             w.write_uleb128(self.directories.len() as u64)?;
@@ -596,20 +596,20 @@ impl LineProgram {
             w.write_u8(count)?;
             w.write_uleb128(u64::from(constants::DW_LNCT_path.0))?;
             let file_form = self.comp_file.0.form();
-            w.write_uleb128(file_form.0)?;
+            w.write_uleb128(file_form.0.into())?;
             w.write_uleb128(u64::from(constants::DW_LNCT_directory_index.0))?;
-            w.write_uleb128(constants::DW_FORM_udata.0)?;
+            w.write_uleb128(constants::DW_FORM_udata.0.into())?;
             if self.file_has_timestamp {
                 w.write_uleb128(u64::from(constants::DW_LNCT_timestamp.0))?;
-                w.write_uleb128(constants::DW_FORM_udata.0)?;
+                w.write_uleb128(constants::DW_FORM_udata.0.into())?;
             }
             if self.file_has_size {
                 w.write_uleb128(u64::from(constants::DW_LNCT_size.0))?;
-                w.write_uleb128(constants::DW_FORM_udata.0)?;
+                w.write_uleb128(constants::DW_FORM_udata.0.into())?;
             }
             if self.file_has_md5 {
                 w.write_uleb128(u64::from(constants::DW_LNCT_MD5.0))?;
-                w.write_uleb128(constants::DW_FORM_data16.0)?;
+                w.write_uleb128(constants::DW_FORM_data16.0.into())?;
             }
 
             // File name entries.


### PR DESCRIPTION
Reduce the size of abbreviations, and store them in a `SmallVec`.


```
 name                                                       before ns/iter  after ns/iter  diff ns/iter   diff %  speedup 
 bench_parsing_debug_abbrev                                 21,492          11,008              -10,484  -48.78%   x 1.95 
 bench_parsing_debug_info                                   1,352,849       1,234,978          -117,871   -8.71%   x 1.10 
 bench_parsing_debug_info_tree                              1,417,695       1,259,731          -157,964  -11.14%   x 1.13 
 bench_parsing_debug_info_with_endian_rc_slice              2,136,618       1,982,039          -154,579   -7.23%   x 1.08 
```