### PR TITLE
Remove `read` feature's dependency on `fallible-iterator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ test-assembler = "0.1.3"
 typed-arena = "2"
 
 [features]
-read = ["arrayvec", "fallible-iterator", "smallvec", "stable_deref_trait"]
+read = ["arrayvec", "smallvec", "stable_deref_trait"]
 write = ["indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
-default = ["read", "write", "std"]
+default = ["read", "write", "std", "fallible-iterator"]
 
 [profile.bench]
 debug = true

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -26,6 +26,7 @@ case "$GIMLI_JOB" in
     "features")
         cargo test --no-default-features
         cargo test --no-default-features --features read
+        cargo test --no-default-features --features read,fallible-iterator
         cargo test --no-default-features --features read,std
         cargo test --no-default-features --features write
         ;;

--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -1,6 +1,5 @@
 use core::cmp::Ordering;
 use core::marker::PhantomData;
-use fallible_iterator::FallibleIterator;
 
 use crate::common::{DebugInfoOffset, Encoding, SectionId};
 use crate::endianity::Endianity;
@@ -246,7 +245,8 @@ impl<R: Reader> ArangeEntryIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for ArangeEntryIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for ArangeEntryIter<R> {
     type Item = ArangeEntry<R::Offset>;
     type Error = Error;
 

--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -4,7 +4,6 @@ use core::cmp::{Ord, Ordering};
 use core::fmt::Debug;
 use core::iter::FromIterator;
 use core::mem;
-use fallible_iterator::FallibleIterator;
 
 use crate::common::{DebugFrameOffset, EhFrameOffset, Encoding, Format, Register, SectionId};
 use crate::constants::{self, DwEhPe};
@@ -936,7 +935,8 @@ where
     }
 }
 
-impl<'bases, Section, R> FallibleIterator for CfiEntriesIter<'bases, Section, R>
+#[cfg(feature = "fallible-iterator")]
+impl<'bases, Section, R> fallible_iterator::FallibleIterator for CfiEntriesIter<'bases, Section, R>
 where
     R: Reader,
     Section: UnwindSection<R>,
@@ -3146,7 +3146,8 @@ impl<'a, R: Reader> CallFrameInstructionIter<'a, R> {
     }
 }
 
