### PR TITLE
Fix ranges with the GNU DWO extension and other improvements

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -1757,7 +1757,7 @@ fn dump_loc_list<R: Reader, W: Write>(
     unit: &gimli::Unit<R>,
     dwarf: &gimli::Dwarf<R>,
 ) -> Result<()> {
-    let raw_locations = dwarf.locations.raw_locations(offset, unit.encoding())?;
+    let raw_locations = dwarf.raw_locations(unit, offset)?;
     let raw_locations: Vec<_> = raw_locations.collect()?;
     let mut locations = dwarf.locations(unit, offset)?;
     writeln!(
@@ -1885,7 +1885,7 @@ fn dump_range_list<R: Reader, W: Write>(
     unit: &gimli::Unit<R>,
     dwarf: &gimli::Dwarf<R>,
 ) -> Result<()> {
-    let raw_ranges = dwarf.ranges.raw_ranges(offset, unit.encoding())?;
+    let raw_ranges = dwarf.raw_ranges(unit, offset)?;
     let raw_ranges: Vec<_> = raw_ranges.collect()?;
     let mut ranges = dwarf.ranges(unit, offset)?;
     writeln!(

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -297,6 +297,12 @@ impl<R: Reader> Dwarf<R> {
         unit: &Unit<R>,
         offset: RangeListsOffset<R::Offset>,
     ) -> Result<RngListIter<R>> {
+        let offset = if self.file_type == DwarfFileType::Dwo && unit.header.version() < 5 {
+            RangeListsOffset(offset.0.wrapping_add(unit.rnglists_base.0))
+        } else {
+            offset
+        };
+
         self.ranges.ranges(
             offset,
             unit.encoding(),
@@ -312,6 +318,11 @@ impl<R: Reader> Dwarf<R> {
         unit: &Unit<R>,
         offset: RangeListsOffset<R::Offset>,
     ) -> Result<RawRngListIter<R>> {
+        let offset = if self.file_type == DwarfFileType::Dwo && unit.header.version() < 5 {
+            RangeListsOffset(offset.0.wrapping_add(unit.rnglists_base.0))
+        } else {
+            offset
+        };
         self.ranges.raw_ranges(offset, unit.encoding())
     }
 


### PR DESCRIPTION
This set of commits makes `dwarfdump` more useful for dumping a .dwo, by allowing me to provide the path of the "parent" binary, and fixes a nasty bug in the handling of ranges in the pre-DWARF5 GNU DWO extension where we weren't doing the behavior that's documented at https://github.com/bminor/binutils-gdb/blob/fac3b6a2e04f7feeefbf425c3798c34d134752d6/gdb/dwarf2/cu.h#L189