### PR TITLE
Delete alloc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ script: ./ci/script.sh
 
 env:
   matrix:
-    - GIMLI_JOB="test"              GIMLI_PROFILE=
-    - GIMLI_JOB="build"             GIMLI_PROFILE="--no-default-features --features read,std"
-    - GIMLI_JOB="build"             GIMLI_PROFILE="--no-default-features --features write"
+    - GIMLI_JOB="test"
+    - GIMLI_JOB="features"
 
 matrix:
   fast_finish: true
@@ -42,17 +41,14 @@ matrix:
     - rust: nightly
       os: linux
       sudo: required
-      env: GIMLI_JOB="coverage"     GIMLI_PROFILE=
+      env: GIMLI_JOB="coverage"
     # Building docs only needs to happen on one os and only on stable.
     - rust: stable
       os: linux
-      env: GIMLI_JOB="doc"          GIMLI_PROFILE=
+      env: GIMLI_JOB="doc"
     # Benching should only happen on nightly.
     - rust: nightly
-      env: GIMLI_JOB="bench"        GIMLI_PROFILE=
-    # The no-std/alloc build should only happen on nightly.
-    - rust: nightly
-      env: GIMLI_JOB="alloc"        GIMLI_PROFILE=
+      env: GIMLI_JOB="bench"
     # Build a 32 bit target.
     - rust: stable
       sudo: required
@@ -60,7 +56,6 @@ matrix:
       env:
         - TARGET=i686-unknown-linux-gnu
         - GIMLI_JOB=cross
-        - GIMLI_PROFILE=
     # Build a big-endian target.
     - rust: stable
       sudo: required
@@ -68,6 +63,3 @@ matrix:
       env:
         - TARGET=powerpc64-unknown-linux-gnu
         - GIMLI_JOB=cross
-        - GIMLI_PROFILE=
-  allow_failures:
-    - env: GIMLI_JOB="alloc"        GIMLI_PROFILE=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = { version = "1.0", default-features = false }
 fallible-iterator = { version = "0.2.0", default-features = false }
 indexmap = { version = "1.0.2", optional = true }
 smallvec = { version = "0.6.10", default-features = false }
