### PR TITLE
read: handle combination of DW_FORM_indirect and DW_FORM_implicit_const

### DIFF
--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -410,9 +410,12 @@ impl AttributeSpecification {
 
     /// Get the attribute's implicit const value.
     #[inline]
-    pub fn implicit_const_value(&self) -> i64 {
-        assert!(self.form == constants::DW_FORM_implicit_const);
-        self.implicit_const_value
+    pub fn implicit_const_value(&self) -> Option<i64> {
+        if self.form == constants::DW_FORM_implicit_const {
+            Some(self.implicit_const_value)
+        } else {
+            None
+        }
     }
 
     /// Return the size of the attribute, in bytes.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -383,6 +383,8 @@ pub enum Error {
     MissingFileEntryFormatPath,
     /// Expected an attribute value to be a string form.
     ExpectedStringAttributeValue,
+    /// `DW_FORM_implicit_const` used in an invalid context.
+    InvalidImplicitConst,
 }
 
 impl fmt::Display for Error {
@@ -526,6 +528,7 @@ impl Error {
             Error::ExpectedStringAttributeValue => {
                 "Expected an attribute value to be a string form."
             }
+            Error::InvalidImplicitConst => "DW_FORM_implicit_const used in an invalid context.",
         }
     }
 }


### PR DESCRIPTION
The standard specifies that DW_FORM_indirect only has a single ULEB128,
which means it can't also contain the implicit constant. It also
doesn't make sense to want to combine these.

Fixes #501 