### PR TITLE
Accept aranges headers with version 3

### DIFF
--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -158,8 +158,12 @@ where
         let (length, format) = input.read_initial_length()?;
         let mut rest = input.split(length)?;
 
+        // Check the version. The DWARF 5 spec says that this is always 2, but version 3
+        // has been observed in the wild, potentially due to a bug; see
+        // https://github.com/gimli-rs/gimli/issues/559 for more information.
+        // lldb allows versions 2 through 5, possibly by mistake.
         let version = rest.read_u16()?;
-        if version != 2 {
+        if version != 2 && version != 3 {
             return Err(Error::UnknownVersion(u64::from(version)));
         }
 


### PR DESCRIPTION
This allows parsing Firefox libxul.so files. It is not clear why those
have an unexpected version 3 in some of their aranges headers.

Fixes #559.