### PR TITLE
Allow invalid ranges in RngListIter

### DIFF
--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -650,13 +650,8 @@ impl<R: Reader> LocListIter<R> {
             }
         };
 
-        if range.begin == tombstone {
+        if range.begin == tombstone || range.begin > range.end {
             return Ok(None);
-        }
-
-        if range.begin > range.end {
-            self.raw.input.empty();
-            return Err(Error::InvalidLocationAddressRange);
         }
 
         Ok(Some(LocationListEntry { range, data }))
@@ -1522,7 +1517,7 @@ mod tests {
                 debug_addr_base,
             )
             .unwrap();
-        assert_eq!(locations.next(), Err(Error::InvalidLocationAddressRange));
+        assert_eq!(locations.next(), Ok(None));
 
         // An invalid location range after wrapping.
         let mut locations = loclists
@@ -1534,7 +1529,7 @@ mod tests {
                 debug_addr_base,
             )
             .unwrap();
-        assert_eq!(locations.next(), Err(Error::InvalidLocationAddressRange));
+        assert_eq!(locations.next(), Ok(None));
 
         // An invalid offset.
         match loclists.locations(

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -382,8 +382,6 @@ pub enum Error {
     UnknownCallFrameInstruction(constants::DwCfa),
     /// The end of an address range was before the beginning.
     InvalidAddressRange,
-    /// The end offset of a loc list entry was before the beginning.
-    InvalidLocationAddressRange,
     /// Encountered a call frame instruction in a context in which it is not
     /// valid.
     CfiInstructionInInvalidContext,
@@ -536,9 +534,6 @@ impl Error {
             Error::UnknownCallFrameInstruction(_) => "An unknown DW_CFA_* instructiion",
             Error::InvalidAddressRange => {
                 "The end of an address range must not be before the beginning."
-            }
-            Error::InvalidLocationAddressRange => {
-                "The end offset of a location list entry must not be before the beginning."
             }
             Error::CfiInstructionInInvalidContext => {
                 "Encountered a call frame instruction in a context in which it is not valid."

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -569,7 +569,7 @@ impl<R: Reader> RngListIter<R> {
             }
         };
 
-        if range.begin == tombstone {
+        if range.begin == tombstone || range.begin > range.end {
             return Ok(None);
         }
 
@@ -1397,13 +1397,7 @@ mod tests {
                 debug_addr_base,
             )
             .unwrap();
-        assert_eq!(
-            ranges.next(),
-            Ok(Some(Range {
-                begin: 0x0102_0000,
-                end: 0x0101_0000
-            }))
-        );
+        assert_eq!(ranges.next(), Ok(None));
 
         // An invalid range after wrapping.
         let mut ranges = rnglists
@@ -1415,13 +1409,7 @@ mod tests {
                 debug_addr_base,
             )
             .unwrap();
-        assert_eq!(
-            ranges.next(),
-            Ok(Some(Range {
-                begin: 0x0102_0000,
-                end: 0x0001_0000
-            }))
-        );
+        assert_eq!(ranges.next(), Ok(None));
 
         // An invalid offset.
         match rnglists.ranges(

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -573,11 +573,6 @@ impl<R: Reader> RngListIter<R> {
             return Ok(None);
         }
 
-        if range.begin > range.end {
-            self.raw.input.empty();
-            return Err(Error::InvalidAddressRange);
-        }
-
         Ok(Some(range))
     }
 }
@@ -1402,7 +1397,13 @@ mod tests {
                 debug_addr_base,
             )
             .unwrap();
-        assert_eq!(ranges.next(), Err(Error::InvalidAddressRange));
+        assert_eq!(
+            ranges.next(),
+            Ok(Some(Range {
+                begin: 0x0102_0000,
+                end: 0x0101_0000
+            }))
+        );
 
         // An invalid range after wrapping.
         let mut ranges = rnglists
@@ -1414,7 +1415,13 @@ mod tests {
                 debug_addr_base,
             )
             .unwrap();
-        assert_eq!(ranges.next(), Err(Error::InvalidAddressRange));
+        assert_eq!(
+            ranges.next(),
+            Ok(Some(Range {
+                begin: 0x0102_0000,
+                end: 0x0001_0000
+            }))
+        );
 
         // An invalid offset.
         match rnglists.ranges(


### PR DESCRIPTION
I thought it would be easiest to describe the issue I'm encountering with a patch, but I'm not attached to this particular solution if folks would prefer some other approach.

I've encountered a toolchain which produces invalid ranges, where the end of the range is before the beginning.

I want to fix that toolchain, of course, but I also noticed that tools like `llvm-addr2line` and `llvm-dwarfdump --lookup` apparently silently skip the invalid ranges, so they're able to give partial answers. By contrast, `gimli` returns an error in this case. Then the `addr2line` crate, for example, bubbles the error all the way out and doesn't return any results.

It would be useful to be able to skip over the invalid ranges, instead of truncating a range-list at the first error. To that end I've deleted the check here in `RngListIter::convert_raw`, so the caller can decide what they want to do with such ranges. `addr2line`, for example, already checks that `range.begin < range.end` and silently ignores the range otherwise.

The specific toolchain where I've encountered this is TinyGo (which uses LLVM), when building WebAssembly with the `wasip1` target. I tested TinyGo 0.32.0-dev and LLVM 17, and this was the shortest program I could find which produces invalid ranges:

```go
package main
import "os"
func main() {
        os.Lstat("some-filename")
}
```