### PR TITLE
read: replace Dwarf::debug_str_sup with Dwarf::sup

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -27,12 +27,9 @@ fn dump_file(object: &object::File, endian: gimli::RunTimeEndian) -> Result<(), 
             None => Ok(borrow::Cow::Borrowed(&[][..])),
         }
     };
-    // Load a supplementary section. We don't have a supplementary object file,
-    // so always return an empty slice.
-    let load_section_sup = |_| Ok(borrow::Cow::Borrowed(&[][..]));
 
     // Load all of the sections.
-    let dwarf_cow = gimli::Dwarf::load(&load_section, &load_section_sup)?;
+    let dwarf_cow = gimli::Dwarf::load(&load_section)?;
 
     // Borrow a `Cow<[u8]>` to create an `EndianSlice`.
     let borrow_section: &dyn for<'a> Fn(

--- a/examples/simple_line.rs
+++ b/examples/simple_line.rs
@@ -27,12 +27,9 @@ fn dump_file(object: &object::File, endian: gimli::RunTimeEndian) -> Result<(), 
             None => Ok(borrow::Cow::Borrowed(&[][..])),
         }
     };
-    // Load a supplementary section. We don't have a supplementary object file,
-    // so always return an empty slice.
-    let load_section_sup = |_| Ok(borrow::Cow::Borrowed(&[][..]));
 
     // Load all of the sections.
-    let dwarf_cow = gimli::Dwarf::load(&load_section, &load_section_sup)?;
+    let dwarf_cow = gimli::Dwarf::load(&load_section)?;
 
     // Borrow a `Cow<[u8]>` to create an `EndianSlice`.
     let borrow_section: &dyn for<'a> Fn(

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -17,7 +17,8 @@
 //! // These closures should return a `Reader` instance (e.g. `EndianSlice`).
 //! let loader = |section: gimli::SectionId| { get_file_section_reader(section.name()) };
 //! let sup_loader = |section: gimli::SectionId| { get_sup_file_section_reader(section.name()) };
-//! let dwarf = gimli::Dwarf::load(loader, sup_loader)?;
+//! let mut dwarf = gimli::Dwarf::load(loader)?;
+//! dwarf.load_sup(sup_loader)?;
 //!
 //! // Iterate over all compilation units.
 //! let mut iter = dwarf.units();


### PR DESCRIPTION
This is simpler and allows us to avoid loading the supplementary
`.debug_str` twice.

Also split the supplementary section loading into `Dwarf::load_sup`,
which has the benefit that users don't have to pass a dummy section
loader when there is no supplementary object file.