### PR TITLE
Fix Op::ImplicitPointer::size() to match Op::ImplicitPointer::write()

### DIFF
--- a/src/write/op.rs
+++ b/src/write/op.rs
@@ -1077,7 +1077,7 @@ mod tests {
     #[test]
     #[allow(clippy::type_complexity)]
     fn test_operation() {
-        for version in [3, 4, 5] {
+        for version in [2, 3, 4, 5] {
             for address_size in [4, 8] {
                 for format in [Format::Dwarf32, Format::Dwarf64] {
                     let encoding = Encoding {

--- a/src/write/op.rs
+++ b/src/write/op.rs
@@ -566,7 +566,12 @@ impl Operation {
             }
             Operation::ImplicitValue(ref data) => uleb128_size(data.len() as u64) + data.len(),
             Operation::ImplicitPointer { byte_offset, .. } => {
-                encoding.format.word_size() as usize + sleb128_size(byte_offset)
+                let size = if encoding.version == 2 {
+                    encoding.address_size
+                } else {
+                    encoding.format.word_size()
+                };
+                size as usize + sleb128_size(byte_offset)
             }
             Operation::Piece { size_in_bytes } => uleb128_size(size_in_bytes),
             Operation::BitPiece {


### PR DESCRIPTION
The `size` function  did not mirror the corresponding size adjustment based on dwarf version 2 found in `write` causing an assertion to fail due to a mismatch between the expected location and the actual write location.

```
thread '<unnamed>' panicked at /home/crzysdrs/proj/gimli/src/write/unit.rs:620:9:
assertion `left == right` failed
  left: DebugInfoOffset(1324)
 right: DebugInfoOffset(1328)
 ```

This looks like an oversight on my part when contributing #618.