### PR TITLE
skip tombstone when iter rangelist

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -361,3 +361,11 @@ impl Default for DwarfFileType {
         DwarfFileType::Main
     }
 }
+
+/// compute tombstone address. LLVM's dwarf impl use tombstone to indicate
+/// the address is not use, so parser should ignore it.
+pub const fn compute_tombstone_address(address_size: u8) -> u64 {
+    debug_assert!(address_size <= 8);
+
+    u64::MAX >> (8 - address_size) * 8
+}


### PR DESCRIPTION
fixes #629 
I add the check and skip logic between raw range => range, all tests passed, but dwarfdump tool is broken, because it expects one to one relationship between raw range and range. 
Any idea on how to fix this?