### PR TITLE
Don't fail if unable to read the string for DW_AT_comp_dir or DW_AT_name

### DIFF
--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -608,11 +608,11 @@ impl<R: Reader> Unit<R> {
         }
 
         unit.name = match name {
-            Some(val) => Some(dwarf.attr_string(&unit, val)?),
+            Some(val) => dwarf.attr_string(&unit, val).ok(),
             None => None,
         };
         unit.comp_dir = match comp_dir {
-            Some(val) => Some(dwarf.attr_string(&unit, val)?),
+            Some(val) => dwarf.attr_string(&unit, val).ok(),
             None => None,
         };
         unit.line_program = match line_program_offset {


### PR DESCRIPTION
This matches the behaviour of llvm-dwarfdump:
e.g. dwarf::toString(UnitDie.find(DW_AT_comp_dir)) just returns an
Optional and doesn't fail.

Fixes #514