### PR TITLE
read: handle more attributes names in Attribute::value()

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -1112,8 +1112,7 @@ fn dump_attr_value<R: Reader, W: Write>(
             writeln!(w)?;
         }
         gimli::AttributeValue::Flag(true) => {
-            // We don't record what the value was, so assume 1.
-            writeln!(w, "yes(1)")?;
+            writeln!(w, "yes")?;
         }
         gimli::AttributeValue::Flag(false) => {
             writeln!(w, "no")?;
@@ -1130,26 +1129,23 @@ fn dump_attr_value<R: Reader, W: Write>(
         }
         gimli::AttributeValue::UnitRef(offset) => {
             write!(w, "0x{:08x}", offset.0)?;
-            let goff = match offset.to_unit_section_offset(unit) {
-                UnitSectionOffset::DebugInfoOffset(o) => {
-                    write!(w, "<.debug_info+")?;
-                    o.0
+            match offset.to_unit_section_offset(unit) {
+                UnitSectionOffset::DebugInfoOffset(goff) => {
+                    write!(w, "<.debug_info+0x{:08x}>", goff.0)?;
                 }
-                UnitSectionOffset::DebugTypesOffset(o) => {
-                    write!(w, "<.debug_types+")?;
-                    o.0
+                UnitSectionOffset::DebugTypesOffset(goff) => {
+                    write!(w, "<.debug_types+0x{:08x}>", goff.0)?;
                 }
-            };
-            writeln!(w, "0x{:08x}>", goff)?;
+            }
         }
-        gimli::AttributeValue::DebugInfoRef(gimli::DebugInfoOffset(offset)) => {
-            writeln!(w, "<.debug_info+0x{:08x}>", offset)?;
+        gimli::AttributeValue::DebugInfoRef(offset) => {
+            writeln!(w, "<.debug_info+0x{:08x}>", offset.0)?;
         }
-        gimli::AttributeValue::DebugInfoRefSup(gimli::DebugInfoOffset(offset)) => {
-            writeln!(w, "<.debug_info(sup)+0x{:08x}>", offset)?;
+        gimli::AttributeValue::DebugInfoRefSup(offset) => {
+            writeln!(w, "<.debug_info(sup)+0x{:08x}>", offset.0)?;
         }
-        gimli::AttributeValue::DebugLineRef(gimli::DebugLineOffset(offset)) => {
-            writeln!(w, "0x{:08x}", offset)?;
+        gimli::AttributeValue::DebugLineRef(offset) => {
+            writeln!(w, "<.debug_line+0x{:08x}>", offset.0)?;
         }
         gimli::AttributeValue::LocationListsRef(offset) => {
             dump_loc_list(w, offset, unit, dwarf)?;
@@ -1161,8 +1157,11 @@ fn dump_attr_value<R: Reader, W: Write>(
             let offset = dwarf.locations_offset(unit, index)?;
             dump_loc_list(w, offset, unit, dwarf)?;
         }
-        gimli::AttributeValue::DebugMacinfoRef(gimli::DebugMacinfoOffset(offset)) => {
-            writeln!(w, "{}", offset)?;
+        gimli::AttributeValue::DebugMacinfoRef(offset) => {
+            writeln!(w, "<.debug_macinfo+0x{:08x}>", offset.0)?;
+        }
+        gimli::AttributeValue::DebugMacroRef(offset) => {
+            writeln!(w, "<.debug_macro+0x{:08x}>", offset.0)?;
         }
         gimli::AttributeValue::RangeListsRef(offset) => {
             dump_range_list(w, offset, unit, dwarf)?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -125,6 +125,10 @@ pub struct DebugLocListsIndex<T = usize>(pub T);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DebugMacinfoOffset<T = usize>(pub T);
 
+/// An offset into the `.debug_macro` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DebugMacroOffset<T = usize>(pub T);
+
 /// An offset into either the `.debug_ranges` section or the `.debug_rnglists` section,
 /// depending on the version of the unit the offset was contained in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -216,6 +220,8 @@ pub enum SectionId {
     DebugLocLists,
     /// The `.debug_macinfo` section.
     DebugMacinfo,
+    /// The `.debug_macro` section.
+    DebugMacro,
     /// The `.debug_pubnames` section.
     DebugPubNames,
     /// The `.debug_pubtypes` section.
@@ -248,6 +254,7 @@ impl SectionId {
             SectionId::DebugLoc => ".debug_loc",
             SectionId::DebugLocLists => ".debug_loclists",
             SectionId::DebugMacinfo => ".debug_macinfo",
+            SectionId::DebugMacro => ".debug_macro",
             SectionId::DebugPubNames => ".debug_pubnames",
             SectionId::DebugPubTypes => ".debug_pubtypes",
             SectionId::DebugRanges => ".debug_ranges",


### PR DESCRIPTION
I think the only change of significance is the handling for `DW_AT_macros` from DWARF 5.