### PR TITLE
ci: switch to powerpc64 for big endian test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,7 @@ jobs:
           # A 32-bit target.
           - i686-unknown-linux-gnu
           # A big-endian target
-          - mips64-unknown-linux-gnuabi64
+          - powerpc64-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
mips64 isn't available currently.