### PR TITLE
read: cache abbreviations at offset 0

### DIFF
--- a/src/read/lazy.rs
+++ b/src/read/lazy.rs
@@ -1,0 +1,108 @@
+pub(crate) use imp::*;
+
+#[cfg(not(feature = "std"))]
+mod imp {
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicPtr, Ordering};
+    use core::{mem, ptr};
+
+    #[derive(Debug, Default)]
+    pub(crate) struct LazyArc<T> {
+        // Only written once with a value obtained from `Arc<T>::into_raw`.
+        value: AtomicPtr<T>,
+    }
+
+    impl<T> Drop for LazyArc<T> {
+        fn drop(&mut self) {
+            let value_ptr = self.value.load(Ordering::Acquire);
+            if !value_ptr.is_null() {
+                // SAFETY: all writes to `self.value` are pointers obtained from `Arc::into_raw`.
+                unsafe {
+                    Arc::from_raw(value_ptr);
+                }
+            }
+        }
+    }
+
+    impl<T> LazyArc<T> {
+        pub(crate) fn get<E, F: FnOnce() -> Result<T, E>>(&self, f: F) -> Result<Arc<T>, E> {
+            // Clone an `Arc` given a pointer obtained from `Arc::into_raw`.
+            // SAFETY: `value_ptr` must be a valid pointer obtained from `Arc<T>::into_raw`.
+            unsafe fn clone_arc_ptr<T>(value_ptr: *const T) -> Arc<T> {
+                let value = Arc::from_raw(value_ptr);
+                let clone = Arc::clone(&value);
+                mem::forget(value);
+                clone
+            }
+
+            // Return the existing value if already computed.
+            let value_ptr = self.value.load(Ordering::Acquire);
+            if !value_ptr.is_null() {
+                // SAFETY: all writes to `self.value` are pointers obtained from `Arc::into_raw`.
+                return Ok(unsafe { clone_arc_ptr(value_ptr) });
+            }
+
+            // Race to compute and set the value.
+            let value = f().map(Arc::new)?;
+            let value_ptr = Arc::into_raw(value);
+            match self.value.compare_exchange(
+                ptr::null_mut(),
+                value_ptr as *mut T,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    // Return the value we computed.
+                    // SAFETY: `value_ptr` was obtained from `Arc::into_raw`.
+                    Ok(unsafe { clone_arc_ptr(value_ptr) })
+                }
+                Err(existing_value_ptr) => {
+                    // We lost the race, drop unneeded `value_ptr`.
+                    // SAFETY: `value_ptr` was obtained from `Arc::into_raw`.
+                    unsafe { Arc::from_raw(value_ptr) };
+                    // Return the existing value.
+                    // SAFETY: all writes to `self.value` are pointers obtained from `Arc::into_raw`.
+                    Ok(unsafe { clone_arc_ptr(existing_value_ptr) })
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod imp {
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Default)]
+    pub(crate) struct LazyArc<T> {
+        value: Mutex<Option<Arc<T>>>,
+    }
+
+    impl<T> LazyArc<T> {
+        pub(crate) fn get<E, F: FnOnce() -> Result<T, E>>(&self, f: F) -> Result<Arc<T>, E> {
+            let mut lock = self.value.lock().unwrap();
+            if let Some(value) = &*lock {
+                return Ok(value.clone());
+            }
+            let value = f().map(Arc::new)?;
+            *lock = Some(value.clone());
+            Ok(value)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lazy_arc() {
+        let lazy = LazyArc::default();
+        let value = lazy.get(|| Err(()));
+        assert_eq!(value, Err(()));
+        let value = lazy.get(|| Ok::<i32, ()>(3)).unwrap();
+        assert_eq!(*value, 3);
+        let value = lazy.get(|| Err(())).unwrap();
+        assert_eq!(*value, 3);
+    }
+}

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -214,6 +214,9 @@ mod index;
 pub use self::index::*;
 
 #[cfg(feature = "read")]
+mod lazy;
+
+#[cfg(feature = "read")]
 mod line;
 #[cfg(feature = "read")]
 pub use self::line::*;

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -436,6 +436,7 @@ mod tests {
     };
     use crate::LittleEndian;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn test_loc_list() {
@@ -508,7 +509,7 @@ mod tests {
                             DebugInfoOffset(0).into(),
                             read::EndianSlice::default(),
                         ),
-                        abbreviations: read::Abbreviations::default(),
+                        abbreviations: Arc::new(read::Abbreviations::default()),
                         name: None,
                         comp_dir: None,
                         low_pc: 0,

--- a/src/write/op.rs
+++ b/src/write/op.rs
@@ -1071,6 +1071,7 @@ mod tests {
     };
     use crate::LittleEndian;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn test_operation() {
@@ -1578,7 +1579,7 @@ mod tests {
                             DebugInfoOffset(0).into(),
                             read::EndianSlice::new(&[], LittleEndian),
                         ),
-                        abbreviations: read::Abbreviations::default(),
+                        abbreviations: Arc::new(read::Abbreviations::default()),
                         name: None,
                         comp_dir: None,
                         low_pc: 0,

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -315,6 +315,7 @@ mod tests {
     };
     use crate::LittleEndian;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn test_range() {
@@ -375,7 +376,7 @@ mod tests {
                             DebugInfoOffset(0).into(),
                             read::EndianSlice::default(),
                         ),
-                        abbreviations: read::Abbreviations::default(),
+                        abbreviations: Arc::new(read::Abbreviations::default()),
                         name: None,
                         comp_dir: None,
                         low_pc: 0,

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1931,6 +1931,7 @@ mod tests {
     use crate::LittleEndian;
     use std::collections::HashMap;
     use std::mem;
+    use std::sync::Arc;
 
     #[test]
     #[allow(clippy::cyclomatic_complexity)]
@@ -2542,7 +2543,7 @@ mod tests {
 
                         let unit = read::Unit {
                             header: from_unit,
-                            abbreviations: read::Abbreviations::default(),
+                            abbreviations: Arc::new(read::Abbreviations::default()),
                             name: None,
                             comp_dir: None,
                             low_pc: 0,
@@ -3015,7 +3016,7 @@ mod tests {
 
                         let unit = read::Unit {
                             header: from_unit,
-                            abbreviations: read::Abbreviations::default(),
+                            abbreviations: Arc::new(read::Abbreviations::default()),
                             name: None,
                             comp_dir: None,
                             low_pc: 0,


### PR DESCRIPTION
This optimises for the case where there is a single set of abbreviations that is used for all units.

Closes #626
Closes #628