### PR TITLE
Prevent hidden re-export to be displayed in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,9 @@ pub mod constants;
 pub use crate::constants::*;
 
 mod endianity;
-pub use crate::endianity::{BigEndian, Endianity, LittleEndian, NativeEndian, RunTimeEndian};
+pub use crate::endianity::{BigEndian, Endianity, LittleEndian, RunTimeEndian};
+#[doc(hidden)]
+pub use crate::endianity::NativeEndian;
 
 pub mod leb128;
 


### PR DESCRIPTION
I'm working on https://github.com/rust-lang/rust/pull/109697 and it'll make re-export of doc hidden items visible.

Just one thing I'm wondering: is it intended this way or do you want it to be visible in the documentation? If the latter, I'll just close this PR.