-stable_deref_trait = { version = "1.1.0", default-features = false }
+stable_deref_trait = { version = "1.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 crossbeam = "0.7.1"
@@ -37,12 +37,23 @@ typed-arena = "1"
 target-lexicon = "0.8"
 
 [features]
-read = []
+read = ["stable_deref_trait"]
 write = ["std", "indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
-alloc = ["fallible-iterator/alloc", "stable_deref_trait/alloc"]
 default = ["read", "write", "std"]
 
 [profile.bench]
 debug = true
 codegen-units = 1
+
+[[example]]
+name = "simple"
+required-features = ["read"]
+
+[[example]]
+name = "dwarfdump"
+required-features = ["read", "std"]
+
+[[example]]
+name = "dwarf-validate"
+required-features = ["read", "std"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add this to your `Cargo.toml`:
 gimli = "0.19.0"
 ```
 
-The minimum supported Rust version is 1.32.0.
+The minimum supported Rust version is 1.36.0.
 
 ## Documentation
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,16 +3,11 @@
 set -ex
 
 case "$GIMLI_JOB" in
-    "build")
-        cargo build $GIMLI_PROFILE
-        cargo build --release $GIMLI_PROFILE
-        ;;
-
     "test")
-        cargo build $GIMLI_PROFILE
-        cargo test $GIMLI_PROFILE
-        cargo build --release $GIMLI_PROFILE
-        cargo test --release $GIMLI_PROFILE
+        cargo build
+        cargo test
+        cargo build --release
+        cargo test --release
         case "$TRAVIS_OS_NAME" in
             "osx")
                 with_debug_info=$(find ./target/debug -type f | grep DWARF | grep gimli | head -n 1)
@@ -28,14 +23,15 @@ case "$GIMLI_JOB" in
         cargo run --release --example dwarfdump -- "$with_debug_info" > /dev/null
         ;;
 
-    "doc")
-        cargo doc
+    "features")
+        cargo test --no-default-features
+        cargo test --no-default-features --features read
+        cargo test --no-default-features --features read,std
+        cargo test --no-default-features --features write
         ;;
 
-    "alloc")
-        test "$TRAVIS_RUST_VERSION" == "nightly"
-        cargo build           --no-default-features --features read,alloc $GIMLI_PROFILE
-        cargo build --release --no-default-features --features read,alloc $GIMLI_PROFILE
+    "doc")
+        cargo doc
         ;;
 
     "bench")
@@ -50,7 +46,7 @@ case "$GIMLI_JOB" in
     "cross")
         rustup target add $TARGET
         cargo install cross --force
-        cross test --target $TARGET $GIMLI_PROFILE
+        cross test --target $TARGET
         ;;
 
     *)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -25,7 +25,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(missing_docs)]
 
-use std::fmt;
+use core::fmt;
 
 // The `dw!` macro turns this:
 //

--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -2,7 +2,7 @@
 
 use byteorder;
 use byteorder::ByteOrder;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// A trait describing the endianity of some buffer.
 pub trait Endianity: Debug + Default + Clone + Copy + PartialEq + Eq {

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -7,6 +7,7 @@
 //! Read and write signed integers:
 //!
 //! ```
+//! # #[cfg(all(feature = "read", feature = "write"))] {
 //! use gimli::{EndianSlice, NativeEndian, leb128};
 //!
 //! let mut buf = [0; 1024];
@@ -21,11 +22,13 @@
 //! let mut readable = EndianSlice::new(&buf[..], NativeEndian);
 //! let val = leb128::read::signed(&mut readable).expect("Should read number");
 //! assert_eq!(val, -12345);
+//! # }
 //! ```
 //!
 //! Or read and write unsigned integers:
 //!
 //! ```
+//! # #[cfg(all(feature = "read", feature = "write"))] {
 //! use gimli::{EndianSlice, NativeEndian, leb128};
 //!
 //! let mut buf = [0; 1024];
@@ -38,9 +41,8 @@
 //! let mut readable = EndianSlice::new(&buf[..], NativeEndian);
 //! let val = leb128::read::unsigned(&mut readable).expect("Should read number");
 //! assert_eq!(val, 98765);
+//! # }
 //! ```
-
-use std;
 
 const CONTINUATION_BIT: u8 = 1 << 7;
 const SIGN_BIT: u8 = 1 << 6;
@@ -53,7 +55,7 @@ fn low_bits_of_byte(byte: u8) -> u8 {
 #[inline]
 #[allow(dead_code)]
 fn low_bits_of_u64(val: u64) -> u8 {
-    let byte = val & u64::from(std::u8::MAX);
+    let byte = val & u64::from(core::u8::MAX);
     low_bits_of_byte(byte as u8)
 }
 
@@ -208,12 +210,11 @@ pub mod write {
 }
 
 #[cfg(test)]
+#[cfg(all(feature = "read", feature = "write"))]
 mod tests {
     use super::{low_bits_of_byte, low_bits_of_u64, read, write, CONTINUATION_BIT};
     use crate::endianity::NativeEndian;
     use crate::read::{EndianSlice, Error, ReaderOffsetId};
-    use std;
-    use std::io;
 
     trait ResultExt {
         fn map_eof(self, input: &[u8]) -> Self;
@@ -395,7 +396,7 @@ mod tests {
         let mut buf = [0; 1];
         let mut writable = &mut buf[..];
         match write::unsigned(&mut writable, 128) {
-            Err(e) => assert_eq!(e.kind(), io::ErrorKind::WriteZero),
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::WriteZero),
             otherwise => panic!("Unexpected: {:?}", otherwise),
         }
     }
@@ -405,7 +406,7 @@ mod tests {
         let mut buf = [0; 1];
         let mut writable = &mut buf[..];
         match write::signed(&mut writable, 128) {
-            Err(e) => assert_eq!(e.kind(), io::ErrorKind::WriteZero),
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::WriteZero),
             otherwise => panic!("Unexpected: {:?}", otherwise),
         }
     }
@@ -427,7 +428,7 @@ mod tests {
         for i in -513..513 {
             inner(i);
         }
-        inner(std::i64::MIN);
+        inner(core::i64::MIN);
     }
 
     #[test]
@@ -568,7 +569,7 @@ mod tests {
         .iter()
         {
             let mut readable = EndianSlice::new(buf, NativeEndian);
-            assert!(read::u16(&mut readable).is_err(), format!("{:?}", buf));
+            assert!(read::u16(&mut readable).is_err(), "{:?}", buf);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,10 @@
 //! * `std`: Enabled by default. Use the `std` library. Disabling this feature
 //! allows using `gimli` in embedded environments that do not have access to
 //! `std`. Note that even when `std` is disabled, `gimli` still requires an
-//! implementation of the `alloc` crate, and you must enable the `nightly`
-//! feature.
+//! implementation of the `alloc` crate.
 //!
-//! * `alloc`: Nightly only. Enables usage of the unstable, nightly-only
-//! `#![feature(alloc)]` Rust feature that allows `gimli` to use boxes and
-//! collection types in a `#[no_std]` environment.
-//!
-//! * `read`: Enabled by default. Enables the `read` module. Requires
-//! either `alloc` or `std` to also be enabled.
+//! * `read`: Enabled by default. Enables the `read` module. Use of `std` is
+//! optional.
 //!
 //! * `write`: Enabled by default. Enables the `write` module. Automatically
 //! enables `std` too.
@@ -40,43 +35,16 @@
 // False positives when block expressions are used inside an assertion.
 #![allow(clippy::panic_params)]
 #![no_std]
-#![cfg_attr(feature = "alloc", feature(alloc))]
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
 
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 
-#[cfg(not(feature = "std"))]
-#[macro_use]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-#[macro_use]
-extern crate core as std;
-
-#[cfg(feature = "std")]
-mod imports {
-    pub use std::borrow;
-    pub use std::boxed;
-    pub use std::collections;
-    pub use std::rc;
-    pub use std::string;
-    pub use std::sync::Arc;
-    pub use std::vec;
-}
-
-#[cfg(not(feature = "std"))]
-mod imports {
-    pub use alloc::borrow;
-    pub use alloc::boxed;
-    pub use alloc::collections;
-    pub use alloc::rc;
-    pub use alloc::string;
-    pub use alloc::sync::Arc;
-    pub use alloc::vec;
-}
-
-use crate::imports::*;
-
+#[cfg(feature = "read")]
 pub use stable_deref_trait::{CloneStableDeref, StableDeref};
 
 mod common;

--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -1,7 +1,7 @@
 //! Functions for parsing DWARF debugging abbreviations.
 
-use crate::collections::btree_map;
-use crate::vec::Vec;
+use alloc::collections::btree_map;
+use alloc::vec::Vec;
 use smallvec::SmallVec;
 
 use crate::common::{DebugAbbrevOffset, SectionId};
@@ -122,7 +122,7 @@ impl Abbreviations {
     /// Returns `Ok` if it is the first abbreviation in the set with its code,
     /// `Err` if the code is a duplicate and there already exists an
     /// abbreviation in the set with the given abbreviation's code.
-    fn insert(&mut self, abbrev: Abbreviation) -> ::std::result::Result<(), ()> {
+    fn insert(&mut self, abbrev: Abbreviation) -> ::core::result::Result<(), ()> {
         let code_usize = abbrev.code as usize;
         if code_usize as u64 == abbrev.code {
             // Optimize for sequential abbreviation codes by storing them
@@ -418,9 +418,9 @@ pub mod tests {
     use crate::endianity::LittleEndian;
     use crate::read::{EndianSlice, Error};
     use crate::test_util::GimliSectionMethods;
-    use smallvec::smallvec;
     #[cfg(target_pointer_width = "32")]
-    use std::u32;
+    use core::u32;
+    use smallvec::smallvec;
     use test_assembler::Section;
 
     pub trait AbbrevSectionMethods {

--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -1,6 +1,6 @@
+use core::cmp::Ordering;
+use core::marker::PhantomData;
 use fallible_iterator::FallibleIterator;
-use std::cmp::Ordering;
-use std::marker::PhantomData;
 
 use crate::common::{DebugInfoOffset, Encoding, SectionId};
 use crate::endianity::Endianity;
@@ -250,7 +250,7 @@ impl<R: Reader> FallibleIterator for ArangeEntryIter<R> {
     type Item = ArangeEntry<R::Offset>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()
     }
 }

--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -1,10 +1,10 @@
-use crate::boxed::Box;
+use alloc::boxed::Box;
 use arrayvec::ArrayVec;
+use core::cmp::{Ord, Ordering};
+use core::fmt::Debug;
+use core::iter::FromIterator;
+use core::mem;
 use fallible_iterator::FallibleIterator;
-use std::cmp::{Ord, Ordering};
-use std::fmt::Debug;
-use std::iter::FromIterator;
-use std::mem;
 
 use crate::common::{DebugFrameOffset, EhFrameOffset, Encoding, Format, Register, SectionId};
 use crate::constants::{self, DwEhPe};
@@ -309,10 +309,10 @@ impl<'a, R: Reader + 'a> EhHdrTable<'a, R> {
     /// # Example
     ///
     /// ```
-    /// # use gimli::{BaseAddresses, EhFrame, ParsedEhFrameHdr, EndianRcSlice, NativeEndian, Error, UnwindSection};
+    /// # use gimli::{BaseAddresses, EhFrame, ParsedEhFrameHdr, EndianSlice, NativeEndian, Error, UnwindSection};
     /// # fn foo() -> Result<(), Error> {
-    /// # let eh_frame: EhFrame<EndianRcSlice<NativeEndian>> = unreachable!();
-    /// # let eh_frame_hdr: ParsedEhFrameHdr<EndianRcSlice<NativeEndian>> = unimplemented!();
+    /// # let eh_frame: EhFrame<EndianSlice<NativeEndian>> = unreachable!();
+    /// # let eh_frame_hdr: ParsedEhFrameHdr<EndianSlice<NativeEndian>> = unimplemented!();
     /// # let addr = 0;
     /// # let bases = unimplemented!();
     /// let table = eh_frame_hdr.table().unwrap();
@@ -986,7 +986,7 @@ where
     type Item = CieOrFde<'bases, Section, R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         CfiEntriesIter::next(self)
     }
 }
@@ -2410,7 +2410,7 @@ impl<R> Eq for RegisterRuleMap<R> where R: Reader + Eq {}
 
 /// An unordered iterator for register rules.
 #[derive(Debug, Clone)]
-pub struct RegisterRuleIter<'iter, R>(::std::slice::Iter<'iter, (Register, RegisterRule<R>)>)
+pub struct RegisterRuleIter<'iter, R>(::core::slice::Iter<'iter, (Register, RegisterRule<R>)>)
 where
     R: Reader;
 
@@ -3165,7 +3165,7 @@ impl<'a, R: Reader> FallibleIterator for CallFrameInstructionIter<'a, R> {
     type Item = CallFrameInstruction<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         CallFrameInstructionIter::next(self)
     }
 }
@@ -3318,10 +3318,10 @@ mod tests {
         EndianSlice, Error, Expression, Pointer, ReaderOffsetId, Result, Section as ReadSection,
     };
     use crate::test_util::GimliSectionMethods;
-    use crate::vec::Vec;
-    use std::marker::PhantomData;
-    use std::mem;
-    use std::u64;
+    use alloc::vec::Vec;
+    use core::marker::PhantomData;
+    use core::mem;
+    use core::u64;
     use test_assembler::{Endian, Label, LabelMaker, LabelOrNum, Section, ToLabelOrNum};
 
     // Ensure each test tries to read the same section kind that it wrote.
@@ -6053,7 +6053,7 @@ mod tests {
     fn test_eh_frame_resolve_cie_offset_underflow() {
         let buf = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         assert_eq!(
-            resolve_cie_offset(&buf, ::std::usize::MAX),
+            resolve_cie_offset(&buf, ::core::usize::MAX),
             Err(Error::OffsetOutOfBounds)
         );
     }
@@ -6646,7 +6646,7 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size_of_unwind_ctx() {
-        use std::mem;
+        use core::mem;
         let size = mem::size_of::<UnwindContext<EndianSlice<NativeEndian>>>();
         let max_size = 5416;
         if size > max_size {
@@ -6657,7 +6657,7 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size_of_register_rule_map() {
-        use std::mem;
+        use core::mem;
         let size = mem::size_of::<RegisterRuleMap<EndianSlice<NativeEndian>>>();
         let max_size = 1040;
         if size > max_size {

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use fallible_iterator::FallibleIterator;
 
 use crate::common::{
@@ -15,7 +16,6 @@ use crate::read::{
     ReaderOffsetId, Result, RngListIter, Section, TypeUnitHeader, TypeUnitHeadersIter, UnitHeader,
     UnitOffset,
 };
-use crate::string::String;
 
 /// All of the commonly used DWARF sections, and other common information.
 #[derive(Debug, Default)]
@@ -64,10 +64,10 @@ impl<T> Dwarf<T> {
     /// The provided callback functions may either directly return a `Reader` instance
     /// (such as `EndianSlice`), or they may return some other type and then convert
     /// that type into a `Reader` using `Dwarf::borrow`.
-    pub fn load<F1, F2, E>(mut section: F1, mut sup: F2) -> std::result::Result<Self, E>
+    pub fn load<F1, F2, E>(mut section: F1, mut sup: F2) -> core::result::Result<Self, E>
     where
-        F1: FnMut(SectionId) -> std::result::Result<T, E>,
-        F2: FnMut(SectionId) -> std::result::Result<T, E>,
+        F1: FnMut(SectionId) -> core::result::Result<T, E>,
+        F2: FnMut(SectionId) -> core::result::Result<T, E>,
     {
         // Section types are inferred.
         let debug_loc = Section::load(&mut section)?;
@@ -742,7 +742,7 @@ impl<R: Reader> FallibleIterator for RangeIter<R> {
     type Error = Error;
 
     #[inline]
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         RangeIter::next(self)
     }
 }

--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -1,14 +1,14 @@
 //! Defining custom `Reader`s quickly.
 
-use crate::borrow::Cow;
-use crate::rc::Rc;
-use crate::string::String;
-use crate::Arc;
+use alloc::borrow::Cow;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::fmt::Debug;
+use core::ops::{Deref, Index, Range, RangeFrom, RangeTo};
+use core::slice;
+use core::str;
 use stable_deref_trait::CloneStableDeref;
-use std::fmt::Debug;
-use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
-use std::slice;
-use std::str;
 
 use crate::endianity::Endianity;
 use crate::read::{Error, Reader, ReaderOffsetId, Result};
@@ -17,11 +17,13 @@ use crate::read::{Error, Reader, ReaderOffsetId, Result};
 /// endianity.
 ///
 /// ```
+/// # #[cfg(feature = "std")] {
 /// use std::rc::Rc;
 ///
 /// let buf = Rc::from(&[1, 2, 3, 4][..]);
 /// let reader = gimli::EndianRcSlice::new(buf, gimli::NativeEndian);
 /// # let _ = reader;
+/// # }
 /// ```
 pub type EndianRcSlice<Endian> = EndianReader<Endian, Rc<[u8]>>;
 
@@ -29,11 +31,13 @@ pub type EndianRcSlice<Endian> = EndianReader<Endian, Rc<[u8]>>;
 /// endianity.
 ///
 /// ```
+/// # #[cfg(feature = "std")] {
 /// use std::sync::Arc;
 ///
 /// let buf = Arc::from(&[1, 2, 3, 4][..]);
 /// let reader = gimli::EndianArcSlice::new(buf, gimli::NativeEndian);
 /// # let _ = reader;
+/// # }
 /// ```
 pub type EndianArcSlice<Endian> = EndianReader<Endian, Arc<[u8]>>;
 
@@ -251,6 +255,7 @@ where
     /// new `EndianReader`.
     ///
     /// ```
+    /// # #[cfg(feature = "std")] {
     /// use gimli::{EndianReader, LittleEndian};
     /// use std::sync::Arc;
     ///
@@ -258,6 +263,7 @@ where
     /// let reader = EndianReader::new(buf.clone(), LittleEndian);
     /// assert_eq!(reader.range(1..3),
     ///            EndianReader::new(&buf[1..3], LittleEndian));
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -274,6 +280,7 @@ where
     /// `EndianReader`.
     ///
     /// ```
+    /// # #[cfg(feature = "std")] {
     /// use gimli::{EndianReader, LittleEndian};
     /// use std::sync::Arc;
     ///
@@ -281,6 +288,7 @@ where
     /// let reader = EndianReader::new(buf.clone(), LittleEndian);
     /// assert_eq!(reader.range_from(2..),
     ///            EndianReader::new(&buf[2..], LittleEndian));
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -296,6 +304,7 @@ where
     /// `EndianReader`.
     ///
     /// ```
+    /// # #[cfg(feature = "std")] {
     /// use gimli::{EndianReader, LittleEndian};
     /// use std::sync::Arc;
     ///
@@ -303,6 +312,7 @@ where
     /// let reader = EndianReader::new(buf.clone(), LittleEndian);
     /// assert_eq!(reader.range_to(..3),
     ///            EndianReader::new(&buf[..3], LittleEndian));
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -1,9 +1,9 @@
 //! Working with byte slices that have an associated endianity.
 
-use crate::borrow::Cow;
-use crate::string::String;
-use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
-use std::str;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use core::ops::{Deref, Index, Range, RangeFrom, RangeTo};
+use core::str;
 
 use crate::endianity::Endianity;
 use crate::read::{Error, Reader, ReaderOffsetId, Result};

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1,6 +1,6 @@
-use crate::vec::Vec;
-use std::fmt;
-use std::result;
+use alloc::vec::Vec;
+use core::fmt;
+use core::result;
 
 use crate::common::{
     DebugLineOffset, DebugLineStrOffset, DebugStrOffset, DebugStrOffsetsIndex, Encoding, Format,
@@ -1886,7 +1886,7 @@ mod tests {
     use crate::endianity::LittleEndian;
     use crate::read::{EndianSlice, Error};
     use crate::test_util::GimliSectionMethods;
-    use std::u8;
+    use core::u8;
     use test_assembler::{Endian, Label, LabelMaker, Section};
 
     #[test]
@@ -2953,7 +2953,6 @@ mod tests {
 
             let header = LineProgramHeader::parse(input, DebugLineOffset(0), 0, None, None)
                 .expect("should parse header ok");
-            println!("{:?}", header);
 
             assert_eq!(header.raw_program_buf().slice(), expected_program);
             assert_eq!(input.slice(), expected_rest);

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -470,7 +470,7 @@ impl<R: Reader> FallibleIterator for RawLocListIter<R> {
     type Item = RawLocListEntry<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         RawLocListIter::next(self)
     }
 }
@@ -582,7 +582,7 @@ impl<R: Reader> FallibleIterator for LocListIter<R> {
     type Item = LocationListEntry<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         LocListIter::next(self)
     }
 }

--- a/src/read/lookup.rs
+++ b/src/read/lookup.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::common::{DebugInfoOffset, Format};
 use crate::read::{parse_debug_info_offset, Error, Reader, ReaderOffset, Result, UnitOffset};

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -160,8 +160,8 @@
 //! # fn main() {}
 //! ```
 
-use std::fmt::{self, Debug};
-use std::result;
+use core::fmt::{self, Debug};
+use core::result;
 #[cfg(feature = "std")]
 use std::{error, io};
 
@@ -383,7 +383,7 @@ pub enum Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> ::core::result::Result<(), fmt::Error> {
         Debug::fmt(self, f)
     }
 }
@@ -565,9 +565,9 @@ pub trait Section<R>: From<R> {
     }
 
     /// Try to load the section using the given loader function.
-    fn load<F, E>(f: F) -> std::result::Result<Self, E>
+    fn load<F, E>(f: F) -> core::result::Result<Self, E>
     where
-        F: FnOnce(SectionId) -> std::result::Result<R, E>,
+        F: FnOnce(SectionId) -> core::result::Result<R, E>,
     {
         f(Self::id()).map(From::from)
     }

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -1,7 +1,7 @@
 //! Functions for parsing and evaluating DWARF expressions.
 
-use crate::vec::Vec;
-use std::mem;
+use alloc::vec::Vec;
+use core::mem;
 
 use crate::common::{DebugAddrIndex, DebugInfoOffset, Encoding, Register};
 use crate::constants;
@@ -1783,6 +1783,8 @@ impl<R: Reader> Evaluation<R> {
 }
 
 #[cfg(test)]
+// Tests require leb128::write.
+#[cfg(feature = "write")]
 mod tests {
     use super::*;
     use crate::common::Format;
@@ -1791,7 +1793,7 @@ mod tests {
     use crate::leb128;
     use crate::read::{EndianSlice, Error, Result, UnitOffset};
     use crate::test_util::GimliSectionMethods;
-    use std::usize;
+    use core::usize;
     use test_assembler::{Endian, Section};
 
     fn encoding4() -> Encoding {

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -136,7 +136,7 @@ impl<R: Reader> FallibleIterator for PubNamesEntryIter<R> {
     type Item = PubNamesEntry<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()
     }
 }

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -136,7 +136,7 @@ impl<R: Reader> FallibleIterator for PubTypesEntryIter<R> {
     type Item = PubTypesEntry<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()
     }
 }

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -1,7 +1,7 @@
-use crate::borrow::Cow;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::ops::{Add, AddAssign, Sub};
+use alloc::borrow::Cow;
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::ops::{Add, AddAssign, Sub};
 
 use crate::common::Format;
 use crate::endianity::Endianity;

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -439,7 +439,7 @@ impl<R: Reader> FallibleIterator for RawRngListIter<R> {
     type Item = RawRngListEntry<R::Offset>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         RawRngListIter::next(self)
     }
 }
@@ -533,7 +533,7 @@ impl<R: Reader> FallibleIterator for RngListIter<R> {
     type Item = Range;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         RngListIter::next(self)
     }
 }

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -1,9 +1,9 @@
 //! Functions for parsing DWARF `.debug_info` and `.debug_types` sections.
 
+use core::cell::Cell;
+use core::ops::{Range, RangeFrom, RangeTo};
+use core::{u16, u8};
 use fallible_iterator::FallibleIterator;
-use std::cell::Cell;
-use std::ops::{Range, RangeFrom, RangeTo};
-use std::{u16, u8};
 
 use crate::common::{
     DebugAbbrevOffset, DebugAddrBase, DebugAddrIndex, DebugInfoOffset, DebugLineOffset,
@@ -225,7 +225,7 @@ impl<R: Reader> FallibleIterator for CompilationUnitHeadersIter<R> {
     type Item = CompilationUnitHeader<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         CompilationUnitHeadersIter::next(self)
     }
 }
@@ -2301,7 +2301,7 @@ impl<'abbrev, 'entry, 'unit, R: Reader> FallibleIterator for AttrsIter<'abbrev, 
     type Item = Attribute<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         AttrsIter::next(self)
     }
 }
@@ -3166,7 +3166,7 @@ impl<R: Reader> FallibleIterator for TypeUnitHeadersIter<R> {
     type Item = TypeUnitHeader<R>;
     type Error = Error;
 
-    fn next(&mut self) -> ::std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         TypeUnitHeadersIter::next(self)
     }
 }
@@ -3412,6 +3412,8 @@ fn parse_type_unit_header<R: Reader>(
 }
 
 #[cfg(test)]
+// Tests require leb128::write.
+#[cfg(feature = "write")]
 mod tests {
     use super::*;
     use crate::constants;
@@ -3423,10 +3425,9 @@ mod tests {
         Abbreviation, AttributeSpecification, DebugAbbrev, EndianSlice, Error, Result,
     };
     use crate::test_util::GimliSectionMethods;
-    use crate::vec::Vec;
+    use alloc::vec::Vec;
+    use core::cell::Cell;
     use smallvec::smallvec;
-    use std;
-    use std::cell::Cell;
     use test_assembler::{Endian, Label, LabelMaker, Section};
 
     // Mixin methods for `Section` to help define binary test data.
@@ -4092,26 +4093,26 @@ mod tests {
         )] = &[
             (AttributeValue::Data1(1), Some(1), Some(1)),
             (
-                AttributeValue::Data1(std::u8::MAX),
+                AttributeValue::Data1(core::u8::MAX),
                 Some(u64::from(std::u8::MAX)),
                 Some(-1),
             ),
             (AttributeValue::Data2(1), Some(1), Some(1)),
             (
-                AttributeValue::Data2(std::u16::MAX),
+                AttributeValue::Data2(core::u16::MAX),
                 Some(u64::from(std::u16::MAX)),
                 Some(-1),
             ),
             (AttributeValue::Data4(1), Some(1), Some(1)),
             (
-                AttributeValue::Data4(std::u32::MAX),
+                AttributeValue::Data4(core::u32::MAX),
                 Some(u64::from(std::u32::MAX)),
                 Some(-1),
             ),
             (AttributeValue::Data8(1), Some(1), Some(1)),
             (
-                AttributeValue::Data8(std::u64::MAX),
-                Some(std::u64::MAX),
+                AttributeValue::Data8(core::u64::MAX),
+                Some(core::u64::MAX),
                 Some(-1),
             ),
             (AttributeValue::Sdata(1), Some(1), Some(1)),
@@ -4178,8 +4179,7 @@ mod tests {
                 assert_eq!(*rest, EndianSlice::new(&buf[len..], Endian::default()));
             }
             otherwise => {
-                println!("Unexpected parse result = {:#?}", otherwise);
-                assert!(false);
+                assert!(false, "Unexpected parse result = {:#?}", otherwise);
             }
         };
     }
@@ -4779,8 +4779,7 @@ mod tests {
                 );
             }
             otherwise => {
-                println!("Unexpected parse result = {:#?}", otherwise);
-                assert!(false);
+                assert!(false, "Unexpected parse result = {:#?}", otherwise);
             }
         }
 
@@ -4797,8 +4796,7 @@ mod tests {
                 );
             }
             otherwise => {
-                println!("Unexpected parse result = {:#?}", otherwise);
-                assert!(false);
+                assert!(false, "Unexpected parse result = {:#?}", otherwise);
             }
         }
 
@@ -4815,8 +4813,7 @@ mod tests {
                 );
             }
             otherwise => {
-                println!("Unexpected parse result = {:#?}", otherwise);
-                assert!(false);
+                assert!(false, "Unexpected parse result = {:#?}", otherwise);
             }
         }
 
@@ -4887,8 +4884,7 @@ mod tests {
                 );
             }
             otherwise => {
-                println!("Unexpected parse result = {:#?}", otherwise);
-                assert!(false);
+                assert!(false, "Unexpected parse result = {:#?}", otherwise);
             }
         }
 
