### PR TITLE
Remove smallvec dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ coveralls = { repository = "gimli-rs/gimli" }
 [dependencies]
 fallible-iterator = { version = "0.2.0", default-features = false, optional = true }
 indexmap = { version = "1.0.2", optional = true }
-smallvec = { version = "1.1.0", default-features = false, optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -34,7 +33,7 @@ test-assembler = "0.1.3"
 typed-arena = "2"
 
 [features]
-read = ["smallvec", "stable_deref_trait"]
+read = ["stable_deref_trait"]
 write = ["indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
 default = ["read", "write", "std", "fallible-iterator"]

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -3451,7 +3451,6 @@ mod tests {
     use crate::test_util::GimliSectionMethods;
     use alloc::vec::Vec;
     use core::cell::Cell;
-    use smallvec::smallvec;
     use test_assembler::{Endian, Label, LabelMaker, Section};
 
     // Mixin methods for `Section` to help define binary test data.
@@ -4770,7 +4769,7 @@ mod tests {
             42,
             constants::DW_TAG_subprogram,
             constants::DW_CHILDREN_yes,
-            smallvec![
+            vec![
                 AttributeSpecification::new(constants::DW_AT_name, constants::DW_FORM_string, None),
                 AttributeSpecification::new(constants::DW_AT_low_pc, constants::DW_FORM_addr, None),
                 AttributeSpecification::new(
@@ -4778,7 +4777,8 @@ mod tests {
                     constants::DW_FORM_addr,
                     None,
                 ),
-            ],
+            ]
+            .into(),
         );
 
         // "foo", 42, 1337, 4 dangling bytes of 0xaa where children would be
@@ -4878,7 +4878,7 @@ mod tests {
             42,
             constants::DW_TAG_subprogram,
             constants::DW_CHILDREN_yes,
-            smallvec![
+            vec![
                 AttributeSpecification::new(constants::DW_AT_name, constants::DW_FORM_string, None),
                 AttributeSpecification::new(constants::DW_AT_low_pc, constants::DW_FORM_addr, None),
                 AttributeSpecification::new(
@@ -4886,7 +4886,8 @@ mod tests {
                     constants::DW_FORM_addr,
                     None,
                 ),
-            ],
+            ]
+            .into(),
         );
 
         // "foo"

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -912,7 +912,6 @@ mod tests {
         Abbreviation, AttributeSpecification, DebuggingInformationEntry, EndianSlice, UnitHeader,
         UnitOffset,
     };
-    use smallvec::smallvec;
 
     #[test]
     #[rustfmt::skip]
@@ -933,7 +932,7 @@ mod tests {
             42,
             constants::DW_TAG_base_type,
             constants::DW_CHILDREN_no,
-            smallvec![
+            vec![
                 AttributeSpecification::new(
                     constants::DW_AT_byte_size,
                     constants::DW_FORM_udata,
@@ -949,7 +948,7 @@ mod tests {
                     constants::DW_FORM_udata,
                     None,
                 ),
-            ],
+            ].into(),
         );
 
         for &(attrs, result) in &[


### PR DESCRIPTION
This commit removes `smallvec` as a dependency of the `read` feature of
this crate. This is an extension of #494 to help make `gimli` easier to
include into the standard library. The `smallvec` crate was only used in
one location inside of `gimli`, in `Abbreviation` parsing. This was
converted to a manual inline small-vector along with a new type
`Attributes` to wrap this up. This also removes `smallvec` from the
public API of `gimli` to allow future changes to the representation if
necessary.