### PR TITLE
Remove the `arrayvec` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "gimli-rs/gimli" }
 coveralls = { repository = "gimli-rs/gimli" }
 
 [dependencies]
-arrayvec = { version = "0.5.0", default-features = false, optional = true }
 fallible-iterator = { version = "0.2.0", default-features = false, optional = true }
 indexmap = { version = "1.0.2", optional = true }
 smallvec = { version = "1.1.0", default-features = false, optional = true }
@@ -35,7 +34,7 @@ test-assembler = "0.1.3"
 typed-arena = "2"
 
 [features]
-read = ["arrayvec", "smallvec", "stable_deref_trait"]
+read = ["smallvec", "stable_deref_trait"]
 write = ["indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
 default = ["read", "write", "std", "fallible-iterator"]


### PR DESCRIPTION
This commit removes the `arrayvec` dependency from `gimli` to continue
the work started in #494. The goal here is to absolutely minimize the
number of dependencies (ideally zero) when using only the bare bones of
the crate.