### PR TITLE
src/read/abbrev.rs: Mark mod tests as pub(crate)

### DIFF
--- a/src/read/abbrev.rs
+++ b/src/read/abbrev.rs
@@ -641,7 +641,7 @@ pub(crate) fn get_attribute_size(form: constants::DwForm, encoding: Encoding) ->
 }
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::constants;
     use crate::endianity::LittleEndian;


### PR DESCRIPTION
Fixes "warning: private item shadows public glob re-export" when doing "cargo test". Before the fix, the warning looks like this:

```
warning: private item shadows public glob re-export
   --> src/read/mod.rs:681:1
    |
681 | / mod tests {
682 | |     use super::*;
683 | |     use crate::common::Format;
684 | |     use crate::endianity::LittleEndian;
...   |
826 | |     }
827 | | }
    | |_^
    |
note: the name `tests` in the type namespace is supposed to be publicly re-exported here
   --> src/read/mod.rs:208:9
    |
208 | pub use self::abbrev::*;
    |         ^^^^^^^^^^^^^^^
note: but the private item here shadows it
   --> src/read/mod.rs:681:1
    |
681 | / mod tests {
682 | |     use super::*;
683 | |     use crate::common::Format;
684 | |     use crate::endianity::LittleEndian;
...   |
826 | |     }
827 | | }
    | |_^
    = note: `#[warn(hidden_glob_reexports)]` on by default
```

With the fix, there is no warning.