### PR TITLE
Prepare for inclusion into libstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ fallible-iterator = { version = "0.2.0", default-features = false, optional = tr
 indexmap = { version = "1.0.2", optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false, optional = true }
 
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
+compiler_builtins = { version = '0.1.2', optional = true }
+
 [dev-dependencies]
 crossbeam = "0.7.1"
 getopts = "0.2"
@@ -38,6 +44,10 @@ endian-reader = ["stable_deref_trait"]
 write = ["indexmap"]
 std = ["fallible-iterator/std", "stable_deref_trait/std"]
 default = ["read", "write", "std", "fallible-iterator", "endian-reader"]
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins']
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
This commit adds the "standard preamble" in `Cargo.toml` which makes
this crate suitable for being used as a dependency of the standard
library. The intention here is that this is a "fire and forget" snippet
added to `Cargo.toml` where it doesn't really impact anything else in
this crate. It's unlikely to be used too too soon for libstd, but I
figure it wouldn't be bad to get ready!

(also see https://github.com/rust-lang/backtrace-rs/issues/328 for some context)