### PR TITLE
Release 0.28.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        rust_channel: ['stable', 'beta', 'nightly', '1.64.0']
+        rust_channel: ['stable', 'beta', 'nightly', '1.65.0']
         include:
           - rust_channel: stable
             os: macOS-latest
@@ -46,9 +46,9 @@ jobs:
     - name: Install rust
       uses: dtolnay/rust-toolchain@1.60.0
     - name: Build
-      run: cargo build --verbose --no-default-features --features read-all
+      run: cargo build --verbose --no-default-features --features read-all -p gimli
     - name: Test
-      run: cargo test --verbose --no-default-features --features read-all
+      run: cargo test --verbose --no-default-features --features read-all -p gimli
 
   build_fuzz_targets:
     name: Build fuzz targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 --------------------------------------------------------------------------------
 
+## 0.28.0
+
+Released 2023/08/12.
+
+### Breaking changes
+
+* Deleted `impl From<EndianSlice> for &[u8]`. Use `EndianSlice::slice` instead.
+  [#669](https://github.com/gimli-rs/gimli/pull/669)
+
+* Deleted `impl Index<usize> for EndianSlice` and
+  `impl Index<RangeFrom<usize>> for EndianSlice`.
+  [#669](https://github.com/gimli-rs/gimli/pull/669)
+
+* Replaced `impl From<Pointer> for u64` with `Pointer::pointer`.
+  [#670](https://github.com/gimli-rs/gimli/pull/670)
+
+* Updated `fallible-iterator` to 0.3.0.
+  [#672](https://github.com/gimli-rs/gimli/pull/672)
+
+* Changed some optional dependencies to use the `dep:` feature syntax.
+  [#672](https://github.com/gimli-rs/gimli/pull/672)
+
+* Added `non_exhaustive` attribute to `read::RegisterRule`,
+  `read::CallFrameInstruction`, and `write::CallFrameInstruction`.
+  [#673](https://github.com/gimli-rs/gimli/pull/673)
+
+### Changed
+
+* The minimum supported rust version for the `read` feature and its dependencies
+  increased to 1.60.0.
+
+* The minimum supported rust version for other features increased to 1.65.0.
+
+### Added
+
+* Added `Vendor`, `read::DebugFrame::set_vendor`, and `read::EhFrame::set_vendor`.
+  [#673](https://github.com/gimli-rs/gimli/pull/673)
+
+* Added more ARM and AArch64 register definitions, and
+  `DW_CFA_AARCH64_negate_ra_state` support.
+  [#673](https://github.com/gimli-rs/gimli/pull/673)
+
+--------------------------------------------------------------------------------
+
 ## 0.27.3
 
 Released 2023/06/14.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 categories = ["development-tools::debugging", "development-tools::profiling", "parser-implementations"]
 description = "A library for reading and writing the DWARF debugging format."
 documentation = "https://docs.rs/gimli"
@@ -17,6 +17,7 @@ keywords = ["DWARF", "debug", "ELF", "eh_frame"]
 license = "MIT OR Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/gimli-rs/gimli"
+rust-version = "1.60"
 
 [dependencies]
 fallible-iterator = { version = "0.3.0", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gimli = "0.27.3"
+gimli = "0.28.0"
 ```
 
 The minimum supported Rust version is:
 
 * 1.60.0 for the `read` feature and its dependencies.
-* 1.64.0 for other features.
+* 1.65.0 for other features.
 
 ## Documentation
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -10,7 +10,7 @@ fallible-iterator = { version = "0.3.0", default-features = false, optional = tr
 getopts = "0.2"
 memmap2 = "0.7.1"
 num_cpus = "1"
-object = { version = "0.31.1", features = ["wasm"] }
+object = { version = "0.32.0", features = ["wasm"] }
 rayon = "1.0"
 regex = "1"
 typed-arena = "2"


### PR DESCRIPTION
The MSRV increase to 1.65.0 is only needed for examples, but makes CI
testing simpler.