### PR TITLE
Implement read/write of DW_OP_WASM_location

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1209,7 +1209,7 @@ DwOp(u8) {
     DW_OP_convert = 0xa8,
     DW_OP_reinterpret = 0xa9,
 
-// GNU extensions
+    // GNU extensions
     DW_OP_GNU_push_tls_address = 0xe0,
     DW_OP_GNU_implicit_pointer = 0xf2,
     DW_OP_GNU_entry_value = 0xf3,
@@ -1221,6 +1221,9 @@ DwOp(u8) {
     DW_OP_GNU_parameter_ref = 0xfa,
     DW_OP_GNU_addr_index = 0xfb,
     DW_OP_GNU_const_index = 0xfc,
+
+    // Wasm extensions
+    DW_OP_WASM_location = 0xed,
 });
 
 dw!(

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -320,6 +320,8 @@ pub enum Error {
     /// An unrecognized operation was found while parsing a DWARF
     /// expression.
     InvalidExpression(constants::DwOp),
+    /// An unsupported operation was found while evaluating a DWARF expression.
+    UnsupportedEvaluation,
     /// The expression had a piece followed by an expression
     /// terminator without a piece.
     InvalidPiece,
@@ -470,6 +472,7 @@ impl Error {
             Error::NotEnoughStackItems => "Not enough items on stack when evaluating expression",
             Error::TooManyIterations => "Too many iterations to evaluate DWARF expression",
             Error::InvalidExpression(_) => "Invalid opcode in DWARF expression",
+            Error::UnsupportedEvaluation => "Unsupported operation when evaluating expression",
             Error::InvalidPiece => {
                 "DWARF expression has piece followed by non-piece expression at end"
             }

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -1,4 +1,5 @@
 use alloc::borrow::Cow;
+use core::convert::TryInto;
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{Add, AddAssign, Sub};
@@ -389,6 +390,13 @@ pub trait Reader: Debug + Clone {
     /// Read an unsigned LEB128 encoded integer.
     fn read_uleb128(&mut self) -> Result<u64> {
         leb128::read::unsigned(self)
+    }
+
+    /// Read an unsigned LEB128 encoded u32.
+    fn read_uleb128_u32(&mut self) -> Result<u32> {
+        leb128::read::unsigned(self)?
+            .try_into()
+            .map_err(|_| Error::BadUnsignedLeb128)
     }
 
     /// Read an unsigned LEB128 encoded u16.


### PR DESCRIPTION
Does not support evaluation though.

Sample dwarfdump output:
```
DW_AT_frame_base            len 0x0007: ed03000000009f: DW_OP_WASM_location 0x3 0x0 DW_OP_stack_value
```

Fixes #544 