### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/examples/dwarf-validate.rs
+++ b/examples/dwarf-validate.rs
@@ -6,7 +6,6 @@ use object::Object;
 use rayon::prelude::*;
 use std::borrow::{Borrow, Cow};
 use std::env;
-use std::error;
 use std::fs;
 use std::io::{self, BufWriter, Write};
 use std::iter::Iterator;
@@ -48,11 +47,7 @@ fn main() {
         let file = match fs::File::open(&path) {
             Ok(file) => file,
             Err(err) => {
-                eprintln!(
-                    "Failed to open file '{}': {}",
-                    path.display(),
-                    error::Error::description(&err)
-                );
+                eprintln!("Failed to open file '{}': {}", path.display(), err);
                 errors += 1;
                 continue;
             }
@@ -150,8 +145,7 @@ fn validate_info<W, R>(
             Err(err) => {
                 w.error(format!(
                     "Can't read unit header at offset {:#x}, stopping reading units: {}",
-                    last_offset,
-                    error::Error::description(&err)
+                    last_offset, err
                 ));
                 break;
             }
@@ -174,7 +168,7 @@ fn validate_info<W, R>(
                 w.error(format!(
                     "Invalid abbrevs for unit {:#x}: {}",
                     unit.offset().0,
-                    error::Error::description(&err)
+                    &err
                 ));
                 return ret;
             }
@@ -187,7 +181,7 @@ fn validate_info<W, R>(
                     w.error(format!(
                         "Invalid DIE for unit {:#x}: {}",
                         unit.offset().0,
-                        error::Error::description(&err)
+                        &err
                     ));
                     return ret;
                 }
@@ -204,7 +198,7 @@ fn validate_info<W, R>(
                             "Invalid attribute for unit {:#x} at DIE {:#x}: {}",
                             unit.offset().0,
                             entry.offset().0,
-                            error::Error::description(&err)
+                            &err
                         ));
                         return ret;
                     }

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -459,7 +459,7 @@ impl<R: Reader> Dwarf<R> {
                 Some((sup, section, offset)) => {
                     return format!(
                         "{} at {}{}+0x{:x}",
-                        err.description(),
+                        err,
                         section.name(),
                         if sup { "(sup)" } else { "" },
                         offset.into_u64(),

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -384,7 +384,7 @@ pub enum Error {
 impl fmt::Display for Error {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> ::core::result::Result<(), fmt::Error> {
-        Debug::fmt(self, f)
+        write!(f, "{}", self.description())
     }
 }
 
@@ -527,11 +527,7 @@ impl Error {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        Error::description(self)
-    }
-}
+impl error::Error for Error {}
 
 #[cfg(feature = "std")]
 impl From<io::Error> for Error {


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes the implementation of `description` in error type

Related PR: https://github.com/rust-lang/rust/pull/66919