### PR TITLE
Add support for XCOFF

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -291,6 +291,7 @@ pub enum SectionId {
 
 impl SectionId {
     /// Returns the ELF section name for this kind.
+    #[cfg(not(target_os = "aix"))]
     pub fn name(self) -> &'static str {
         match self {
             SectionId::DebugAbbrev => ".debug_abbrev",
@@ -315,6 +316,35 @@ impl SectionId {
             SectionId::DebugStrOffsets => ".debug_str_offsets",
             SectionId::DebugTuIndex => ".debug_tu_index",
             SectionId::DebugTypes => ".debug_types",
+        }
+    }
+
+    /// Returns the XCOFF section name for this kind.
+    #[cfg(target_os = "aix")]
+    pub fn name(self) -> &'static str {
+        match self {
+            SectionId::DebugAbbrev => ".dwabrev",
+            SectionId::DebugAddr => panic!("XCOFF doesn't have debug address section"),
+            SectionId::DebugAranges => ".dwarnge",
+            SectionId::DebugCuIndex => panic!("XCOFF doesn't have debug cu index section"),
+            SectionId::DebugFrame => ".dwframe",
+            SectionId::EhFrame => panic!("XCOFF doesn't have eh frame section"),
+            SectionId::EhFrameHdr => panic!("XCOFF doesn't have eh frame hdr section"),
+            SectionId::DebugInfo => ".dwinfo",
+            SectionId::DebugLine => ".dwline",
+            SectionId::DebugLineStr => panic!("XCOFF doesn't have debug line string section"),
+            SectionId::DebugLoc => ".dwloc",
+            SectionId::DebugLocLists => panic!("XCOFF doesn't have debug loc lists section"),
+            SectionId::DebugMacinfo => ".dwmac",
+            SectionId::DebugMacro => panic!("XCOFF doesn't have debug macro section"),
+            SectionId::DebugPubNames => ".dwpbnms",
+            SectionId::DebugPubTypes => ".dwpbtyp",
+            SectionId::DebugRanges => ".dwrnges",
+            SectionId::DebugRngLists => panic!("XCOFF doesn't have debug range lists section"),
+            SectionId::DebugStr => ".dwstr",
+            SectionId::DebugStrOffsets => panic!("XCOFF doesn't have debug str offsets section"),
+            SectionId::DebugTuIndex => panic!("XCOFF doesn't have debug tu index section"),
+            SectionId::DebugTypes => panic!("XCOFF doesn't have debug type section"),
         }
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -318,34 +318,6 @@ impl SectionId {
         }
     }
 
-    /// Returns the XCOFF section name for this kind.
-    pub fn xcoff_name(self) -> Option<&'static str> {
-        match self {
-            SectionId::DebugAbbrev => Some(".dwabrev"),
-            SectionId::DebugAddr => None,
-            SectionId::DebugAranges => Some(".dwarnge"),
-            SectionId::DebugCuIndex => None,
-            SectionId::DebugFrame => Some(".dwframe"),
-            SectionId::EhFrame => None,
-            SectionId::EhFrameHdr => None,
-            SectionId::DebugInfo => Some(".dwinfo"),
-            SectionId::DebugLine => Some(".dwline"),
-            SectionId::DebugLineStr => None,
-            SectionId::DebugLoc => Some(".dwloc"),
-            SectionId::DebugLocLists => None,
-            SectionId::DebugMacinfo => Some(".dwmac"),
-            SectionId::DebugMacro => None,
-            SectionId::DebugPubNames => Some(".dwpbnms"),
-            SectionId::DebugPubTypes => Some(".dwpbtyp"),
-            SectionId::DebugRanges => Some(".dwrnges"),
-            SectionId::DebugRngLists => None,
-            SectionId::DebugStr => Some(".dwstr"),
-            SectionId::DebugStrOffsets => None,
-            SectionId::DebugTuIndex => None,
-            SectionId::DebugTypes => None,
-        }
-    }
-
     /// Returns the ELF section name for this kind, when found in a .dwo or .dwp file.
     pub fn dwo_name(self) -> Option<&'static str> {
         Some(match self {
@@ -363,6 +335,24 @@ impl SectionId {
             SectionId::DebugStrOffsets => ".debug_str_offsets.dwo",
             SectionId::DebugTuIndex => ".debug_tu_index",
             SectionId::DebugTypes => ".debug_types.dwo",
+            _ => return None,
+        })
+    }
+
+    /// Returns the XCOFF section name for this kind.
+    pub fn xcoff_name(self) -> Option<&'static str> {
+        Some(match self {
+            SectionId::DebugAbbrev => ".dwabrev",
+            SectionId::DebugAranges => ".dwarnge",
+            SectionId::DebugFrame => ".dwframe",
+            SectionId::DebugInfo => ".dwinfo",
+            SectionId::DebugLine => ".dwline",
+            SectionId::DebugLoc => ".dwloc",
+            SectionId::DebugMacinfo => ".dwmac",
+            SectionId::DebugPubNames => ".dwpbnms",
+            SectionId::DebugPubTypes => ".dwpbtyp",
+            SectionId::DebugRanges => ".dwrnges",
+            SectionId::DebugStr => ".dwstr",
             _ => return None,
         })
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -291,7 +291,6 @@ pub enum SectionId {
 
 impl SectionId {
     /// Returns the ELF section name for this kind.
-    #[cfg(not(target_os = "aix"))]
     pub fn name(self) -> &'static str {
         match self {
             SectionId::DebugAbbrev => ".debug_abbrev",
@@ -320,31 +319,30 @@ impl SectionId {
     }
 
     /// Returns the XCOFF section name for this kind.
-    #[cfg(target_os = "aix")]
-    pub fn name(self) -> &'static str {
+    pub fn xcoff_name(self) -> Option<&'static str> {
         match self {
-            SectionId::DebugAbbrev => ".dwabrev",
-            SectionId::DebugAddr => panic!("XCOFF doesn't have debug address section"),
-            SectionId::DebugAranges => ".dwarnge",
-            SectionId::DebugCuIndex => panic!("XCOFF doesn't have debug cu index section"),
-            SectionId::DebugFrame => ".dwframe",
-            SectionId::EhFrame => panic!("XCOFF doesn't have eh frame section"),
-            SectionId::EhFrameHdr => panic!("XCOFF doesn't have eh frame hdr section"),
-            SectionId::DebugInfo => ".dwinfo",
-            SectionId::DebugLine => ".dwline",
-            SectionId::DebugLineStr => panic!("XCOFF doesn't have debug line string section"),
-            SectionId::DebugLoc => ".dwloc",
-            SectionId::DebugLocLists => panic!("XCOFF doesn't have debug loc lists section"),
-            SectionId::DebugMacinfo => ".dwmac",
-            SectionId::DebugMacro => panic!("XCOFF doesn't have debug macro section"),
-            SectionId::DebugPubNames => ".dwpbnms",
-            SectionId::DebugPubTypes => ".dwpbtyp",
-            SectionId::DebugRanges => ".dwrnges",
-            SectionId::DebugRngLists => panic!("XCOFF doesn't have debug range lists section"),
-            SectionId::DebugStr => ".dwstr",
-            SectionId::DebugStrOffsets => panic!("XCOFF doesn't have debug str offsets section"),
-            SectionId::DebugTuIndex => panic!("XCOFF doesn't have debug tu index section"),
-            SectionId::DebugTypes => panic!("XCOFF doesn't have debug type section"),
+            SectionId::DebugAbbrev => Some(".dwabrev"),
+            SectionId::DebugAddr => None,
+            SectionId::DebugAranges => Some(".dwarnge"),
+            SectionId::DebugCuIndex => None,
+            SectionId::DebugFrame => Some(".dwframe"),
+            SectionId::EhFrame => None,
+            SectionId::EhFrameHdr => None,
+            SectionId::DebugInfo => Some(".dwinfo"),
+            SectionId::DebugLine => Some(".dwline"),
+            SectionId::DebugLineStr => None,
+            SectionId::DebugLoc => Some(".dwloc"),
+            SectionId::DebugLocLists => None,
+            SectionId::DebugMacinfo => Some(".dwmac"),
+            SectionId::DebugMacro => None,
+            SectionId::DebugPubNames => Some(".dwpbnms"),
+            SectionId::DebugPubTypes => Some(".dwpbtyp"),
+            SectionId::DebugRanges => Some(".dwrnges"),
+            SectionId::DebugRngLists => None,
+            SectionId::DebugStr => Some(".dwstr"),
+            SectionId::DebugStrOffsets => None,
+            SectionId::DebugTuIndex => None,
+            SectionId::DebugTypes => None,
         }
     }
 

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1129,33 +1129,19 @@ mod tests {
         match dwarf.debug_str.get_str(DebugStrOffset(1)) {
             Ok(r) => panic!("Unexpected str {:?}", r),
             Err(e) => {
-                if cfg!(not(target_os = "aix")) {
-                    assert_eq!(
-                        dwarf.format_error(e),
-                        "Hit the end of input before it was expected at .debug_str+0x1"
-                    );
-                } else {
-                    assert_eq!(
-                        dwarf.format_error(e),
-                        "Hit the end of input before it was expected at .dwstr+0x1"
-                    );
-                }
+                assert_eq!(
+                    dwarf.format_error(e),
+                    "Hit the end of input before it was expected at .debug_str+0x1"
+                );
             }
         }
         match dwarf.sup().unwrap().debug_str.get_str(DebugStrOffset(1)) {
             Ok(r) => panic!("Unexpected str {:?}", r),
             Err(e) => {
-                if cfg!(not(target_os = "aix")) {
-                    assert_eq!(
-                        dwarf.format_error(e),
-                        "Hit the end of input before it was expected at .debug_str(sup)+0x1"
-                    );
-                } else {
-                    assert_eq!(
-                        dwarf.format_error(e),
-                        "Hit the end of input before it was expected at .dwstr(sup)+0x1"
-                    );
-                }
+                assert_eq!(
+                    dwarf.format_error(e),
+                    "Hit the end of input before it was expected at .debug_str(sup)+0x1"
+                );
             }
         }
         assert_eq!(dwarf.format_error(Error::Io), Error::Io.description());

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -1129,19 +1129,33 @@ mod tests {
         match dwarf.debug_str.get_str(DebugStrOffset(1)) {
             Ok(r) => panic!("Unexpected str {:?}", r),
             Err(e) => {
-                assert_eq!(
-                    dwarf.format_error(e),
-                    "Hit the end of input before it was expected at .debug_str+0x1"
-                );
+                if cfg!(not(target_os = "aix")) {
+                    assert_eq!(
+                        dwarf.format_error(e),
+                        "Hit the end of input before it was expected at .debug_str+0x1"
+                    );
+                } else {
+                    assert_eq!(
+                        dwarf.format_error(e),
+                        "Hit the end of input before it was expected at .dwstr+0x1"
+                    );
+                }
             }
         }
         match dwarf.sup().unwrap().debug_str.get_str(DebugStrOffset(1)) {
             Ok(r) => panic!("Unexpected str {:?}", r),
             Err(e) => {
-                assert_eq!(
-                    dwarf.format_error(e),
-                    "Hit the end of input before it was expected at .debug_str(sup)+0x1"
-                );
+                if cfg!(not(target_os = "aix")) {
+                    assert_eq!(
+                        dwarf.format_error(e),
+                        "Hit the end of input before it was expected at .debug_str(sup)+0x1"
+                    );
+                } else {
+                    assert_eq!(
+                        dwarf.format_error(e),
+                        "Hit the end of input before it was expected at .dwstr(sup)+0x1"
+                    );
+                }
             }
         }
         assert_eq!(dwarf.format_error(Error::Io), Error::Io.description());

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -627,6 +627,12 @@ pub trait Section<R>: From<R> {
         Self::id().dwo_name()
     }
 
+    /// Returns the XCOFF section name (if any) for this type when used in a XCOFF
+    /// file.
+    fn xcoff_section_name() -> Option<&'static str> {
+        Self::id().xcoff_name()
+    }
+
     /// Try to load the section using the given loader function.
     fn load<F, E>(f: F) -> core::result::Result<Self, E>
     where


### PR DESCRIPTION
XCOFF has different names for debug sections. This PR adds support for XCOFF which is the default object file format on AIX. Tests on AIX server all pass.
```
rg  '(Running)|(passed)' test.log 
2:     Running unittests src/lib.rs (target/debug/deps/gimli-f009eada21901b94)
464:test result: ok. 458 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
466:     Running tests/convert_self.rs (target/debug/deps/convert_self-6975f7e844e5c08a)
472:test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.04s
474:     Running tests/parse_self.rs (target/debug/deps/parse_self-86a99c3c60cd3793)
488:test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.62s
490:     Running benches/bench.rs (target/debug/deps/bench-74d0874835d90a7c)
517:test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.88s
519:     Running unittests examples/dwarf-validate.rs (target/debug/examples/dwarf_validate-9cebfaaf145a12ef)
523:test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
525:     Running unittests examples/dwarfdump.rs (target/debug/examples/dwarfdump-dfec48f8bc4e68ab)
529:test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
531:     Running unittests examples/simple.rs (target/debug/examples/simple-bfa04b1b769853fc)
535:test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
537:     Running unittests examples/simple_line.rs (target/debug/examples/simple_line-826c47cfd577f13f)
541:test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```