### PR TITLE
Remove dependency on `byteorder`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ coveralls = { repository = "gimli-rs/gimli" }
 
 [dependencies]
 arrayvec = { version = "0.5.0", default-features = false, optional = true }
-byteorder = { version = "1.0", default-features = false }
 fallible-iterator = { version = "0.2.0", default-features = false, optional = true }
 indexmap = { version = "1.0.2", optional = true }
 smallvec = { version = "1.1.0", default-features = false, optional = true }


### PR DESCRIPTION
This commit remove `gimli`'s dependency on the `byteorder` crate. While
this crate is quite small and general not expensive as a dependency, I'm
curious to eventually enable the `gimli-symbolize` feature of the
`backtrace` crate in the standard library. The standard library has
odd technical restrictions about what crates can be used in the standard
library, namely that nonstandard `Cargo.toml` configuration is required
to get the build working correctly. In order to inflict this oddness on
as few crates as possible, and to minimize the amount of auditing the
standard library needs to do, I'm hoping to remove most dependencies
from the `gimli-symbolize` dependency tree of the `backtrace` crate.

The usage of `byteorder` in `gimli` was quite light and pretty easy to
remove, especially now that `{to,from}_{le,be}_bytes` methods have been
stable on integers from the standard library for some time now!