### PR TITLE
Fix Hash for EndianReader

### DIFF
--- a/src/read/endian_reader.rs
+++ b/src/read/endian_reader.rs
@@ -5,6 +5,7 @@ use alloc::rc::Rc;
 use alloc::string::String;
 use alloc::sync::Arc;
 use core::fmt::Debug;
+use core::hash::{Hash, Hasher};
 use core::ops::{Deref, Index, Range, RangeFrom, RangeTo};
 use core::slice;
 use core::str;
@@ -116,7 +117,7 @@ pub type EndianArcSlice<Endian> = EndianReader<Endian, Arc<[u8]>>;
 /// pub type MmapFileReader<Endian> = gimli::EndianReader<Endian, ArcMmapFile>;
 /// # fn test(_: &MmapFileReader<gimli::NativeEndian>) { }
 /// ```
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy)]
 pub struct EndianReader<Endian, T>
 where
     Endian: Endianity,
@@ -142,6 +143,17 @@ where
     Endian: Endianity,
     T: CloneStableDeref<Target = [u8]> + Debug,
 {
+}
+
+impl<Endian, T> Hash for EndianReader<Endian, T>
+where
+    Endian: Endianity,
+    T: CloneStableDeref<Target = [u8]> + Debug,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // This must match the `PartialEq` implementation.
+        self.bytes().hash(state);
+    }
 }
 
 // This is separated out from `EndianReader` so that we can avoid running afoul


### PR DESCRIPTION
Since we have a manual PartialEq implementation, we need a matching manual Hash implementation.