@@ -5500,8 +5496,7 @@ mod tests {
         match cursor {
             Err(Error::OffsetOutOfBounds) => {}
             otherwise => {
-                println!("Unexpected result = {:#?}", otherwise);
-                assert!(false);
+                assert!(false, "Unexpected parse result = {:#?}", otherwise);
             }
         }
     }
@@ -5580,8 +5575,7 @@ mod tests {
             match node {
                 Ok(None) => {}
                 otherwise => {
-                    println!("Unexpected parse result = {:#?}", otherwise);
-                    assert!(false);
+                    assert!(false, "Unexpected parse result = {:#?}", otherwise);
                 }
             }
         }
@@ -5710,7 +5704,7 @@ mod tests {
             match entries.read_abbreviation() {
                 Ok(None) => {}
                 otherwise => {
-                    assert!(false, format!("Unexpected parse result = {:#?}", otherwise));
+                    assert!(false, "Unexpected parse result = {:#?}", otherwise);
                 }
             }
         }

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -1,6 +1,6 @@
 //! Definitions for values used in DWARF expressions.
 
-use std::mem;
+use core::mem;
 
 use crate::constants;
 use crate::read::{AttributeValue, DebuggingInformationEntry, Error, Reader, Result};

--- a/src/write/abbrev.rs
+++ b/src/write/abbrev.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
@@ -106,6 +106,7 @@ define_section!(
 );
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::constants;

