### PR TITLE
When making Dwarfs for DWOs, copy over the supplementary file from the parent.

### DIFF
--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -583,6 +583,7 @@ impl<R: Clone> Dwarf<R> {
         // parent file.
         self.ranges
             .set_debug_ranges(parent.ranges.debug_ranges().clone());
+        self.sup = parent.sup.clone();
     }
 }
 
@@ -802,7 +803,7 @@ impl<R: Reader> DwarfPackage<R> {
             locations: LocationLists::new(debug_loc, debug_loclists),
             ranges: RangeLists::new(debug_ranges, debug_rnglists),
             file_type: DwarfFileType::Dwo,
-            sup: None,
+            sup: parent.sup.clone(),
             abbreviations_cache: AbbreviationsCache::new(),
         })
     }


### PR DESCRIPTION
The spec contemplates that split DWARF and supplementary files can be used together in section B.2. The only tool I know of that generates supplementary files is dwz, which doesn't have any support for split DWARF yet. But there's no inherent reason they can't be used together. While it wouldn't make much sense to do this with unpackaged dwos, it would make a lot of sense to do it with packaged dwps.