### PR TITLE
Add lifetime to Section references

### DIFF
--- a/src/write/section.rs
+++ b/src/write/section.rs
@@ -121,9 +121,9 @@ impl<W: Writer + Clone> Sections<W> {
 
 impl<W: Writer> Sections<W> {
     /// For each section, call `f` once with a shared reference.
-    pub fn for_each<F, E>(&self, mut f: F) -> result::Result<(), E>
+    pub fn for_each<'a, F, E>(&'a self, mut f: F) -> result::Result<(), E>
     where
-        F: FnMut(SectionId, &W) -> result::Result<(), E>,
+        F: FnMut(SectionId, &'a W) -> result::Result<(), E>,
     {
         macro_rules! f {
             ($s:expr) => {
@@ -146,9 +146,9 @@ impl<W: Writer> Sections<W> {
     }
 
     /// For each section, call `f` once with a mutable reference.
-    pub fn for_each_mut<F, E>(&mut self, mut f: F) -> result::Result<(), E>
+    pub fn for_each_mut<'a, F, E>(&'a mut self, mut f: F) -> result::Result<(), E>
     where
-        F: FnMut(SectionId, &mut W) -> result::Result<(), E>,
+        F: FnMut(SectionId, &'a mut W) -> result::Result<(), E>,
     {
         macro_rules! f {
             ($s:expr) => {


### PR DESCRIPTION
By providing the lifetime of the Sections struct to the closure, the user can hold references to the data if neccesary. 

Motivating Example:
```rust
use gimli::write::{DwarfUnit, EndianVec, Sections};

fn main() {
    let encoding = gimli::Encoding {
        format: gimli::Format::Dwarf32,
        version: 5,
        address_size: 8,
    };
    // Create a container for a single compilation unit.
    let mut dwarf = DwarfUnit::new(encoding);

    let mut sections = Sections::new(EndianVec::new(gimli::LittleEndian));
    // Finally, write the DWARF data to the sections.
    dwarf.write(&mut sections).unwrap();
    {
        let mut vec: Vec<&[u8]> = vec![];
        sections
            .for_each(|_id, data| {
                vec.push(data.slice());
                Result::<(), ()>::Ok(())
            })
            .unwrap();
        println!("{}", vec.len());
    }
    {
        let mut vec: Vec<&mut _> = vec![];
        sections
            .for_each_mut(|_id, data| {
                vec.push(data);
                Result::<(), ()>::Ok(())
            })
            .unwrap();
        println!("{}", vec.len());
    }
}

```