--- a/src/write/cfi.rs
+++ b/src/write/cfi.rs
@@ -1,9 +1,7 @@
-use crate::collections::hash_map;
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
-use crate::collections::HashMap;
 use crate::common::{DebugFrameOffset, EhFrameOffset, Encoding, Format, Register, SectionId};
 use crate::constants;
 use crate::write::{Address, BaseId, Error, Expression, Result, Section, Writer};
@@ -586,6 +584,7 @@ pub(crate) mod convert {
     use super::*;
     use crate::read::{self, Reader};
     use crate::write::{ConvertError, ConvertResult};
+    use std::collections::{hash_map, HashMap};
 
     impl FrameTable {
         /// Create a frame table by reading the data in the given section.
@@ -835,6 +834,7 @@ pub(crate) mod convert {
 }
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::arch::X86_64;

--- a/src/write/dwarf.rs
+++ b/src/write/dwarf.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::common::Encoding;
 use crate::write::{

--- a/src/write/endian_vec.rs
+++ b/src/write/endian_vec.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use std::mem;
 
 use crate::endianity::Endianity;

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use indexmap::{IndexMap, IndexSet};
 use std::ops::{Deref, DerefMut};
 
@@ -927,6 +927,8 @@ mod id {
 
         /// The id for file index 0 in DWARF version 5.
         /// Only used when converting.
+        // Used for tests only.
+        #[allow(unused)]
         pub(super) fn zero() -> Self {
             FileId(0)
         }
@@ -1146,6 +1148,7 @@ mod convert {
 }
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::read;

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
@@ -384,6 +384,7 @@ mod convert {
 }
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::common::{

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
@@ -301,6 +301,7 @@ mod convert {
 }
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::common::{

--- a/src/write/str.rs
+++ b/src/write/str.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
@@ -127,6 +127,7 @@ define_offsets!(
 );
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::read;

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1,4 +1,4 @@
-use crate::vec::Vec;
+use alloc::vec::Vec;
 use std::ops::{Deref, DerefMut};
 use std::{slice, usize};
 
@@ -9,9 +9,9 @@ use crate::common::{
 use crate::constants;
 use crate::write::{
     Abbreviation, AbbreviationTable, Address, AttributeSpecification, BaseId, DebugLineStrOffsets,
-    DebugStrOffsets, Error, FileId, LineProgram, LineStringId, LocationList, LocationListId,
-    LocationListOffsets, LocationListTable, RangeList, RangeListId, RangeListOffsets,
-    RangeListTable, Result, Section, Sections, StringId, Writer,
+    DebugStrOffsets, Error, FileId, LineProgram, LineStringId, LocationListId, LocationListOffsets,
+    LocationListTable, RangeListId, RangeListOffsets, RangeListTable, Result, Section, Sections,
+    StringId, Writer,
 };
 
 define_id!(UnitId, "An identifier for a unit in a `UnitTable`.");
@@ -1183,9 +1183,9 @@ impl UnitOffsets {
 #[cfg(feature = "read")]
 pub(crate) mod convert {
     use super::*;
-    use crate::collections::HashMap;
     use crate::read::{self, Reader};
-    use crate::write::{self, ConvertError, ConvertResult};
+    use crate::write::{self, ConvertError, ConvertResult, LocationList, RangeList};
+    use std::collections::HashMap;
 
     pub(crate) struct ConvertUnitContext<'a, R: Reader<Offset = usize>> {
         pub dwarf: &'a read::Dwarf<R>,
@@ -1565,6 +1565,7 @@ pub(crate) mod convert {
 }
 
 #[cfg(test)]
+#[cfg(feature = "read")]
 mod tests {
     use super::*;
     use crate::common::{
@@ -1574,7 +1575,8 @@ mod tests {
     use crate::read;
     use crate::write::{
         DebugLine, DebugLineStr, DebugStr, EndianVec, LineString, LineStringTable, Location,
-        LocationListTable, Range, RangeListOffsets, RangeListTable, StringTable,
+        LocationList, LocationListTable, Range, RangeList, RangeListOffsets, RangeListTable,
+        StringTable,
     };
     use crate::LittleEndian;
     use std::mem;

--- a/tests/convert_self.rs
+++ b/tests/convert_self.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "read", feature = "write"))]
+
 use std::env;
 use std::fs::File;
 use std::io::Read;

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "read", feature = "std"))]
+
 use gimli::{
     AttributeValue, DebugAbbrev, DebugAddr, DebugAddrBase, DebugAranges, DebugInfo, DebugLine,
     DebugLoc, DebugLocLists, DebugPubNames, DebugPubTypes, DebugRanges, DebugRngLists, DebugStr,


### PR DESCRIPTION
gimli can't do anything useful without allocating, and the alloc crate
is now stable, so having a separate alloc feature is not required.
Instead, you should simply disable all features.

Also fix `cargo test` with features disabled.