### PR TITLE
Update actions/upload-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,11 +61,11 @@ jobs:
       - name: Install `cargo fuzz`
         run: cargo install cargo-fuzz --vers "^0.11.0"
       - run: cargo fuzz build -Oa
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: fuzz-targets
           path: fuzz/target/x86_64-unknown-linux-gnu/release/debug_*
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: fuzz-targets
           path: fuzz/target/x86_64-unknown-linux-gnu/release/eh_*
@@ -99,7 +99,7 @@ jobs:
       # can debug them.
       - name: Upload fuzz artifacts
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.fuzz_target}}_artifacts
           path: ./${{matrix.fuzz_target}}_artifacts


### PR DESCRIPTION
Updates the `actions/upload-artifact` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):
> ## v3.1.2
> Update all `@actions/*` NPM packages to their latest versions
> Update all dev dependencies to their most recent versions
>
> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/upload-artifact` will generate some warning like in this run: https://github.com/gimli-rs/gimli/actions/runs/4181074314

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/upload-artifact`, because v3 uses Node.js 16.