### PR TITLE
read: shorten Debug output for EndianSlice

### DIFF
--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -4,6 +4,7 @@
 use alloc::borrow::Cow;
 #[cfg(feature = "read")]
 use alloc::string::String;
+use core::fmt;
 use core::ops::{Deref, Range, RangeFrom, RangeTo};
 use core::str;
 
@@ -13,7 +14,7 @@ use crate::read::{Error, Reader, ReaderOffsetId, Result};
 /// A `&[u8]` slice with endianity metadata.
 ///
 /// This implements the `Reader` trait, which is used for all reading of DWARF sections.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EndianSlice<'input, Endian>
 where
     Endian: Endianity,
@@ -174,6 +175,44 @@ where
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         self.slice
+    }
+}
+
+impl<'input, Endian: Endianity> fmt::Debug for EndianSlice<'input, Endian> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> core::result::Result<(), fmt::Error> {
+        fmt.debug_tuple("EndianSlice")
+            .field(&self.endian)
+            .field(&DebugBytes(self.slice))
+            .finish()
+    }
+}
+
+struct DebugBytes<'input>(&'input [u8]);
+
+impl<'input> core::fmt::Debug for DebugBytes<'input> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> core::result::Result<(), fmt::Error> {
+        let mut list = fmt.debug_list();
+        list.entries(self.0.iter().take(8).copied().map(DebugByte));
+        if self.0.len() > 8 {
+            list.entry(&DebugLen(self.0.len()));
+        }
+        list.finish()
+    }
+}
+
+struct DebugByte(u8);
+
+impl fmt::Debug for DebugByte {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "0x{:02x}", self.0)
+    }
+}
+
+struct DebugLen(usize);
+
+impl fmt::Debug for DebugLen {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "...; {}", self.0)
     }
 }
 


### PR DESCRIPTION
These often contain entire sections, and it's not useful to display everything in the section.