### PR TITLE
More split dwarf work

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -550,7 +550,10 @@ where
         reader: Default::default(),
     };
 
-    let dwarf = gimli::Dwarf::load(&mut load_section, |_| Ok(no_reader.clone())).unwrap();
+    let mut dwarf = gimli::Dwarf::load(&mut load_section, |_| Ok(no_reader.clone())).unwrap();
+    if flags.dwo {
+        dwarf.file_type = gimli::DwarfFileType::Dwo;
+    }
 
     let out = io::stdout();
     if flags.eh_frame {

--- a/src/common.rs
+++ b/src/common.rs
@@ -311,6 +311,7 @@ impl SectionId {
             SectionId::DebugLoc => ".debug_loc.dwo",
             SectionId::DebugLocLists => ".debug_loclists.dwo",
             SectionId::DebugMacro => ".debug_macro.dwo",
+            SectionId::DebugRngLists => ".debug_rnglists.dwo",
             SectionId::DebugStr => ".debug_str.dwo",
             SectionId::DebugStrOffsets => ".debug_str_offsets.dwo",
             _ => return None,

--- a/src/common.rs
+++ b/src/common.rs
@@ -323,3 +323,20 @@ impl SectionId {
 /// split DWARF and linking a split compilation unit back together.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DwoId(pub u64);
+
+/// The "type" of file with DWARF debugging information. This determines, among other things,
+/// which files DWARF sections should be loaded from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DwarfFileType {
+    /// A normal executable or object file.
+    Main,
+    /// A .dwo split DWARF file.
+    Dwo,
+    // TODO: Supplementary files, .dwps?
+}
+
+impl Default for DwarfFileType {
+    fn default() -> Self {
+        DwarfFileType::Main
+    }
+}

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -381,13 +381,22 @@ impl<R: Reader> Dwarf<R> {
         unit: &Unit<R>,
         offset: LocationListsOffset<R::Offset>,
     ) -> Result<LocListIter<R>> {
-        self.locations.locations(
-            offset,
-            unit.encoding(),
-            unit.low_pc,
-            &self.debug_addr,
-            unit.addr_base,
-        )
+        match self.file_type {
+            DwarfFileType::Main => self.locations.locations(
+                offset,
+                unit.encoding(),
+                unit.low_pc,
+                &self.debug_addr,
+                unit.addr_base,
+            ),
+            DwarfFileType::Dwo => self.locations.locations_dwo(
+                offset,
+                unit.encoding(),
+                unit.low_pc,
+                &self.debug_addr,
+                unit.addr_base,
+            ),
+        }
     }
 
     /// Try to return an attribute value as a location list offset.

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -660,7 +660,9 @@ impl<R: Reader> Unit<R> {
     pub fn copy_relocated_attributes(&mut self, other: &Unit<R>) {
         self.low_pc = other.low_pc;
         self.addr_base = other.addr_base;
-        self.rnglists_base = other.rnglists_base;
+        if self.header.version() < 5 {
+            self.rnglists_base = other.rnglists_base;
+        }
     }
 }
 

--- a/src/read/lists.rs
+++ b/src/read/lists.rs
@@ -1,0 +1,67 @@
+use crate::common::{Encoding, Format};
+use crate::read::{Error, Reader, Result};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ListsHeader {
+    encoding: Encoding,
+    offset_entry_count: u32,
+}
+
+impl Default for ListsHeader {
+    fn default() -> Self {
+        ListsHeader {
+            encoding: Encoding {
+                format: Format::Dwarf32,
+                version: 5,
+                address_size: 0,
+            },
+            offset_entry_count: 0,
+        }
+    }
+}
+
+impl ListsHeader {
+    /// Return the serialized size of the table header.
+    #[allow(dead_code)]
+    #[inline]
+    fn size(self) -> u8 {
+        // initial_length + version + address_size + segment_selector_size + offset_entry_count
+        ListsHeader::size_for_encoding(self.encoding)
+    }
+
+    /// Return the serialized size of the table header.
+    #[inline]
+    pub(crate) fn size_for_encoding(encoding: Encoding) -> u8 {
+        // initial_length + version + address_size + segment_selector_size + offset_entry_count
+        encoding.format.initial_length_size() + 2 + 1 + 1 + 4
+    }
+}
+
+// TODO: add an iterator over headers in the appropriate sections section
+#[allow(dead_code)]
+fn parse_header<R: Reader>(input: &mut R) -> Result<ListsHeader> {
+    let (length, format) = input.read_initial_length()?;
+    input.truncate(length)?;
+
+    let version = input.read_u16()?;
+    if version != 5 {
+        return Err(Error::UnknownVersion(u64::from(version)));
+    }
+
+    let address_size = input.read_u8()?;
+    let segment_selector_size = input.read_u8()?;
+    if segment_selector_size != 0 {
+        return Err(Error::UnsupportedSegmentSize);
+    }
+    let offset_entry_count = input.read_u32()?;
+
+    let encoding = Encoding {
+        format,
+        version,
+        address_size,
+    };
+    Ok(ListsHeader {
+        encoding,
+        offset_entry_count,
+    })
+}

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -199,6 +199,8 @@ pub use self::aranges::*;
 mod line;
 pub use self::line::*;
 
+mod lists;
+
 mod loclists;
 pub use self::loclists::*;
 


### PR DESCRIPTION
The pre-DWARF5 GNU split dwarf extension differs from the standardized version in at least two ways:

1. The various new list sections do not have the headers that they have in the standardized version.
2. The .debug_loclists section can be present in a .dwo as .debug_loc.dwo, with a slightly different encoding format.

Additionally, the default values for the various base attributes are wrong in DWARF 5, where there is the section header (that is not present in the GNU split dwarf extension) that must be skipped.

To handle all of this, I fix the default base handling by keying off the DWARF version, then I refactor LocationLists and RangeLists because only one of the two sections is present at any given time. Which encoding to use for these lists is no longer keyed off the DWARF version but rather the section in use. That allows the DWARF version to be used to distinguish the pre-DWARF5 GNU split dwarf encoding for location lists.