### PR TITLE
read: Make `Abbreviations::get` take a `NonZeroU64`

### DIFF
--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -1,6 +1,7 @@
 //! Functions for parsing DWARF `.debug_info` and `.debug_types` sections.
 
 use core::cell::Cell;
+use core::num::NonZeroU64;
 use core::ops::{Range, RangeFrom, RangeTo};
 use core::{u16, u8};
 
@@ -1001,6 +1002,7 @@ where
         if code == 0 {
             return Ok(None);
         };
+        let code = NonZeroU64::new(code).unwrap();
         let abbrev = abbreviations.get(code).ok_or(Error::UnknownAbbreviation)?;
         Ok(Some(DebuggingInformationEntry {
             offset: UnitOffset(offset),
@@ -2433,6 +2435,7 @@ impl<'abbrev, 'unit, R: Reader> EntriesRaw<'abbrev, 'unit, R> {
             self.depth -= 1;
             return Ok(None);
         };
+        let code = NonZeroU64::new(code).unwrap();
         let abbrev = self
             .abbreviations
             .get(code)

--- a/src/write/abbrev.rs
+++ b/src/write/abbrev.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::num::NonZeroU64;
 use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
@@ -18,10 +19,10 @@ pub(crate) struct AbbreviationTable {
 
 impl AbbreviationTable {
     /// Add an abbreviation to the table and return its code.
-    pub fn add(&mut self, abbrev: Abbreviation) -> u64 {
+    pub fn add(&mut self, abbrev: Abbreviation) -> NonZeroU64 {
         let (code, _) = self.abbrevs.insert_full(abbrev);
         // Code must be non-zero
-        (code + 1) as u64
+        NonZeroU64::new((code + 1) as u64).unwrap()
     }
 
     /// Write the abbreviation table to the `.debug_abbrev` section.
@@ -134,9 +135,9 @@ mod tests {
             ],
         );
         let code1 = abbrevs.add(abbrev1.clone());
-        assert_eq!(code1, 1);
+        assert_eq!(code1.get(), 1);
         let code2 = abbrevs.add(abbrev2.clone());
-        assert_eq!(code2, 2);
+        assert_eq!(code2.get(), 2);
         assert_eq!(abbrevs.add(abbrev1.clone()), code1);
         assert_eq!(abbrevs.add(abbrev2.clone()), code2);
 

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -576,7 +576,8 @@ impl DebuggingInformationEntry {
         abbrevs: &mut AbbreviationTable,
     ) -> Result<()> {
         offsets.entries[self.id.index].offset = DebugInfoOffset(*offset);
-        offsets.entries[self.id.index].abbrev = abbrevs.add(self.abbreviation(unit.encoding())?);
+        offsets.entries[self.id.index].abbrev =
+            abbrevs.add(self.abbreviation(unit.encoding())?).get();
         *offset += self.size(unit, offsets);
         if !self.children.is_empty() {
             for child in &self.children {


### PR DESCRIPTION
This fixes a subtraction overflow when `Abbreviations::get` is called with zero now.

Alternative fix to #505; @philipc do you have a preference between these two patches?