### PR TITLE
Don't include "/fixtures" in published packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,15 @@ categories = ["development-tools::debugging", "development-tools::profiling", "p
 description = "A library for reading and writing the DWARF debugging format."
 documentation = "https://docs.rs/gimli"
 edition = "2018"
-exclude = ["/releases/*", "/.github"]
+include = [
+    "/CHANGELOG.md",
+    "/Cargo.toml",
+    "/examples",
+    "/LICENSE-APACHE",
+    "/LICENSE-MIT",
+    "/README.md",
+    "/src",
+]
 keywords = ["DWARF", "debug", "ELF", "eh_frame"]
 license = "MIT OR Apache-2.0"
 readme = "./README.md"


### PR DESCRIPTION
"/fixtures" is too large for publishing, so don't include it. Currently all of "/tests" and "/benches" require fixtures, so don't include them either.

Also change from using "exclude" to using "include"

Closes #660 