### PR TITLE
Reader::to_{slice,string} -> s/Cow/&//

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -328,12 +328,12 @@ impl<'a, R: gimli::Reader<Offset = usize>> gimli::Reader for Relocate<'a, R> {
     }
 
     #[inline]
-    fn to_slice(&self) -> gimli::Result<Cow<[u8]>> {
+    fn to_slice(&self) -> &[u8] {
         self.reader.to_slice()
     }
 
     #[inline]
-    fn to_string(&self) -> gimli::Result<Cow<str>> {
+    fn to_string(&self) -> gimli::Result<&str> {
         self.reader.to_string()
     }
 
@@ -1364,7 +1364,7 @@ fn dump_attr_value<R: Reader, W: Write>(
             writeln!(w, "0x{:08x}", address)?;
         }
         gimli::AttributeValue::Block(data) => {
-            for byte in data.to_slice()?.iter() {
+            for byte in data.to_slice() {
                 write!(w, "{:02x}", byte)?;
             }
             writeln!(w)?;
@@ -1426,7 +1426,7 @@ fn dump_attr_value<R: Reader, W: Write>(
         gimli::AttributeValue::Exprloc(ref data) => {
             if let gimli::AttributeValue::Exprloc(_) = attr.raw_value() {
                 write!(w, "len 0x{:04x}: ", data.0.len())?;
-                for byte in data.0.to_slice()?.iter() {
+                for byte in data.0.to_slice() {
                     write!(w, "{:02x}", byte)?;
                 }
                 write!(w, ": ")?;
@@ -1783,7 +1783,7 @@ fn dump_op<R: Reader, W: Write>(
             write!(w, " 0x{:08x} offset 0x{:08x}", size_in_bits, bit_offset)?;
         }
         gimli::Operation::ImplicitValue { data } => {
-            let data = data.to_slice()?;
+            let data = data.to_slice();
             write!(w, " 0x{:08x} contents 0x", data.len())?;
             for byte in data.iter() {
                 write!(w, "{:02x}", byte)?;
@@ -1811,7 +1811,7 @@ fn dump_op<R: Reader, W: Write>(
         }
         gimli::Operation::TypedLiteral { base_type, value } => {
             write!(w, " type 0x{:08x} contents 0x", base_type.0)?;
-            for byte in value.to_slice()?.iter() {
+            for byte in value.to_slice() {
                 write!(w, "{:02x}", byte)?;
             }
         }
@@ -2146,7 +2146,7 @@ fn dump_line_program<R: Reader, W: Write>(
             writeln!(w, "Opcodes:")?;
             for (i, length) in header
                 .standard_opcode_lengths()
-                .to_slice()?
+                .to_slice()
                 .iter()
                 .enumerate()
             {

--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -448,12 +448,12 @@ where
     }
 
     #[inline]
-    fn to_slice(&self) -> Result<Cow<[u8]>> {
-        Ok(self.bytes().into())
+    fn to_slice(&self) -> &[u8] {
+        self.bytes().into()
     }
 
     #[inline]
-    fn to_string(&self) -> Result<Cow<str>> {
+    fn to_string(&self) -> Result<&str> {
         match str::from_utf8(self.bytes()) {
             Ok(s) => Ok(s.into()),
             _ => Err(Error::BadUtf8),
@@ -598,10 +598,7 @@ mod tests {
 
     #[test]
     fn to_slice() {
-        assert_eq!(
-            native_reader(BUF).range(2..5).to_slice(),
-            Ok(Cow::from(&BUF[2..5]))
-        );
+        assert_eq!(native_reader(BUF).range(2..5).to_slice(), &BUF[2..5]);
     }
 
     #[test]
@@ -609,7 +606,7 @@ mod tests {
         let buf = b"hello, world!";
         let reader = native_reader(&buf[..]);
         let reader = reader.range_from(7..);
-        assert_eq!(reader.to_string(), Ok(Cow::from("world!")));
+        assert_eq!(reader.to_string(), Ok("world!"));
     }
 
     // The rocket emoji (🚀 = [0xf0, 0x9f, 0x9a, 0x80]) but rotated left by one

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -294,13 +294,13 @@ where
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_slice(&self) -> Result<Cow<[u8]>> {
-        Ok(self.slice.into())
+    fn to_slice(&self) -> &[u8] {
+        self.slice
     }
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_string(&self) -> Result<Cow<str>> {
+    fn to_string(&self) -> Result<&str> {
         match str::from_utf8(self.slice) {
             Ok(s) => Ok(s.into()),
             _ => Err(Error::BadUtf8),

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -274,7 +274,7 @@ pub trait Reader: Debug + Clone {
     ///
     /// Does not advance the reader.
     #[cfg(feature = "read")]
-    fn to_slice(&self) -> Result<Cow<[u8]>>;
+    fn to_slice(&self) -> &[u8];
 
     /// Convert all remaining data to a clone-on-write string.
     ///
@@ -285,7 +285,7 @@ pub trait Reader: Debug + Clone {
     ///
     /// Returns an error if the data contains invalid characters.
     #[cfg(feature = "read")]
-    fn to_string(&self) -> Result<Cow<str>>;
+    fn to_string(&self) -> Result<&str>;
 
     /// Convert all remaining data to a clone-on-write string, including invalid characters.
     ///

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1133,15 +1133,15 @@ mod convert {
             strings: &mut write::StringTable,
         ) -> ConvertResult<LineString> {
             Ok(match from_attr {
-                read::AttributeValue::String(r) => LineString::String(r.to_slice()?.to_vec()),
+                read::AttributeValue::String(r) => LineString::String(r.to_slice().into()),
                 read::AttributeValue::DebugStrRef(offset) => {
                     let r = dwarf.debug_str.get_str(offset)?;
-                    let id = strings.add(r.to_slice()?);
+                    let id = strings.add(r.to_slice());
                     LineString::StringRef(id)
                 }
                 read::AttributeValue::DebugLineStrRef(offset) => {
                     let r = dwarf.debug_line_str.get_str(offset)?;
-                    let id = line_strings.add(r.to_slice()?);
+                    let id = line_strings.add(r.to_slice());
                     LineString::LineStringRef(id)
                 }
                 _ => return Err(ConvertError::UnsupportedLineStringForm),

--- a/src/write/op.rs
+++ b/src/write/op.rs
@@ -982,7 +982,7 @@ pub(crate) mod convert {
                         bit_offset,
                     },
                     read::Operation::ImplicitValue { data } => {
-                        Operation::ImplicitValue(data.to_slice()?.into_owned().into())
+                        Operation::ImplicitValue(data.to_slice().into())
                     }
                     read::Operation::StackValue => Operation::Simple(constants::DW_OP_stack_value),
                     read::Operation::ImplicitPointer { value, byte_offset } => {
@@ -1024,7 +1024,7 @@ pub(crate) mod convert {
                     }
                     read::Operation::TypedLiteral { base_type, value } => {
                         let entry = convert_unit_offset(base_type)?;
-                        Operation::ConstantType(entry, value.to_slice()?.into_owned().into())
+                        Operation::ConstantType(entry, value.to_slice().into())
                     }
                     read::Operation::Convert { base_type } => {
                         if base_type.0 == 0 {

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1740,7 +1740,7 @@ pub(crate) mod convert {
                     Some(val) => AttributeValue::Address(val),
                     None => return Err(ConvertError::InvalidAddress),
                 },
-                read::AttributeValue::Block(r) => AttributeValue::Block(r.to_slice()?.into()),
+                read::AttributeValue::Block(r) => AttributeValue::Block(r.to_slice().into()),
                 read::AttributeValue::Data1(val) => AttributeValue::Data1(val),
                 read::AttributeValue::Data2(val) => AttributeValue::Data2(val),
                 read::AttributeValue::Data4(val) => AttributeValue::Data4(val),
@@ -1851,7 +1851,7 @@ pub(crate) mod convert {
                 read::AttributeValue::DebugTypesRef(val) => AttributeValue::DebugTypesRef(val),
                 read::AttributeValue::DebugStrRef(offset) => {
                     let r = context.dwarf.string(offset)?;
-                    let id = context.strings.add(r.to_slice()?);
+                    let id = context.strings.add(r.to_slice());
                     AttributeValue::StringRef(id)
                 }
                 read::AttributeValue::DebugStrRefSup(val) => AttributeValue::DebugStrRefSup(val),
@@ -1863,15 +1863,15 @@ pub(crate) mod convert {
                 read::AttributeValue::DebugStrOffsetsIndex(index) => {
                     let offset = context.dwarf.string_offset(context.unit, index)?;
                     let r = context.dwarf.string(offset)?;
-                    let id = context.strings.add(r.to_slice()?);
+                    let id = context.strings.add(r.to_slice());
                     AttributeValue::StringRef(id)
                 }
                 read::AttributeValue::DebugLineStrRef(offset) => {
                     let r = context.dwarf.line_string(offset)?;
-                    let id = context.line_strings.add(r.to_slice()?);
+                    let id = context.line_strings.add(r.to_slice());
                     AttributeValue::LineStringRef(id)
                 }
-                read::AttributeValue::String(r) => AttributeValue::String(r.to_slice()?.into()),
+                read::AttributeValue::String(r) => AttributeValue::String(r.to_slice().into()),
                 read::AttributeValue::Encoding(val) => AttributeValue::Encoding(val),
                 read::AttributeValue::DecimalSign(val) => AttributeValue::DecimalSign(val),
                 read::AttributeValue::Endianity(val) => AttributeValue::Endianity(val),


### PR DESCRIPTION
The implementations of these methods always return references; formalize
this in the API. The implementations of `Reader::to_slice` are all
infallible; formalize this as well.
