### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -182,7 +182,7 @@ where
             .and_then(|x| x.checked_add(segment_size))
             .ok_or(Error::InvalidAddressRange)?;
         if tuple_length == 0 {
-            return Err(Error::InvalidAddressRange)?;
+            return Err(Error::InvalidAddressRange);
         }
         let padding = if header_length % tuple_length == 0 {
             0

--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -393,8 +393,8 @@ where
 
     #[inline]
     fn offset_from(&self, base: &EndianReader<Endian, T>) -> usize {
-        let base_ptr = base.bytes().as_ptr() as *const u8 as usize;
-        let ptr = self.bytes().as_ptr() as *const u8 as usize;
+        let base_ptr = base.bytes().as_ptr() as usize;
+        let ptr = self.bytes().as_ptr() as usize;
         debug_assert!(base_ptr <= ptr);
         debug_assert!(ptr + self.bytes().len() <= base_ptr + base.bytes().len());
         ptr - base_ptr

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -68,8 +68,8 @@ where
     /// of the given slice.
     #[inline]
     pub fn offset_from(&self, base: EndianSlice<'input, Endian>) -> usize {
-        let base_ptr = base.slice.as_ptr() as *const u8 as usize;
-        let ptr = self.slice.as_ptr() as *const u8 as usize;
+        let base_ptr = base.slice.as_ptr() as usize;
+        let ptr = self.slice.as_ptr() as usize;
         debug_assert!(base_ptr <= ptr);
         debug_assert!(ptr + self.slice.len() <= base_ptr + base.slice.len());
         ptr - base_ptr

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -199,7 +199,7 @@ impl Value {
             Value::I32(value) => value as u64,
             Value::U32(value) => u64::from(value),
             Value::I64(value) => value as u64,
-            Value::U64(value) => value as u64,
+            Value::U64(value) => value,
             _ => return Err(Error::IntegralTypeRequired),
         };
         Ok(value)

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -410,7 +410,7 @@ mod convert {
                 // In some cases, existing data may contain begin == end, filtering
                 // these out.
                 match loc {
-                    Location::StartLength { length, .. } if length == 0 => continue,
+                    Location::StartLength { length: 0, .. } => continue,
                     Location::StartEnd { begin, end, .. } if begin == end => continue,
                     Location::OffsetPair { begin, end, .. } if begin == end => continue,
                     _ => (),

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -288,7 +288,7 @@ mod convert {
                 };
                 // Filtering empty ranges out.
                 match range {
-                    Range::StartLength { length, .. } if length == 0 => continue,
+                    Range::StartLength { length: 0, .. } => continue,
                     Range::StartEnd { begin, end, .. } if begin == end => continue,
                     Range::OffsetPair { begin, end, .. } if begin == end => continue,
                     _ => (),

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1098,7 +1098,7 @@ impl AttributeValue {
             }
             AttributeValue::AddressClass(val) => {
                 debug_assert_form!(constants::DW_FORM_udata);
-                uleb128_size(val.0 as u64)
+                uleb128_size(val.0)
             }
             AttributeValue::IdentifierCase(val) => {
                 debug_assert_form!(constants::DW_FORM_udata);


### PR DESCRIPTION
This PR makes these commands return no warnings (except "unknown lint" from 1.60 for  `clippy::bool_to_int_with_if` and `clippy::derive_partial_eq_without_eq`).

```sh
cargo +1.75 clippy --lib    # current stable version
cargo +1.65 clippy --lib
cargo +1.60 clippy --lib --no-default-features --features read
```

In the case of `#![allow(clippy::unnecessary_cast)]` the current code is by my estimation clearer and more symmetric than the code clippy would want, so I ended up allowing unnecessary casts.