### PR TITLE
Fix 'hidden lifetime parameters in types are deprecated'

### DIFF
--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -28,7 +28,7 @@ pub enum Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         Debug::fmt(self, f)
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -51,7 +51,7 @@ use core::{fmt, ops};
 //     }
 //
 //     impl fmt::Display for DwFoo {
-//         fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+//         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
 //             ...
 //         }
 //     }
@@ -83,7 +83,7 @@ macro_rules! dw {
         }
 
         impl fmt::Display for $struct_name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
                 if let Some(s) = self.static_string() {
                     f.pad(s)
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 #![warn(bare_trait_objects)]
 #![warn(unused_extern_crates)]
 #![warn(ellipsis_inclusive_range_patterns)]
-//#![warn(elided_lifetimes_in_paths)]
+#![warn(elided_lifetimes_in_paths)]
 #![warn(explicit_outlives_requirements)]
 // Style.
 #![allow(clippy::bool_to_int_with_if)]

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -540,7 +540,7 @@ impl<R: Reader> Dwarf<R> {
     pub fn die_ranges(
         &self,
         unit: &Unit<R>,
-        entry: &DebuggingInformationEntry<R>,
+        entry: &DebuggingInformationEntry<'_, '_, R>,
     ) -> Result<RangeIter<R>> {
         let mut low_pc = None;
         let mut high_pc = None;
@@ -992,7 +992,7 @@ impl<R: Reader> DwarfPackage<R> {
     /// This function should only be needed by low level parsers.
     pub fn sections(
         &self,
-        sections: UnitIndexSectionIterator<R>,
+        sections: UnitIndexSectionIterator<'_, R>,
         parent: &Dwarf<R>,
     ) -> Result<Dwarf<R>> {
         let mut abbrev_offset = 0;
@@ -1276,33 +1276,45 @@ impl<R: Reader> Unit<R> {
     }
 
     /// Read the `DebuggingInformationEntry` at the given offset.
-    pub fn entry(&self, offset: UnitOffset<R::Offset>) -> Result<DebuggingInformationEntry<R>> {
+    pub fn entry(
+        &self,
+        offset: UnitOffset<R::Offset>,
+    ) -> Result<DebuggingInformationEntry<'_, '_, R>> {
         self.header.entry(&self.abbreviations, offset)
     }
 
     /// Navigate this unit's `DebuggingInformationEntry`s.
     #[inline]
-    pub fn entries(&self) -> EntriesCursor<R> {
+    pub fn entries(&self) -> EntriesCursor<'_, '_, R> {
         self.header.entries(&self.abbreviations)
     }
 
     /// Navigate this unit's `DebuggingInformationEntry`s
     /// starting at the given offset.
     #[inline]
-    pub fn entries_at_offset(&self, offset: UnitOffset<R::Offset>) -> Result<EntriesCursor<R>> {
+    pub fn entries_at_offset(
+        &self,
+        offset: UnitOffset<R::Offset>,
+    ) -> Result<EntriesCursor<'_, '_, R>> {
         self.header.entries_at_offset(&self.abbreviations, offset)
     }
 
     /// Navigate this unit's `DebuggingInformationEntry`s as a tree
     /// starting at the given offset.
     #[inline]
-    pub fn entries_tree(&self, offset: Option<UnitOffset<R::Offset>>) -> Result<EntriesTree<R>> {
+    pub fn entries_tree(
+        &self,
+        offset: Option<UnitOffset<R::Offset>>,
+    ) -> Result<EntriesTree<'_, '_, R>> {
         self.header.entries_tree(&self.abbreviations, offset)
     }
 
     /// Read the raw data that defines the Debugging Information Entries.
     #[inline]
-    pub fn entries_raw(&self, offset: Option<UnitOffset<R::Offset>>) -> Result<EntriesRaw<R>> {
+    pub fn entries_raw(
+        &self,
+        offset: Option<UnitOffset<R::Offset>>,
+    ) -> Result<EntriesRaw<'_, '_, R>> {
         self.header.entries_raw(&self.abbreviations, offset)
     }
 
@@ -1466,7 +1478,7 @@ impl<'a, R: Reader> UnitRef<'a, R> {
     /// Return an iterator for the address ranges of a `DebuggingInformationEntry`.
     ///
     /// This uses `DW_AT_low_pc`, `DW_AT_high_pc` and `DW_AT_ranges`.
-    pub fn die_ranges(&self, entry: &DebuggingInformationEntry<R>) -> Result<RangeIter<R>> {
+    pub fn die_ranges(&self, entry: &DebuggingInformationEntry<'_, '_, R>) -> Result<RangeIter<R>> {
         self.dwarf.die_ranges(self.unit, entry)
     }
 
@@ -1634,8 +1646,8 @@ mod tests {
     #[test]
     fn test_send() {
         fn assert_is_send<T: Send>() {}
-        assert_is_send::<Dwarf<EndianSlice<LittleEndian>>>();
-        assert_is_send::<Unit<EndianSlice<LittleEndian>>>();
+        assert_is_send::<Dwarf<EndianSlice<'_, LittleEndian>>>();
+        assert_is_send::<Unit<EndianSlice<'_, LittleEndian>>>();
     }
 
     #[test]

--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -448,12 +448,12 @@ where
     }
 
     #[inline]
-    fn to_slice(&self) -> Result<Cow<[u8]>> {
+    fn to_slice(&self) -> Result<Cow<'_, [u8]>> {
         Ok(self.bytes().into())
     }
 
     #[inline]
-    fn to_string(&self) -> Result<Cow<str>> {
+    fn to_string(&self) -> Result<Cow<'_, str>> {
         match str::from_utf8(self.bytes()) {
             Ok(s) => Ok(s.into()),
             _ => Err(Error::BadUtf8),
@@ -461,7 +461,7 @@ where
     }
 
     #[inline]
-    fn to_string_lossy(&self) -> Result<Cow<str>> {
+    fn to_string_lossy(&self) -> Result<Cow<'_, str>> {
         Ok(String::from_utf8_lossy(self.bytes()))
     }
 

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -304,13 +304,13 @@ where
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_slice(&self) -> Result<Cow<[u8]>> {
+    fn to_slice(&self) -> Result<Cow<'_, [u8]>> {
         Ok(self.slice.into())
     }
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_string(&self) -> Result<Cow<str>> {
+    fn to_string(&self) -> Result<Cow<'_, str>> {
         match str::from_utf8(self.slice) {
             Ok(s) => Ok(s.into()),
             _ => Err(Error::BadUtf8),
@@ -319,7 +319,7 @@ where
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_string_lossy(&self) -> Result<Cow<str>> {
+    fn to_string_lossy(&self) -> Result<Cow<'_, str>> {
         Ok(String::from_utf8_lossy(self.slice))
     }
 

--- a/src/read/index.rs
+++ b/src/read/index.rs
@@ -256,7 +256,7 @@ impl<R: Reader> UnitIndex<R> {
     }
 
     /// Return the section offsets and sizes for the given row index.
-    pub fn sections(&self, mut row: u32) -> Result<UnitIndexSectionIterator<R>> {
+    pub fn sections(&self, mut row: u32) -> Result<UnitIndexSectionIterator<'_, R>> {
         if row == 0 {
             return Err(Error::InvalidIndexRow);
         }

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -521,7 +521,7 @@ where
     R: Reader<Offset = Offset>,
     Offset: ReaderOffset,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         match *self {
             LineInstruction::Special(opcode) => write!(f, "Special opcode {}", opcode),
             LineInstruction::Copy => write!(f, "{}", constants::DW_LNS_copy),
@@ -2124,8 +2124,8 @@ mod tests {
     const STANDARD_OPCODE_LENGTHS: &[u8] = &[0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1];
 
     fn make_test_header(
-        buf: EndianSlice<LittleEndian>,
-    ) -> LineProgramHeader<EndianSlice<LittleEndian>> {
+        buf: EndianSlice<'_, LittleEndian>,
+    ) -> LineProgramHeader<EndianSlice<'_, LittleEndian>> {
         let encoding = Encoding {
             format: Format::Dwarf32,
             version: 4,
@@ -2170,8 +2170,8 @@ mod tests {
     }
 
     fn make_test_program(
-        buf: EndianSlice<LittleEndian>,
-    ) -> IncompleteLineProgram<EndianSlice<LittleEndian>> {
+        buf: EndianSlice<'_, LittleEndian>,
+    ) -> IncompleteLineProgram<EndianSlice<'_, LittleEndian>> {
         IncompleteLineProgram {
             header: make_test_header(buf),
         }
@@ -2198,7 +2198,7 @@ mod tests {
         fn test<Operands>(
             raw: constants::DwLns,
             operands: Operands,
-            expected: LineInstruction<EndianSlice<LittleEndian>>,
+            expected: LineInstruction<EndianSlice<'_, LittleEndian>>,
         ) where
             Operands: AsRef<[u8]>,
         {
@@ -2341,7 +2341,7 @@ mod tests {
         fn test<Operands>(
             raw: constants::DwLne,
             operands: Operands,
-            expected: LineInstruction<EndianSlice<LittleEndian>>,
+            expected: LineInstruction<EndianSlice<'_, LittleEndian>>,
         ) where
             Operands: AsRef<[u8]>,
         {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -442,7 +442,7 @@ pub enum Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::core::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::core::result::Result<(), fmt::Error> {
         write!(f, "{}", self.description())
     }
 }

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -2095,7 +2095,7 @@ mod tests {
 
     fn check_op_parse<F>(
         input: F,
-        expect: &Operation<EndianSlice<LittleEndian>>,
+        expect: &Operation<EndianSlice<'_, LittleEndian>>,
         encoding: Encoding,
     ) where
         F: Fn(Section) -> Section,
@@ -2918,7 +2918,7 @@ mod tests {
 
     fn check_eval_with_args<F>(
         program: &[AssemblerEntry],
-        expect: Result<&[Piece<EndianSlice<LittleEndian>>]>,
+        expect: Result<&[Piece<EndianSlice<'_, LittleEndian>>]>,
         encoding: Encoding,
         object_address: Option<u64>,
         initial_value: Option<u64>,
@@ -2967,7 +2967,7 @@ mod tests {
 
     fn check_eval(
         program: &[AssemblerEntry],
-        expect: Result<&[Piece<EndianSlice<LittleEndian>>]>,
+        expect: Result<&[Piece<EndianSlice<'_, LittleEndian>>]>,
         encoding: Encoding,
     ) {
         check_eval_with_args(program, expect, encoding, None, None, None, |_, result| {

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -274,7 +274,7 @@ pub trait Reader: Debug + Clone {
     ///
     /// Does not advance the reader.
     #[cfg(feature = "read")]
-    fn to_slice(&self) -> Result<Cow<[u8]>>;
+    fn to_slice(&self) -> Result<Cow<'_, [u8]>>;
 
     /// Convert all remaining data to a clone-on-write string.
     ///
@@ -285,7 +285,7 @@ pub trait Reader: Debug + Clone {
     ///
     /// Returns an error if the data contains invalid characters.
     #[cfg(feature = "read")]
-    fn to_string(&self) -> Result<Cow<str>>;
+    fn to_string(&self) -> Result<Cow<'_, str>>;
 
     /// Convert all remaining data to a clone-on-write string, including invalid characters.
     ///
@@ -294,7 +294,7 @@ pub trait Reader: Debug + Clone {
     ///
     /// Does not advance the reader.
     #[cfg(feature = "read")]
-    fn to_string_lossy(&self) -> Result<Cow<str>>;
+    fn to_string_lossy(&self) -> Result<Cow<'_, str>>;
 
     /// Read exactly `buf.len()` bytes into `buf`.
     fn read_slice(&mut self, buf: &mut [u8]) -> Result<()>;

--- a/src/read/relocate.rs
+++ b/src/read/relocate.rs
@@ -130,19 +130,19 @@ where
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_slice(&self) -> Result<Cow<[u8]>> {
+    fn to_slice(&self) -> Result<Cow<'_, [u8]>> {
         self.reader.to_slice()
     }
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_string(&self) -> Result<Cow<str>> {
+    fn to_string(&self) -> Result<Cow<'_, str>> {
         self.reader.to_string()
     }
 
     #[cfg(feature = "read")]
     #[inline]
-    fn to_string_lossy(&self) -> Result<Cow<str>> {
+    fn to_string_lossy(&self) -> Result<Cow<'_, str>> {
         self.reader.to_string_lossy()
     }
 

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -4189,7 +4189,7 @@ mod tests {
     fn test_attribute_udata_sdata_value() {
         #[allow(clippy::type_complexity)]
         let tests: &[(
-            AttributeValue<EndianSlice<LittleEndian>>,
+            AttributeValue<EndianSlice<'_, LittleEndian>>,
             Option<u64>,
             Option<i64>,
         )] = &[
@@ -5036,8 +5036,10 @@ mod tests {
         assert!(entry.attrs_len.get().is_none());
     }
 
-    fn assert_entry_name<Endian>(entry: &DebuggingInformationEntry<EndianSlice<Endian>>, name: &str)
-    where
+    fn assert_entry_name<Endian>(
+        entry: &DebuggingInformationEntry<'_, '_, EndianSlice<'_, Endian>>,
+        name: &str,
+    ) where
         Endian: Endianity,
     {
         let value = entry
@@ -5051,16 +5053,20 @@ mod tests {
         );
     }
 
-    fn assert_current_name<Endian>(cursor: &EntriesCursor<EndianSlice<Endian>>, name: &str)
-    where
+    fn assert_current_name<Endian>(
+        cursor: &EntriesCursor<'_, '_, EndianSlice<'_, Endian>>,
+        name: &str,
+    ) where
         Endian: Endianity,
     {
         let entry = cursor.current().expect("Should have an entry result");
         assert_entry_name(entry, name);
     }
 
-    fn assert_next_entry<Endian>(cursor: &mut EntriesCursor<EndianSlice<Endian>>, name: &str)
-    where
+    fn assert_next_entry<Endian>(
+        cursor: &mut EntriesCursor<'_, '_, EndianSlice<'_, Endian>>,
+        name: &str,
+    ) where
         Endian: Endianity,
     {
         cursor
@@ -5070,7 +5076,7 @@ mod tests {
         assert_current_name(cursor, name);
     }
 
-    fn assert_next_entry_null<Endian>(cursor: &mut EntriesCursor<EndianSlice<Endian>>)
+    fn assert_next_entry_null<Endian>(cursor: &mut EntriesCursor<'_, '_, EndianSlice<'_, Endian>>)
     where
         Endian: Endianity,
     {
@@ -5082,7 +5088,7 @@ mod tests {
     }
 
     fn assert_next_dfs<Endian>(
-        cursor: &mut EntriesCursor<EndianSlice<Endian>>,
+        cursor: &mut EntriesCursor<'_, '_, EndianSlice<'_, Endian>>,
         name: &str,
         depth: isize,
     ) where
@@ -5099,8 +5105,10 @@ mod tests {
         assert_current_name(cursor, name);
     }
 
-    fn assert_next_sibling<Endian>(cursor: &mut EntriesCursor<EndianSlice<Endian>>, name: &str)
-    where
+    fn assert_next_sibling<Endian>(
+        cursor: &mut EntriesCursor<'_, '_, EndianSlice<'_, Endian>>,
+        name: &str,
+    ) where
         Endian: Endianity,
     {
         {
@@ -5113,7 +5121,7 @@ mod tests {
         assert_current_name(cursor, name);
     }
 
-    fn assert_valid_sibling_ptr<Endian>(cursor: &EntriesCursor<EndianSlice<Endian>>)
+    fn assert_valid_sibling_ptr<Endian>(cursor: &EntriesCursor<'_, '_, EndianSlice<'_, Endian>>)
     where
         Endian: Endianity,
     {
@@ -5493,7 +5501,9 @@ mod tests {
         section.get_contents().unwrap()
     }
 
-    fn test_cursor_next_sibling_with_ptr(cursor: &mut EntriesCursor<EndianSlice<LittleEndian>>) {
+    fn test_cursor_next_sibling_with_ptr(
+        cursor: &mut EntriesCursor<'_, '_, EndianSlice<'_, LittleEndian>>,
+    ) {
         assert_next_dfs(cursor, "001", 0);
 
         // Down to the first child of the root.
@@ -5700,7 +5710,9 @@ mod tests {
             node.children()
         }
 
-        fn assert_null<E: Endianity>(node: Result<Option<EntriesTreeNode<EndianSlice<E>>>>) {
+        fn assert_null<E: Endianity>(
+            node: Result<Option<EntriesTreeNode<'_, '_, '_, EndianSlice<'_, E>>>>,
+        ) {
             match node {
                 Ok(None) => {}
                 otherwise => {

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -109,7 +109,7 @@ impl ValueType {
     /// Construct a `ValueType` from a base type DIE.
     #[cfg(feature = "read")]
     pub fn from_entry<R: Reader>(
-        entry: &DebuggingInformationEntry<R>,
+        entry: &DebuggingInformationEntry<'_, '_, R>,
     ) -> Result<Option<ValueType>> {
         if entry.tag() != constants::DW_TAG_base_type {
             return Ok(None);

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -305,7 +305,7 @@ mod convert {
         /// Create a location list by reading the data from the give location list iter.
         pub(crate) fn from<R: Reader<Offset = usize>>(
             mut from: read::RawLocListIter<R>,
-            context: &ConvertUnitContext<R>,
+            context: &ConvertUnitContext<'_, R>,
         ) -> ConvertResult<Self> {
             let mut have_base_address = context.base_address != Address::Constant(0);
             let convert_address =

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -204,7 +204,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         match *self {
             Error::OffsetOutOfBounds => write!(f, "The given offset is out of bounds."),
             Error::LengthOutOfBounds => write!(f, "The given length is out of bounds."),
@@ -364,7 +364,7 @@ mod convert {
     }
 
     impl fmt::Display for ConvertError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
             use self::ConvertError::*;
             match *self {
                 Read(ref e) => e.fmt(f),

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -221,7 +221,7 @@ mod convert {
         /// Create a range list by reading the data from the give range list iter.
         pub(crate) fn from<R: Reader<Offset = usize>>(
             mut from: read::RawRngListIter<R>,
-            context: &ConvertUnitContext<R>,
+            context: &ConvertUnitContext<'_, R>,
         ) -> ConvertResult<Self> {
             let mut have_base_address = context.base_address != Address::Constant(0);
             let convert_address =


### PR DESCRIPTION
I am messing around with Rust's standard library and gimli. In my particular setup, Rust's build system tries to build gimli in a way that can be simulated like this:

```
cargo rustc --  -Wrust_2018_idioms -Wunused_lifetimes -Dwarnings
```

When build that way, the master branch fails with a bunch of errors like this:

```
error: hidden lifetime parameters in types are deprecated
```

This PR fixes that.