-impl<'a, R: Reader> FallibleIterator for CallFrameInstructionIter<'a, R> {
+#[cfg(feature = "fallible-iterator")]
+impl<'a, R: Reader> fallible_iterator::FallibleIterator for CallFrameInstructionIter<'a, R> {
     type Item = CallFrameInstruction<R>;
     type Error = Error;
 

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1,5 +1,4 @@
 use alloc::string::String;
-use fallible_iterator::FallibleIterator;
 
 use crate::common::{
     DebugAddrBase, DebugAddrIndex, DebugInfoOffset, DebugLineStrOffset, DebugLocListsBase,
@@ -744,7 +743,8 @@ impl<R: Reader> RangeIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for RangeIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for RangeIter<R> {
     type Item = Range;
     type Error = Error;
 

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -1,5 +1,3 @@
-use fallible_iterator::FallibleIterator;
-
 use crate::common::{
     DebugAddrBase, DebugAddrIndex, DebugLocListsBase, DebugLocListsIndex, Encoding, Format,
     LocationListsOffset, SectionId,
@@ -466,7 +464,8 @@ impl<R: Reader> RawLocListIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for RawLocListIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for RawLocListIter<R> {
     type Item = RawLocListEntry<R>;
     type Error = Error;
 
@@ -578,7 +577,8 @@ impl<R: Reader> LocListIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for LocListIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for LocListIter<R> {
     type Item = LocationListEntry<R>;
     type Error = Error;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -142,6 +142,8 @@
 //! into your code:
 //!
 //! ```
+//! # #[cfg(feature = "fallible-iterator")]
+//! # fn foo() {
 //! // Use the `FallibleIterator` trait so its methods are in scope!
 //! use fallible_iterator::FallibleIterator;
 //! use gimli::{DebugAranges, EndianSlice, LittleEndian};
@@ -156,7 +158,7 @@
 //!         // `fold` is provided by `FallibleIterator`!
 //!         .fold(0, |sum, len| Ok(sum + len))
 //! }
-//!
+//! # }
 //! # fn main() {}
 //! ```
 

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -1,9 +1,7 @@
-use fallible_iterator::FallibleIterator;
-
 use crate::common::{DebugInfoOffset, SectionId};
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugLookup, LookupEntryIter, PubStuffEntry, PubStuffParser};
-use crate::read::{EndianSlice, Error, Reader, Result, Section, UnitOffset};
+use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
 
 /// A single parsed pubname.
 #[derive(Debug, Clone)]
@@ -132,9 +130,10 @@ impl<R: Reader> PubNamesEntryIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for PubNamesEntryIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for PubNamesEntryIter<R> {
     type Item = PubNamesEntry<R>;
-    type Error = Error;
+    type Error = crate::read::Error;
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -1,9 +1,7 @@
-use fallible_iterator::FallibleIterator;
-
 use crate::common::{DebugInfoOffset, SectionId};
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugLookup, LookupEntryIter, PubStuffEntry, PubStuffParser};
-use crate::read::{EndianSlice, Error, Reader, Result, Section, UnitOffset};
+use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
 
 /// A single parsed pubtype.
 #[derive(Debug, Clone)]
@@ -132,9 +130,10 @@ impl<R: Reader> PubTypesEntryIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for PubTypesEntryIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for PubTypesEntryIter<R> {
     type Item = PubTypesEntry<R>;
-    type Error = Error;
+    type Error = crate::read::Error;
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -1,5 +1,3 @@
-use fallible_iterator::FallibleIterator;
-
 use crate::common::{
     DebugAddrBase, DebugAddrIndex, DebugRngListsBase, DebugRngListsIndex, Encoding, Format,
     RangeListsOffset, SectionId,
@@ -435,7 +433,8 @@ impl<R: Reader> RawRngListIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for RawRngListIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for RawRngListIter<R> {
     type Item = RawRngListEntry<R::Offset>;
     type Error = Error;
 
@@ -529,7 +528,8 @@ impl<R: Reader> RngListIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for RngListIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for RngListIter<R> {
     type Item = Range;
     type Error = Error;
 

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -3,7 +3,6 @@
 use core::cell::Cell;
 use core::ops::{Range, RangeFrom, RangeTo};
 use core::{u16, u8};
-use fallible_iterator::FallibleIterator;
 
 use crate::common::{
     DebugAbbrevOffset, DebugAddrBase, DebugAddrIndex, DebugInfoOffset, DebugLineOffset,
@@ -221,7 +220,8 @@ impl<R: Reader> CompilationUnitHeadersIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for CompilationUnitHeadersIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for CompilationUnitHeadersIter<R> {
     type Item = CompilationUnitHeader<R>;
     type Error = Error;
 
@@ -2317,7 +2317,10 @@ impl<'abbrev, 'entry, 'unit, R: Reader> AttrsIter<'abbrev, 'entry, 'unit, R> {
     }
 }
 
-impl<'abbrev, 'entry, 'unit, R: Reader> FallibleIterator for AttrsIter<'abbrev, 'entry, 'unit, R> {
+#[cfg(feature = "fallible-iterator")]
+impl<'abbrev, 'entry, 'unit, R: Reader> fallible_iterator::FallibleIterator
+    for AttrsIter<'abbrev, 'entry, 'unit, R>
+{
     type Item = Attribute<R>;
     type Error = Error;
 
@@ -3182,7 +3185,8 @@ impl<R: Reader> TypeUnitHeadersIter<R> {
     }
 }
 
-impl<R: Reader> FallibleIterator for TypeUnitHeadersIter<R> {
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for TypeUnitHeadersIter<R> {
     type Item = TypeUnitHeader<R>;
     type Error = Error;
 


### PR DESCRIPTION
This is similarly motivated as #494, where the `backtrace` crate will
transitively use the `read` feature of `gimli`, so this is intended to
prune the dependencies of that dependency tree. This makes the
`fallible-iterator` feature optional even when the `read` feature is
activated.