### PR TITLE
Add a name_to_register routine to convert names into register numbers

### DIFF
--- a/src/arch.rs
+++ b/src/arch.rs
@@ -19,6 +19,16 @@ macro_rules! registers {
                     _ => return None,
                 }
             }
+
+	    /// Converts a register name into a register number.
+	    pub fn name_to_register(value: &str) -> Option<Register> {
+		match value {
+                    $(
+                        $disp => Some(Self::$name),
+                    )+
+                    _ => return None,
+		}
+	    }
         }
     };
 }


### PR DESCRIPTION
This PR adds a converse of `register_name`, i.e. a function that converts a string register name into a register number. It's useful for debugger command-line interfaces.

Please let me know if this needs a test case.