### PR TITLE
use a more efficient method to copy [u8]

### DIFF
--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -469,7 +469,7 @@ where
     fn read_slice(&mut self, buf: &mut [u8]) -> Result<()> {
         match self.range.read_slice(buf.len()) {
             Some(slice) => {
-                buf.clone_from_slice(slice);
+                buf.copy_from_slice(slice);
                 Ok(())
             }
             None => Err(Error::UnexpectedEof(self.offset_id())),

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -305,7 +305,7 @@ where
     #[inline]
     fn read_slice(&mut self, buf: &mut [u8]) -> Result<()> {
         let slice = self.read_slice(buf.len())?;
-        buf.clone_from_slice(slice);
+        buf.copy_from_slice(slice);
         Ok(())
     }
 }


### PR DESCRIPTION
I saw `clone_from_slice` showing up in some profiles and the assembly looks like a fairly dumb loop of `mov` instructions. `copy_from_slice` should optimize better since it calls `copy_nonoverlapping` (`memcpy`) internally.