### PR TITLE
Adjust default `DW_EH_PE_pcrel` calculation

### DIFF
--- a/src/write/writer.rs
+++ b/src/write/writer.rs
@@ -60,7 +60,7 @@ pub trait Writer {
                     constants::DW_EH_PE_pcrel => {
                         // TODO: better handling of sign
                         let offset = self.len() as u64;
-                        offset.wrapping_sub(val)
+                        val.wrapping_sub(offset)
                     }
                     _ => {
                         return Err(Error::UnsupportedPointerEncoding(eh_pe));


### PR DESCRIPTION
Today I was fiddling around in Wasmtime with how we structure and emit
our `.eh_frame` section for JIT code, and my goal was to avoid the need
to generate `.eh_frame` every time a module is loaded as it is today.
Because the FDEs have absolute addresses in them right now though I
needed to figure out some sort of relative solution so I could just make
sure that the `.eh_frame` section and the JIT code memory were
relatively in the same place.

This exploration led me to stumble upon `DW_EH_PE_pcrel`. That seemed to
be roughly what I wanted where the description of what an FDE was
modifying was relative to the address of the FDE itself. Upon digging
into `gimli`'s implementation of `DW_EH_PE_pcrel` handling it currently
factors in the offset of where the pointer is encoded itself. I assume
that this is because applications generally don't know where the FDE
address is encoded but they do know, for example, where the start of the
`.eh_frame` will be encoded.

I forged ahead with trying to use this but was then a bit confused when
unwinding didn't actually work out. Upon actually trying to do the math,
it appears that what gimli does today is:

    actual_encoded_value = offset_of_fde - provided_value

For my use case I knew that the distance between the start of the text
section and the `.eh_frame` is a constant `N`, so what I was shooting
for was:

    actual_encoded_value = -(N - offset_in_text) - offset_of_fde

where for me `provided_value = -(N - offset_in_text)`. I noticed that
the subtraction here is backwards, and I am submitting this PR because I
think that may be a mistake but I could also be mistaken! I'm well known
to get various minus signs here mixed up and such...