### PR TITLE
Add EntriesRaw::skip_attributes

### DIFF
--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -67,6 +67,16 @@ pub mod read {
     use super::{low_bits_of_byte, CONTINUATION_BIT, SIGN_BIT};
     use crate::read::{Error, Reader, Result};
 
+    /// Read bytes until the LEB128 continuation bit is not set.
+    pub fn skip<R: Reader>(r: &mut R) -> Result<()> {
+        loop {
+            let byte = r.read_u8()?;
+            if byte & CONTINUATION_BIT == 0 {
+                return Ok(());
+            }
+        }
+    }
+
     /// Read an unsigned LEB128 number from the given `Reader` and
     /// return it or an error if reading failed.
     pub fn unsigned<R: Reader>(r: &mut R) -> Result<u64> {

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -387,6 +387,11 @@ pub trait Reader: Debug + Clone {
         Ok(val)
     }
 
+    /// Skip a LEB128 encoded integer.
+    fn skip_leb128(&mut self) -> Result<()> {
+        leb128::read::skip(self)
+    }
+
     /// Read an unsigned LEB128 encoded integer.
     fn read_uleb128(&mut self) -> Result<u64> {
         leb128::read::unsigned(self)

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -13,6 +13,7 @@ use crate::common::{
 };
 use crate::constants;
 use crate::endianity::Endianity;
+use crate::read::abbrev::get_attribute_size;
 use crate::read::{
     Abbreviation, Abbreviations, AttributeSpecification, DebugAbbrev, DebugStr, EndianSlice, Error,
     Expression, Reader, ReaderOffset, Result, Section,
@@ -2208,6 +2209,74 @@ pub(crate) fn parse_attribute<'unit, R: Reader>(
     }
 }
 
+pub(crate) fn skip_attributes<'unit, R: Reader>(
+    input: &mut R,
+    encoding: Encoding,
+    specs: &[AttributeSpecification],
+) -> Result<()> {
+    let mut skip_bytes = R::Offset::from_u8(0);
+    for spec in specs {
+        let mut form = spec.form();
+        loop {
+            if let Some(len) = get_attribute_size(form, encoding) {
+                // We know the length of this attribute. Accumulate that length.
+                skip_bytes += R::Offset::from_u8(len);
+                break;
+            }
+
+            // We have encountered a variable-length attribute.
+            if skip_bytes != R::Offset::from_u8(0) {
+                // Skip the accumulated skip bytes and then read the attribute normally.
+                input.skip(skip_bytes)?;
+                skip_bytes = R::Offset::from_u8(0);
+            }
+
+            match form {
+                constants::DW_FORM_indirect => {
+                    let dynamic_form = input.read_uleb128_u16()?;
+                    form = constants::DwForm(dynamic_form);
+                    continue;
+                }
+                constants::DW_FORM_block1 => {
+                    skip_bytes = input.read_u8().map(R::Offset::from_u8)?;
+                }
+                constants::DW_FORM_block2 => {
+                    skip_bytes = input.read_u16().map(R::Offset::from_u16)?;
+                }
+                constants::DW_FORM_block4 => {
+                    skip_bytes = input.read_u32().map(R::Offset::from_u32)?;
+                }
+                constants::DW_FORM_block | constants::DW_FORM_exprloc => {
+                    skip_bytes = input.read_uleb128().and_then(R::Offset::from_u64)?;
+                }
+                constants::DW_FORM_string => {
+                    let _ = input.read_null_terminated_slice()?;
+                }
+                constants::DW_FORM_udata
+                | constants::DW_FORM_sdata
+                | constants::DW_FORM_ref_udata
+                | constants::DW_FORM_strx
+                | constants::DW_FORM_GNU_str_index
+                | constants::DW_FORM_addrx
+                | constants::DW_FORM_GNU_addr_index
+                | constants::DW_FORM_loclistx
+                | constants::DW_FORM_rnglistx => {
+                    input.skip_leb128()?;
+                }
+                _ => {
+                    return Err(Error::UnknownForm);
+                }
+            };
+            break;
+        }
+    }
+    if skip_bytes != R::Offset::from_u8(0) {
+        // Skip the remaining accumulated skip bytes.
+        input.skip(skip_bytes)?;
+    }
+    Ok(())
+}
+
 /// An iterator over a particular entry's attributes.
 ///
 /// See [the documentation for
@@ -2320,9 +2389,7 @@ impl<'abbrev, 'entry, 'unit, R: Reader> fallible_iterator::FallibleIterator
 ///         }
 ///         _ => {
 ///             // Skip attributes for DIEs we don't care about.
-///             for spec in abbrev.attributes() {
-///                 entries.read_attribute(*spec)?;
-///             }
+///             entries.skip_attributes(abbrev.attributes());
 ///         }
 ///     }
 /// }
@@ -2388,6 +2455,12 @@ impl<'abbrev, 'unit, R: Reader> EntriesRaw<'abbrev, 'unit, R> {
     #[inline]
     pub fn read_attribute(&mut self, spec: AttributeSpecification) -> Result<Attribute<R>> {
         parse_attribute(&mut self.input, self.unit.encoding(), spec)
+    }
+
+    /// Skip all the attributes of an abbreviation.
+    #[inline]
+    pub fn skip_attributes(&mut self, specs: &[AttributeSpecification]) -> Result<()> {
+        skip_attributes(&mut self.input, self.unit.encoding(), specs)
     }
 }
 
@@ -4238,6 +4311,9 @@ mod tests {
             Ok(attr) => {
                 assert_eq!(attr, expect);
                 assert_eq!(*rest, EndianSlice::new(&buf[len..], Endian::default()));
+                if let Some(size) = spec.size(unit) {
+                    assert_eq!(rest.len() + size, buf.len());
+                }
             }
             otherwise => {
                 assert!(false, "Unexpected parse result = {:#?}", otherwise);


### PR DESCRIPTION
This makes it easier for consumers to skip over abbrevs that
they don't need. It might also be slightly faster than parsing
the unneeded attributes and throwing away their values.

Co-authored-by: Markus Stange

Fixes #591
Closes #592 (cc @mstange)