### PR TITLE
Remove dependency of `read` on `stable_deref_trait`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,11 @@ test-assembler = "0.1.3"
 typed-arena = "2"
 
 [features]
-read = ["stable_deref_trait"]
+read = []
+endian-reader = ["stable_deref_trait"]
 write = ["indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
-default = ["read", "write", "std", "fallible-iterator"]
+default = ["read", "write", "std", "fallible-iterator", "endian-reader"]
 
 [profile.bench]
 debug = true

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -28,6 +28,8 @@ case "$GIMLI_JOB" in
         cargo test --no-default-features --features read
         cargo test --no-default-features --features read,fallible-iterator
         cargo test --no-default-features --features read,std
+        cargo test --no-default-features --features read,endian-reader
+        cargo test --no-default-features --features read,endian-reader,std
         cargo test --no-default-features --features write
         ;;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-#[cfg(feature = "read")]
+#[cfg(feature = "stable_deref_trait")]
 pub use stable_deref_trait::{CloneStableDeref, StableDeref};
 
 mod common;

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -182,7 +182,9 @@ pub use self::dwarf::*;
 mod endian_slice;
 pub use self::endian_slice::*;
 
+#[cfg(feature = "endian-reader")]
 mod endian_reader;
+#[cfg(feature = "endian-reader")]
 pub use self::endian_reader::*;
 
 mod reader;

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "read", feature = "std"))]
+#![cfg(all(feature = "read", feature = "std", feature = "endian-reader"))]
 
 use gimli::{
     AttributeValue, DebugAbbrev, DebugAddr, DebugAddrBase, DebugAranges, DebugInfo, DebugLine,


### PR DESCRIPTION
This commit adds a new feature to this crate, enabled by default, called
`endian-reader`. The goal here is to remove the need for the `backtrace`
crate to depend on `stable_deref_trait`, and it looks like currently
`addr2line` and friends don't need the only usage of
`stable_deref_trait`, which is the `EndianReader` type.

Another possible solution might be to break up the `read` feature, too,
and have `addr2line` only enable a small subset of the `read` feature
that it actually needs.