### PR TITLE
Add support for DW_LNCT_LLVM_source

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1052,9 +1052,9 @@ DwLnct(u16) {
     DW_LNCT_timestamp = 0x3,
     DW_LNCT_size = 0x4,
     DW_LNCT_MD5 = 0x5,
-    DW_LNCT_source = 0x6,
+    // DW_LNCT_source = 0x6,
     DW_LNCT_lo_user = 0x2000,
-    // LLVM project extensions.
+    // We currently only implement the LLVM embedded source code extension for DWARF v5.
     DW_LNCT_LLVM_source = 0x2001,
     DW_LNCT_hi_user = 0x3fff,
 });

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1052,7 +1052,10 @@ DwLnct(u16) {
     DW_LNCT_timestamp = 0x3,
     DW_LNCT_size = 0x4,
     DW_LNCT_MD5 = 0x5,
+    DW_LNCT_source = 0x6,
     DW_LNCT_lo_user = 0x2000,
+    // LLVM project extensions.
+    DW_LNCT_LLVM_source = 0x2001,
     DW_LNCT_hi_user = 0x3fff,
 });
 

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1688,9 +1688,13 @@ where
         match self.source {
             Some(ref source) => {
                 let res = unit.attr_string(source.clone())?;
-                // If the string is empty (missing mandatory line ending), we'll
-                // return Ok(None)
-                Ok((!res.is_empty()).then_some(res))
+                // Empty source strings (missing mandatory line ending) indicate
+                // that no source was provided for this file
+                if res.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(res))
+                }
             }
             None => Ok(None),
         }

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1224,16 +1224,6 @@ where
             .any(|x| x.content_type == constants::DW_LNCT_MD5)
     }
 
-    /// Return true if the file debug information entry contains the source code.
-    pub fn file_has_source(&self) -> bool {
-        self.file_name_entry_format.iter().any(|x| {
-            matches!(
-                x.content_type,
-                constants::DW_LNCT_source | constants::DW_LNCT_LLVM_source
-            )
-        })
-    }
-
     /// Get the list of source files that appear in this header's line program.
     pub fn file_names(&self) -> &[FileEntry<R, Offset>] {
         &self.file_names[..]

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1684,7 +1684,7 @@ where
 
     /// The source code of this file. (UTF-8 source text string with "\n" line
     /// endings)
-    pub fn source(&self, unit: &crate::UnitRef<R>) -> crate::Result<Option<R>> {
+    pub fn source(&self, unit: &crate::UnitRef<'_, R>) -> crate::Result<Option<R>> {
         match self.source {
             Some(ref source) => {
                 let res = unit.attr_string(source.clone())?;

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1671,9 +1671,29 @@ where
         &self.md5
     }
 
-    /// FIXME
-    pub fn source(&self) -> Option<AttributeValue<R, Offset>> {
+    /// The source code of this file. (UTF-8 source text string with "\n" line
+    /// endings). Note that this may return an empty attribute that indicates
+    /// that no source code is available. The `FileEntry::source` function
+    /// handles this automatically.
+    ///
+    /// This is an accepted proposal for DWARFv6 (Issue 180201.1: DWARF and
+    /// source text embedding)
+    pub fn source_attr(&self) -> Option<AttributeValue<R, Offset>> {
         self.source.clone()
+    }
+
+    /// The source code of this file. (UTF-8 source text string with "\n" line
+    /// endings)
+    pub fn source(&self, unit: &crate::UnitRef<R>) -> crate::Result<Option<R>> {
+        match self.source {
+            Some(ref source) => {
+                let res = unit.attr_string(source.clone())?;
+                // If the string is empty (missing mandatory line ending), we'll
+                // return Ok(None)
+                Ok((!res.is_empty()).then_some(res))
+            }
+            None => Ok(None),
+        }
     }
 }
 

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1380,6 +1380,7 @@ where
                 timestamp: 0,
                 size: 0,
                 md5: [0; 16],
+                source: None,
             });
 
             file_name_entry_format = Vec::new();
@@ -1579,6 +1580,7 @@ where
     timestamp: u64,
     size: u64,
     md5: [u8; 16],
+    source: Option<AttributeValue<R, Offset>>,
 }
 
 impl<R, Offset> FileEntry<R, Offset>
@@ -1598,6 +1600,7 @@ where
             timestamp,
             size,
             md5: [0; 16],
+            source: None,
         };
 
         Ok(entry)
@@ -1667,6 +1670,11 @@ where
     pub fn md5(&self) -> &[u8; 16] {
         &self.md5
     }
+
+    /// FIXME
+    pub fn source(&self) -> Option<AttributeValue<R, Offset>> {
+        self.source.clone()
+    }
 }
 
 /// The format of a component of an include directory or file name entry.
