### PR TITLE
Fix atomic ordering in LazyArc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,10 @@ jobs:
         rustup default ${{matrix.rust_channel}}
     - name: MSRV dependencies
       if: matrix.rust_channel == '1.42.0'
-      run: cargo update -p indexmap --precise 1.6.2
+      run: |
+        cargo update -p indexmap --precise 1.6.2
+        cargo update -p rayon --precise 1.5.3
+        cargo update -p rayon-core --precise 1.9.3
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/read/lazy.rs
+++ b/src/read/lazy.rs
@@ -52,8 +52,9 @@ mod imp {
                 value_ptr as *mut T,
                 // Success: `Ordering::Release` is needed so that the content of the stored `Arc`
                 // is visible to other threads. No ordering is required for the null ptr that is
-                // loaded.
-                Ordering::Release,
+                // loaded, but older rust versions (< 1.64) require that its ordering must not
+                // be weaker than the failure ordering, so we use `Ordering::AcqRel`.
+                Ordering::AcqRel,
                 // Failure: `Ordering::Acquire` is needed so that the content of the loaded `Arc`
                 // is visible to this thread.
                 Ordering::Acquire,


### PR DESCRIPTION
Fixes build error:
error: compare_exchange's failure ordering may not be stronger than the success ordering of `Release`