### PR TITLE
Make Vec from a pointer that is valid for mutation

### DIFF
--- a/src/read/util.rs
+++ b/src/read/util.rs
@@ -180,7 +180,7 @@ impl<T> ArrayVec<Vec<T>> {
         let slice = Box::leak(storage);
         debug_assert!(len <= slice.len());
         // SAFETY: valid elements.
-        unsafe { Vec::from_raw_parts(slice.as_ptr() as _, len, slice.len()) }
+        unsafe { Vec::from_raw_parts(slice.as_mut_ptr() as *mut T, len, slice.len()) }
     }
 }
 


### PR DESCRIPTION
`slice::as_ptr` documents that the returned pointer or any pointer derived from it may not be used for mutation. It is therefore unsound to construct a `Vec` using this pointer, the docs advise `as_raw_ptr` instead: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.as_ptr

I also specified the type in the cast, because `as _` can produce very surprising behavior in unsafe code due to the reference and pointer coercions.

This issue can be detected with `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test`

This change would be rendered unnecessary by https://github.com/gimli-rs/gimli/pull/603 but I can't tell what state that is in, the CI logs seem to have expired.