@@ -1733,6 +1741,7 @@ fn parse_file_v5<R: Reader>(
     let mut timestamp = 0;
     let mut size = 0;
     let mut md5 = [0; 16];
+    let mut source = None;
 
     for format in formats {
         let value = parse_attribute(input, encoding, format.form)?;
@@ -1760,6 +1769,9 @@ fn parse_file_v5<R: Reader>(
                     }
                 }
             }
+            constants::DW_LNCT_source | constants::DW_LNCT_LLVM_source => {
+                source = Some(value);
+            }
             // Ignore unknown content types.
             _ => {}
         }
@@ -1771,6 +1783,7 @@ fn parse_file_v5<R: Reader>(
         timestamp,
         size,
         md5,
+        source,
     })
 }
 
@@ -1986,6 +1999,7 @@ mod tests {
                 timestamp: 0,
                 size: 0,
                 md5: [0; 16],
+                source: None,
             },
             FileEntry {
                 path_name: AttributeValue::String(EndianSlice::new(b"bar.h", LittleEndian)),
@@ -1993,6 +2007,7 @@ mod tests {
                 timestamp: 0,
                 size: 0,
                 md5: [0; 16],
+                source: None,
             },
         ];
         assert_eq!(header.file_names(), &expected_file_names);
@@ -2151,6 +2166,7 @@ mod tests {
                     timestamp: 0,
                     size: 0,
                     md5: [0; 16],
+                    source: None,
                 },
                 FileEntry {
                     path_name: AttributeValue::String(EndianSlice::new(b"bar.rs", LittleEndian)),
@@ -2158,6 +2174,7 @@ mod tests {
                     timestamp: 0,
                     size: 0,
                     md5: [0; 16],
+                    source: None,
                 },
             ],
             include_directories: vec![],
@@ -2404,6 +2421,7 @@ mod tests {
                 timestamp: 1,
                 size: 2,
                 md5: [0; 16],
+                source: None,
             }),
         );
 
@@ -2427,6 +2445,7 @@ mod tests {
             timestamp: 0,
             size: 0,
             md5: [0; 16],
+            source: None,
         };
 
         let mut header = make_test_header(EndianSlice::new(&[], LittleEndian));
@@ -2855,6 +2874,7 @@ mod tests {
             timestamp: 0,
             size: 0,
             md5: [0; 16],
+            source: None,
         };
 
         let opcode = LineInstruction::DefineFile(file);
@@ -2916,6 +2936,7 @@ mod tests {
                 timestamp: 0,
                 size: 0,
                 md5: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                source: None, // TODO: test
             },
             FileEntry {
                 path_name: AttributeValue::String(EndianSlice::new(b"file2", LittleEndian)),
@@ -2925,6 +2946,7 @@ mod tests {
                 md5: [
                     11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
                 ],
+                source: None, // TODO: test
             },
         ];
 

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1224,7 +1224,7 @@ where
             .any(|x| x.content_type == constants::DW_LNCT_MD5)
     }
 
