### PR TITLE
Support skeleton and split compilation units

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -932,6 +932,10 @@ where
             UnitType::Type {
                 type_signature,
                 type_offset,
+            }
+            | UnitType::SplitType {
+                type_signature,
+                type_offset,
             } => {
                 write!(buf, "  signature        = ")?;
                 dump_type_signature(buf, type_signature)?;

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -927,6 +927,23 @@ where
             header.offset().as_debug_info_offset().unwrap().0,
         )?;
 
+        match header.type_() {
+            UnitType::Compilation | UnitType::Partial => (),
+            UnitType::Type {
+                type_signature,
+                type_offset,
+            } => {
+                write!(buf, "  signature        = ")?;
+                dump_type_signature(buf, type_signature)?;
+                writeln!(buf)?;
+                writeln!(buf, "  typeoffset       = 0x{:08x}", type_offset.0,)?;
+            }
+            UnitType::Skeleton(dwo_id) | UnitType::SplitCompilation(dwo_id) => {
+                write!(buf, "  dwo_id           = ")?;
+                writeln!(buf, "0x{:016x}", dwo_id.0)?;
+            }
+        }
+
         let unit = match dwarf.unit(header) {
             Ok(unit) => unit,
             Err(err) => {
@@ -1292,6 +1309,9 @@ fn dump_attr_value<R: Reader, W: Write>(
             write!(w, "0x{:08x}", value)?;
             dump_file_index(w, value, unit, dwarf)?;
             writeln!(w)?;
+        }
+        gimli::AttributeValue::DwoId(value) => {
+            writeln!(w, "0x{:016x}", value.0)?;
         }
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -314,3 +314,8 @@ impl SectionId {
         })
     }
 }
+
+/// An optionally-provided implementation-defined compilation unit ID to enable
+/// split DWARF and linking a split compilation unit back together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DwoId(pub u64);

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -356,6 +356,8 @@ mod convert {
         UnsupportedOperation,
         /// Operation branch target is invalid.
         InvalidBranchTarget,
+        /// Writing this unit type is not supported yet.
+        UnsupportedUnitType,
     }
 
     impl fmt::Display for ConvertError {
@@ -403,6 +405,7 @@ mod convert {
                     "Writing this expression operation is not implemented yet."
                 ),
                 InvalidBranchTarget => write!(f, "Operation branch target is invalid."),
+                UnsupportedUnitType => write!(f, "Writing this unit type is not supported yet."),
             }
         }
     }

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -4,7 +4,7 @@ use std::{slice, usize};
 
 use crate::common::{
     DebugAbbrevOffset, DebugInfoOffset, DebugLineOffset, DebugMacinfoOffset, DebugMacroOffset,
-    DebugStrOffset, DebugTypeSignature, Encoding, Format, SectionId,
+    DebugStrOffset, DebugTypeSignature, DwoId, Encoding, Format, SectionId,
 };
 use crate::constants;
 use crate::leb128::write::{sleb128_size, uleb128_size};
@@ -1900,6 +1900,7 @@ pub(crate) mod convert {
                 read::AttributeValue::SecOffset(_) => {
                     return Err(ConvertError::InvalidAttributeValue);
                 }
+                read::AttributeValue::DwoId(DwoId(val)) => AttributeValue::Udata(val),
             };
             Ok(Some(to))
         }

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1560,6 +1560,10 @@ pub(crate) mod convert {
             entry_ids: &mut HashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
             dwarf: &read::Dwarf<R>,
         ) -> ConvertResult<ConvertUnit<R>> {
+            match from_header.type_() {
+                read::UnitType::Compilation => (),
+                _ => return Err(ConvertError::UnsupportedUnitType),
+            }
             let base_id = BaseId::default();
 
             let from_unit = dwarf.unit(from_header)?;


### PR DESCRIPTION
The gist of this is that in DWARF 5 the DWO id for skeleton/split units lives in the header rather than as an attribute on the CU, so it needs to be parsed and saved somewhere.  I chose not to revisit the decision to have a separate `CompilationUnitHeader` and `TypeUnitHeader`, and instead replaced `UnitHeader` with a trait that they both implement. What was previously `UnitHeader` is now `CommonUnitHeader` and used in many fewer places. Finally, `CompilationUnitHeader` grew a `CompilationUnitType` field that tells us whether we have a conventional, skeleton, or split unit (and what the DWO id is in the latter cases).