### PR TITLE
Delete From and Index trait impls for EndianSlice

### DIFF
--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -3637,7 +3637,7 @@ mod tests {
                 .uleb(cie.code_alignment_factor)
                 .sleb(cie.data_alignment_factor)
                 .uleb(cie.return_address_register.0.into())
-                .append_bytes(cie.initial_instructions.into())
+                .append_bytes(cie.initial_instructions.slice())
                 .mark(&end);
 
             cie.length = (&end - &start) as usize;
@@ -3732,7 +3732,7 @@ mod tests {
                 section
             };
 
-            let section = section.append_bytes(fde.instructions.into()).mark(&end);
+            let section = section.append_bytes(fde.instructions.slice()).mark(&end);
 
             fde.length = (&end - &start) as usize;
             length.set_const(fde.length as u64);
@@ -6262,7 +6262,6 @@ mod tests {
 
         section.start().set_const(0);
         let section = section.get_contents().unwrap();
-        let section = EndianSlice::new(&section, LittleEndian);
         let eh_frame = kind.section(&section);
 
         // Setup eh_frame_hdr

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -4,7 +4,7 @@
 use alloc::borrow::Cow;
 #[cfg(feature = "read")]
 use alloc::string::String;
-use core::ops::{Deref, Index, Range, RangeFrom, RangeTo};
+use core::ops::{Deref, Range, RangeFrom, RangeTo};
 use core::str;
 
 use crate::endianity::Endianity;
@@ -167,26 +167,6 @@ where
     }
 }
 
-impl<'input, Endian> Index<usize> for EndianSlice<'input, Endian>
-where
-    Endian: Endianity,
-{
-    type Output = u8;
-    fn index(&self, idx: usize) -> &Self::Output {
-        &self.slice[idx]
-    }
-}
-
-impl<'input, Endian> Index<RangeFrom<usize>> for EndianSlice<'input, Endian>
-where
-    Endian: Endianity,
-{
-    type Output = [u8];
-    fn index(&self, idx: RangeFrom<usize>) -> &Self::Output {
-        &self.slice[idx]
-    }
-}
-
 impl<'input, Endian> Deref for EndianSlice<'input, Endian>
 where
     Endian: Endianity,
@@ -194,15 +174,6 @@ where
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         self.slice
-    }
-}
-
-impl<'input, Endian> From<EndianSlice<'input, Endian>> for &'input [u8]
-where
-    Endian: Endianity,
-{
-    fn from(endian_slice: EndianSlice<'input, Endian>) -> &'input [u8] {
-        endian_slice.slice
     }
 }
 

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -2327,7 +2327,7 @@ mod tests {
     fn test_parse_unknown_standard_opcode_many_args() {
         let input = [OPCODE_BASE, 1, 2, 3];
         let input = EndianSlice::new(&input, LittleEndian);
-        let args = EndianSlice::new(&input[1..], LittleEndian);
+        let args = input.range_from(1..);
         let mut standard_opcode_lengths = Vec::new();
         let mut header = make_test_header(input);
         standard_opcode_lengths.extend(header.standard_opcode_lengths.slice());

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -3295,7 +3295,7 @@ mod tests {
                 }
             };
 
-            let section = section.append_bytes(unit.entries_buf.into()).mark(&end);
+            let section = section.append_bytes(unit.entries_buf.slice()).mark(&end);
 
             unit.unit_length = (&end - &start) as usize;
             length.set_const(unit.unit_length as u64);


### PR DESCRIPTION
The From implementation for &[u8] can cause type inference problems. We could change back to only having an Into implementation, but in practice EndianSlice is never used in a generic context that requires this trait, and the &[u8] is easily obtained by either the `slice` method or Deref.

Remove the Index implementation while we're at it, since this is also not useful in practice.

See https://github.com/rust-lang/rust/issues/113238