-    /// Return true if the file name entry format contains an source field.
+    /// Return true if the file name entry format contains a source field.
     pub fn file_has_source(&self) -> bool {
         self.file_name_entry_format
             .iter()

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1031,7 +1031,7 @@ mod convert {
                                 timestamp: comp_file.timestamp(),
                                 size: comp_file.size(),
                                 md5: *comp_file.md5(),
-                                source: match comp_file.source() {
+                                source: match comp_file.source_attr() {
                                     Some(source) => Some(LineString::from(
                                         source,
                                         dwarf,
@@ -1093,7 +1093,7 @@ mod convert {
                         timestamp: from_file.timestamp(),
                         size: from_file.size(),
                         md5: *from_file.md5(),
-                        source: match from_file.source() {
+                        source: match from_file.source_attr() {
                             Some(source) => {
                                 Some(LineString::from(source, dwarf, line_strings, strings)?)
                             }

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -70,7 +70,7 @@ pub struct LineProgram {
     /// True if the file entries have embedded source code.
     ///
     /// For version <= 4, this is ignored.
-    /// For version 5, this controls whether to emit `DW_LNCT_source`.
+    /// For version 5, this controls whether to emit `DW_LNCT_LLVM_source`.
     pub file_has_source: bool,
 
     prev_row: LineRow,
@@ -646,7 +646,7 @@ impl LineProgram {
                     w.write(&info.md5)?;
                 }
                 if self.file_has_source {
-                    // Note: An empty DW_LNCT_source is interpreted as missing
+                    // Note: An empty DW_LNCT_LLVM_source is interpreted as missing
                     // source code. Included source code should always be
                     // terminated by a "\n" line ending.
                     let empty_str = LineString::String(Vec::new());
@@ -1239,8 +1239,8 @@ mod tests {
                         }
 
                         // Note: Embedded source code is an accepted extension
-                        // that will become part of DWARF v6. We're using it for
-                        // v5 here anyways.
+                        // that will become part of DWARF v6. We're using the LLVM extension
+                        // here for v5.
                         if encoding.version >= 5 {
                             program.file_has_source = true;
                         }

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -67,6 +67,12 @@ pub struct LineProgram {
     /// For version 5, this controls whether to emit `DW_LNCT_MD5`.
     pub file_has_md5: bool,
 
+    /// True if the file entries have embedded source code.
+    ///
+    /// For version <= 4, this is ignored.
+    /// For version 5, this controls whether to emit `DW_LNCT_source`.
+    pub file_has_source: bool,
+
     prev_row: LineRow,
     row: LineRow,
     // TODO: this probably should be either rows or sequences instead
@@ -119,6 +125,7 @@ impl LineProgram {
             file_has_timestamp: false,
             file_has_size: false,
             file_has_md5: false,
+            file_has_source: false,
         };
         // For all DWARF versions, directory index 0 is comp_dir.
         // For version <= 4, the entry is implicit. We still add
@@ -153,6 +160,7 @@ impl LineProgram {
             file_has_timestamp: false,
             file_has_size: false,
             file_has_md5: false,
+            file_has_source: false,
         }
     }
 
@@ -592,7 +600,8 @@ impl LineProgram {
             let count = 2
                 + if self.file_has_timestamp { 1 } else { 0 }
                 + if self.file_has_size { 1 } else { 0 }
-                + if self.file_has_md5 { 1 } else { 0 };
+                + if self.file_has_md5 { 1 } else { 0 }
+                + if self.file_has_source { 1 } else { 0 };
             w.write_u8(count)?;
             w.write_uleb128(u64::from(constants::DW_LNCT_path.0))?;
             let file_form = self.comp_file.0.form();
@@ -610,6 +619,10 @@ impl LineProgram {
             if self.file_has_md5 {
                 w.write_uleb128(u64::from(constants::DW_LNCT_MD5.0))?;
                 w.write_uleb128(constants::DW_FORM_data16.0.into())?;
+            }
+            if self.file_has_source {
+                w.write_uleb128(u64::from(constants::DW_LNCT_source.0))?;
+                w.write_uleb128(constants::DW_FORM_string.0.into())?;
             }
 
             // File name entries.
@@ -631,6 +644,17 @@ impl LineProgram {
                 }
                 if self.file_has_md5 {
                     w.write(&info.md5)?;
+                }
+                if self.file_has_source {
+                    let empty_str = LineString::String(Vec::new());
+                    let source = info.source.as_ref().unwrap_or(&empty_str);
+                    source.write(
+                        w,
+                        constants::DW_FORM_string,
+                        self.encoding,
+                        debug_line_str_offsets,
+                        debug_str_offsets,
+                    )?;
                 }
                 Ok(())
             };
@@ -937,7 +961,7 @@ mod id {
 pub use self::id::*;
 
 /// Extra information for file in a `LineProgram`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FileInfo {
     /// The implementation defined timestamp of the last modification of the file,
     /// or 0 if not available.
@@ -950,6 +974,11 @@ pub struct FileInfo {
     ///
     /// Only used if version >= 5 and `LineProgram::file_has_md5` is `true`.
     pub md5: [u8; 16],
+
+    /// Optionally some embedded sourcecode.
+    ///
+    /// Only used if version >= 5 and `LineProgram::file_has_source` is `true`.
+    pub source: Option<LineString>,
 }
 
 define_section!(
@@ -999,6 +1028,15 @@ mod convert {
                                 timestamp: comp_file.timestamp(),
                                 size: comp_file.size(),
                                 md5: *comp_file.md5(),
+                                source: match comp_file.source() {
+                                    Some(source) => Some(LineString::from(
+                                        source,
+                                        dwarf,
+                                        line_strings,
+                                        strings,
+                                    )?),
+                                    None => None,
+                                },
                             }),
                         )
                     }
@@ -1052,6 +1090,12 @@ mod convert {
                         timestamp: from_file.timestamp(),
                         size: from_file.size(),
                         md5: *from_file.md5(),
+                        source: match from_file.source() {
+                            Some(source) => {
+                                Some(LineString::from(source, dwarf, line_strings, strings)?)
+                            }
+                            None => None,
+                        },
                     });
                     files.push(program.add_file(from_name, from_dir, from_info));
                 }
@@ -1190,6 +1234,13 @@ mod tests {
                             program.file_has_md5 = true;
                         }
 
+                        // Note: Embedded source code is an accepted extension
+                        // that will become part of DWARF v6. We're using it for
+                        // v5 here anyways.
+                        if encoding.version >= 5 {
+                            program.file_has_source = true;
+                        }
+
                         let dir_id = program.add_directory(dir2.clone());
                         assert_eq!(&dir2, program.get_directory(dir_id));
                         assert_eq!(dir_id, program.add_directory(dir2.clone()));
@@ -1202,8 +1253,11 @@ mod tests {
                             } else {
                                 [0; 16]
                             },
+                            source: (encoding.version >= 5)
+                                .then(|| LineString::String(b"the source code".into())),
                         };
-                        let file_id = program.add_file(file2.clone(), dir_id, Some(file_info));
+                        let file_id =
+                            program.add_file(file2.clone(), dir_id, Some(file_info.clone()));
                         assert_eq!((&file2, dir_id), program.get_file(file_id));
                         assert_eq!(file_info, *program.get_file_info(file_id));
 
@@ -1213,7 +1267,7 @@ mod tests {
                         assert_ne!(file_info, *program.get_file_info(file_id));
                         assert_eq!(
                             file_id,
-                            program.add_file(file2.clone(), dir_id, Some(file_info))
+                            program.add_file(file2.clone(), dir_id, Some(file_info.clone()))
                         );
                         assert_eq!(file_info, *program.get_file_info(file_id));
 

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1257,7 +1257,7 @@ mod tests {
                                 [0; 16]
                             },
                             source: (encoding.version >= 5)
-                                .then(|| LineString::String(b"the source code".into())),
+                                .then(|| LineString::String(b"the source code\n".into())),
                         };
                         let file_id =
                             program.add_file(file2.clone(), dir_id, Some(file_info.clone()));

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -981,6 +981,10 @@ pub struct FileInfo {
     /// Optionally some embedded sourcecode.
     ///
     /// Only used if version >= 5 and `LineProgram::file_has_source` is `true`.
+    ///
+    /// NOTE: This currently only supports the `LineString::String` variant,
+    /// since we're encoding the string with `DW_FORM_string`.
+    /// Other variants will result in an `LineStringFormMismatch` error.
     pub source: Option<LineString>,
 }
 

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -621,7 +621,7 @@ impl LineProgram {
                 w.write_uleb128(constants::DW_FORM_data16.0.into())?;
             }
             if self.file_has_source {
-                w.write_uleb128(u64::from(constants::DW_LNCT_source.0))?;
+                w.write_uleb128(u64::from(constants::DW_LNCT_LLVM_source.0))?;
                 w.write_uleb128(constants::DW_FORM_string.0.into())?;
             }
 
@@ -1031,7 +1031,7 @@ mod convert {
                                 timestamp: comp_file.timestamp(),
                                 size: comp_file.size(),
                                 md5: *comp_file.md5(),
-                                source: match comp_file.source_attr() {
+                                source: match comp_file.source() {
                                     Some(source) => Some(LineString::from(
                                         source,
                                         dwarf,
@@ -1081,6 +1081,7 @@ mod convert {
                 program.file_has_timestamp = from_header.file_has_timestamp();
                 program.file_has_size = from_header.file_has_size();
                 program.file_has_md5 = from_header.file_has_md5();
+                program.file_has_source = from_header.file_has_source();
                 for from_file in from_header.file_names().iter().skip(file_skip) {
                     let from_name =
                         LineString::from(from_file.path_name(), dwarf, line_strings, strings)?;
@@ -1093,7 +1094,7 @@ mod convert {
                         timestamp: from_file.timestamp(),
                         size: from_file.size(),
                         md5: *from_file.md5(),
-                        source: match from_file.source_attr() {
+                        source: match from_file.source() {
                             Some(source) => {
                                 Some(LineString::from(source, dwarf, line_strings, strings)?)
                             }

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1257,7 +1257,7 @@ mod tests {
                                 [0; 16]
                             },
                             source: (encoding.version >= 5)
-                                .then(|| LineString::String(b"the source code\n".into())),
+                                .then(|| LineString::String(b"the source code\n".to_vec())),
                         };
                         let file_id =
                             program.add_file(file2.clone(), dir_id, Some(file_info.clone()));

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -646,6 +646,9 @@ impl LineProgram {
                     w.write(&info.md5)?;
                 }
                 if self.file_has_source {
+                    // Note: An empty DW_LNCT_source is interpreted as missing
+                    // source code. Included source code should always be
+                    // terminated by a "\n" line ending.
                     let empty_str = LineString::String(Vec::new());
                     let source = info.source.as_ref().unwrap_or(&empty_str);
                     source.write(


### PR DESCRIPTION
Hi,

this is a follow-up on #432 (fixes #431).
The discussion in #432 is still relevant here: The accepted proposal explicitly deals with missing source attributes now by specifying that all provided embedded source attributes should be newline-terminated. 

I don't think there's a clean way to implement this though. (=> I've added `fn source_attr` and `fn source` in this PR)

Let me know if you'd be okay with merging support for this feature without waiting for DWARF v6 :slightly_smiling_face:
(I'd like to use this to simplify tests in `rustc` and wire up support in `symbolic`.)
