### PR TITLE
Dedupe comp-dir/directory in line-table paths

### DIFF
--- a/examples/simple_line.rs
+++ b/examples/simple_line.rs
@@ -68,9 +68,16 @@ fn dump_file(object: &object::File, endian: gimli::RunTimeEndian) -> Result<(), 
                     let mut path = path::PathBuf::new();
                     if let Some(file) = row.file(header) {
                         path = comp_dir.clone();
-                        if let Some(dir) = file.directory(header) {
-                            path.push(dwarf.attr_string(&unit, dir)?.to_string_lossy().as_ref());
+
+                        // The directory index 0 is defined to correspond to the compilation unit directory.
+                        if file.directory_index() != 0 {
+                            if let Some(dir) = file.directory(header) {
+                                path.push(
+                                    dwarf.attr_string(&unit, dir)?.to_string_lossy().as_ref(),
+                                );
+                            }
                         }
+
                         path.push(
                             dwarf
                                 .attr_string(&unit, file.path_name())?

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -1,7 +1,5 @@
 //! Definitions for values used in DWARF expressions.
 
-use core::mem;
-
 use crate::constants;
 #[cfg(feature = "read")]
 use crate::read::{AttributeValue, DebuggingInformationEntry};


### PR DESCRIPTION
The same as https://github.com/gimli-rs/addr2line/pull/239, except updating the `simple_line` example.

Also includes a driveby fix for an unused import.