### PR TITLE
Support DWARF2 for DW_OP_implicit_pointer

### DIFF
--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -705,10 +705,12 @@ where
             }
             constants::DW_OP_stack_value => Ok(Operation::StackValue),
             constants::DW_OP_implicit_pointer | constants::DW_OP_GNU_implicit_pointer => {
-                let value = if encoding.version != 2 {
-                    bytes.read_offset(encoding.format)?
+                let value = if encoding.version == 2 {
+                    bytes
+                        .read_address(encoding.address_size)
+                        .and_then(Offset::from_u64)?
                 } else {
-                    Offset::from_u64(bytes.read_address(encoding.address_size)?)?
+                    bytes.read_offset(encoding.format)?
                 };
                 let byte_offset = bytes.read_sleb128()?;
                 Ok(Operation::ImplicitPointer {

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -705,7 +705,11 @@ where
             }
             constants::DW_OP_stack_value => Ok(Operation::StackValue),
             constants::DW_OP_implicit_pointer | constants::DW_OP_GNU_implicit_pointer => {
-                let value = bytes.read_offset(encoding.format)?;
+                let value = if encoding.version != 2 {
+                    bytes.read_offset(encoding.format)?
+                } else {
+                    Offset::from_u64(bytes.read_address(encoding.address_size)?)?
+                };
                 let byte_offset = bytes.read_sleb128()?;
                 Ok(Operation::ImplicitPointer {
                     value: DebugInfoOffset(value),
@@ -2641,6 +2645,19 @@ mod tests {
                 },
                 encoding8(),
             );
+
+            check_op_parse(
+                |s| s.D8(op.0).D64(0x1234_5678).sleb(0x123),
+                &Operation::ImplicitPointer {
+                    value: DebugInfoOffset(0x1234_5678),
+                    byte_offset: 0x123,
+                },
+                Encoding {
+                    format: Format::Dwarf32,
+                    version: 2,
+                    address_size: 8,
+                },
+            )
         }
     }
 

--- a/src/write/op.rs
+++ b/src/write/op.rs
@@ -778,7 +778,11 @@ impl Operation {
                 } else {
                     w.write_u8(constants::DW_OP_GNU_implicit_pointer.0)?;
                 }
-                let size = encoding.format.word_size();
+                let size = if encoding.version != 2 {
+                    encoding.format.word_size()
+                } else {
+                    encoding.address_size
+                };
                 match entry {
                     Reference::Symbol(symbol) => {
                         w.write_reference(symbol, size)?;

--- a/src/write/op.rs
+++ b/src/write/op.rs
@@ -778,10 +778,10 @@ impl Operation {
                 } else {
                     w.write_u8(constants::DW_OP_GNU_implicit_pointer.0)?;
                 }
-                let size = if encoding.version != 2 {
-                    encoding.format.word_size()
-                } else {
+                let size = if encoding.version == 2 {
                     encoding.address_size
+                } else {
+                    encoding.format.word_size()
                 };
                 match entry {
                     Reference::Symbol(symbol) => {


### PR DESCRIPTION
In DwarfV2, the address length encoding in DW_OP_implicit_pointer is the encoding address size, not the format word size.

[libdwarf/dwarf_loc#L539](https://github.com/avast/libdwarf/blob/7d4f63f44d44386744628ee1bca84afc43a56583/libdwarf/libdwarf/dwarf_loc.c#L539)