### PR TITLE
Use glob re-export for endianity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod constants;
 pub use crate::constants::*;
 
 mod endianity;
-pub use crate::endianity::{BigEndian, Endianity, LittleEndian, NativeEndian, RunTimeEndian};
+pub use crate::endianity::*;
 
 pub mod leb128;
 


### PR DESCRIPTION
The rust compiler may be changing how it handles re-export of hidden items, such as NativeEndian. This behaviour won't change for glob re-exports, and we're already using globs everywhere else.

Closes #656 