### PR TITLE
Add Unit::new_with_abbreviations() to allow the user to implement custom abbreviations cache

### DIFF
--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -856,6 +856,19 @@ impl<R: Reader> Unit<R> {
     #[inline]
     pub fn new(dwarf: &Dwarf<R>, header: UnitHeader<R>) -> Result<Self> {
         let abbreviations = dwarf.abbreviations(&header)?;
+        Self::new_with_abbreviations(dwarf, header, abbreviations)
+    }
+
+    /// Construct a new `Unit` from the given unit header and abbreviations.
+    ///
+    /// The abbreviations for this call can be obtained using `dwarf.abbreviations(&header)`.
+    /// The caller may implement caching to reuse the Abbreviations across units with the same header.debug_abbrev_offset() value.
+    #[inline]
+    pub fn new_with_abbreviations(
+        dwarf: &Dwarf<R>,
+        header: UnitHeader<R>,
+        abbreviations: Arc<Abbreviations>,
+    ) -> Result<Self> {
         let mut unit = Unit {
             abbreviations,
             name: None,


### PR DESCRIPTION
I noticed that, on one binary, iterating over `.debug_info` units was slow because it re-parsed the same abbreviations multiple times. Adding a cache sped it up from 1.5 seconds to 0.37 seconds.

This particular binary had 33109 compilation units with 5513 unique `debug_abbrev_offset` values, so each `Abbreviations` was parsed 6 times on average.

Gimli's `AbbreviationsCache` was ineffective because:
```
/// Currently this only caches the abbreviations for offset 0,                                                                                                                                                                                                                                                         
/// since this is a common case in which abbreviations are reused.                                                                                                                                                                                                                                                     
/// This strategy may change in future if there is sufficient need.                                                                                                                                                                                                                                                    
```
(In this case the abbreviations at offset 0 were used by only one unit, and all the reused abbreviations were at other offsets.)

This PR doesn't change `AbbreviationsCache`, but adds a trivial provision to allow the user to do their own caching of abbreviations. (A trivial `HashMap` works fine in my case, but idk whether it would be good enough for all gimli users.)