### PR TITLE
dwarfdump: change format specifier for addresses

### DIFF
--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -2016,7 +2016,62 @@ fn dump_line_program<R: Reader, W: Write>(w: &mut W, unit: gimli::UnitRef<R>) ->
             writeln!(w, "Line Number Instructions:")?;
             let mut instructions = header.instructions();
             while let Some(instruction) = instructions.next_instruction(header)? {
-                writeln!(w, "  {}", instruction)?;
+                use gimli::{constants, LineInstruction};
+                write!(w, "  ")?;
+                match instruction {
+                    LineInstruction::Special(opcode) => write!(w, "Special opcode {}", opcode),
+                    LineInstruction::Copy => write!(w, "{}", constants::DW_LNS_copy),
+                    LineInstruction::AdvancePc(advance) => {
+                        write!(w, "{} by {}", constants::DW_LNS_advance_pc, advance)
+                    }
+                    LineInstruction::AdvanceLine(increment) => {
+                        write!(w, "{} by {}", constants::DW_LNS_advance_line, increment)
+                    }
+                    LineInstruction::SetFile(file) => {
+                        write!(w, "{} to {}", constants::DW_LNS_set_file, file)
+                    }
+                    LineInstruction::SetColumn(column) => {
+                        write!(w, "{} to {}", constants::DW_LNS_set_column, column)
+                    }
+                    LineInstruction::NegateStatement => {
+                        write!(w, "{}", constants::DW_LNS_negate_stmt)
+                    }
+                    LineInstruction::SetBasicBlock => {
+                        write!(w, "{}", constants::DW_LNS_set_basic_block)
+                    }
+                    LineInstruction::ConstAddPc => write!(w, "{}", constants::DW_LNS_const_add_pc),
+                    LineInstruction::FixedAddPc(advance) => {
+                        write!(w, "{} by {}", constants::DW_LNS_fixed_advance_pc, advance)
+                    }
+                    LineInstruction::SetPrologueEnd => {
+                        write!(w, "{}", constants::DW_LNS_set_prologue_end)
+                    }
+                    LineInstruction::SetEpilogueBegin => {
+                        write!(w, "{}", constants::DW_LNS_set_epilogue_begin)
+                    }
+                    LineInstruction::SetIsa(isa) => {
+                        write!(w, "{} to {}", constants::DW_LNS_set_isa, isa)
+                    }
+                    LineInstruction::UnknownStandard0(opcode) => write!(w, "Unknown {}", opcode),
+                    LineInstruction::UnknownStandard1(opcode, arg) => {
+                        write!(w, "Unknown {} with operand {}", opcode, arg)
+                    }
+                    LineInstruction::UnknownStandardN(opcode, ref args) => {
+                        write!(w, "Unknown {} with operands {:?}", opcode, args)
+                    }
+                    LineInstruction::EndSequence => write!(w, "{}", constants::DW_LNE_end_sequence),
+                    LineInstruction::SetAddress(address) => {
+                        write!(w, "{} to {}", constants::DW_LNE_set_address, address)
+                    }
+                    LineInstruction::DefineFile(_) => {
+                        write!(w, "{}", constants::DW_LNE_define_file)
+                    }
+                    LineInstruction::SetDiscriminator(discr) => {
+                        write!(w, "{} to {}", constants::DW_LNE_set_discriminator, discr)
+                    }
+                    LineInstruction::UnknownExtended(opcode, _) => write!(w, "Unknown {}", opcode),
+                }?;
+                writeln!(w)?;
             }
 
             writeln!(w)?;

--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -661,10 +661,10 @@ fn dump_eh_frame<R: Reader, W: Write>(
                 };
 
                 // TODO: symbolicate the start address like the canonical dwarfdump does.
-                writeln!(w, "    start_addr: {:#018x}", fde.initial_address())?;
+                writeln!(w, "    start_addr: {:#x}", fde.initial_address())?;
                 writeln!(
                     w,
-                    "    range_size: {:#018x} (end_addr = {:#018x})",
+                    "    range_size: {:#x} (end_addr = {:#x})",
                     fde.len(),
                     fde.end_address(),
                 )?;
@@ -684,10 +684,10 @@ fn dump_eh_frame<R: Reader, W: Write>(
 fn dump_pointer<W: Write>(w: &mut W, p: gimli::Pointer) -> Result<()> {
     match p {
         gimli::Pointer::Direct(p) => {
-            write!(w, "{:#018x}", p)?;
+            write!(w, "{:#x}", p)?;
         }
         gimli::Pointer::Indirect(p) => {
-            write!(w, "({:#018x})", p)?;
+            write!(w, "({:#x})", p)?;
         }
     }
     Ok(())
@@ -1189,7 +1189,7 @@ fn dump_attr_value<R: Reader, W: Write>(
     let value = attr.value();
     match value {
         gimli::AttributeValue::Addr(address) => {
-            writeln!(w, "0x{:08x}", address)?;
+            writeln!(w, "{:#x}", address)?;
         }
         gimli::AttributeValue::Block(data) => {
             for byte in data.to_slice()?.iter() {
@@ -1275,9 +1275,9 @@ fn dump_attr_value<R: Reader, W: Write>(
             writeln!(w, "<.debug_addr+0x{:08x}>", base.0)?;
         }
         gimli::AttributeValue::DebugAddrIndex(index) => {
-            write!(w, "(indirect address, index {:#x}): ", index.0)?;
+            write!(w, "(index {:#x}): ", index.0)?;
             let address = unit.address(index)?;
-            writeln!(w, "0x{:08x}", address)?;
+            writeln!(w, "{:#x}", address)?;
         }
         gimli::AttributeValue::UnitRef(offset) => {
             write!(w, "0x{:08x}", offset.0)?;
@@ -1683,7 +1683,7 @@ fn dump_op<R: Reader, W: Write>(
 
 fn dump_range<W: Write>(w: &mut W, range: Option<gimli::Range>) -> Result<()> {
     if let Some(range) = range {
-        write!(w, " [0x{:08x}, 0x{:08x}]", range.begin, range.end)?;
+        write!(w, " [{:#x}, {:#x}]", range.begin, range.end)?;
     } else {
         write!(w, " [ignored]")?;
     }
@@ -1715,11 +1715,11 @@ fn dump_loc_list<R: Reader, W: Write>(
             .map(|location| location.range);
         match raw {
             gimli::RawLocListEntry::BaseAddress { addr } => {
-                writeln!(w, "<base-address 0x{:08x}>", addr)?;
+                writeln!(w, "<base-address {:#x}>", addr)?;
             }
             gimli::RawLocListEntry::BaseAddressx { addr } => {
                 let addr_val = unit.address(addr)?;
-                writeln!(w, "<base-addressx [{}]0x{:08x}>", addr.0, addr_val)?;
+                writeln!(w, "<base-addressx [{}]{:#x}>", addr.0, addr_val)?;
             }
             gimli::RawLocListEntry::StartxEndx {
                 begin,
@@ -1730,7 +1730,7 @@ fn dump_loc_list<R: Reader, W: Write>(
                 let end_val = unit.address(end)?;
                 write!(
                     w,
-                    "<startx-endx [{}]0x{:08x}, [{}]0x{:08x}>",
+                    "<startx-endx [{}]{:#x}, [{}]{:#x}>",
                     begin.0, begin_val, end.0, end_val,
                 )?;
                 dump_range(w, range)?;
@@ -1745,7 +1745,7 @@ fn dump_loc_list<R: Reader, W: Write>(
                 let begin_val = unit.address(begin)?;
                 write!(
                     w,
-                    "<startx-length [{}]0x{:08x}, 0x{:08x}>",
+                    "<startx-length [{}]{:#x}, {:#x}>",
                     begin.0, begin_val, length,
                 )?;
                 dump_range(w, range)?;
@@ -1762,7 +1762,7 @@ fn dump_loc_list<R: Reader, W: Write>(
                 end,
                 ref data,
             } => {
-                write!(w, "<offset-pair 0x{:08x}, 0x{:08x}>", begin, end)?;
+                write!(w, "<offset-pair {:#x}, {:#x}>", begin, end)?;
                 dump_range(w, range)?;
                 dump_exprloc(w, unit, data)?;
                 writeln!(w)?;
@@ -1777,7 +1777,7 @@ fn dump_loc_list<R: Reader, W: Write>(
                 end,
                 ref data,
             } => {
-                write!(w, "<start-end 0x{:08x}, 0x{:08x}>", begin, end)?;
+                write!(w, "<start-end {:#x}, {:#x}>", begin, end)?;
                 dump_range(w, range)?;
                 dump_exprloc(w, unit, data)?;
                 writeln!(w)?;
@@ -1787,7 +1787,7 @@ fn dump_loc_list<R: Reader, W: Write>(
                 length,
                 ref data,
             } => {
-                write!(w, "<start-length 0x{:08x}, 0x{:08x}>", begin, length)?;
+                write!(w, "<start-length {:#x}, {:#x}>", begin, length)?;
                 dump_range(w, range)?;
                 dump_exprloc(w, unit, data)?;
                 writeln!(w)?;
@@ -1820,18 +1820,18 @@ fn dump_range_list<R: Reader, W: Write>(
         let range = ranges.convert_raw(raw.clone())?;
         match raw {
             gimli::RawRngListEntry::BaseAddress { addr } => {
-                writeln!(w, "<new base address 0x{:08x}>", addr)?;
+                writeln!(w, "<new base address {:#x}>", addr)?;
             }
             gimli::RawRngListEntry::BaseAddressx { addr } => {
                 let addr_val = unit.address(addr)?;
-                writeln!(w, "<new base addressx [{}]0x{:08x}>", addr.0, addr_val)?;
+                writeln!(w, "<new base addressx [{}]{:#x}>", addr.0, addr_val)?;
             }
             gimli::RawRngListEntry::StartxEndx { begin, end } => {
                 let begin_val = unit.address(begin)?;
                 let end_val = unit.address(end)?;
                 write!(
                     w,
-                    "<startx-endx [{}]0x{:08x}, [{}]0x{:08x}>",
+                    "<startx-endx [{}]{:#x}, [{}]{:#x}>",
                     begin.0, begin_val, end.0, end_val,
                 )?;
                 dump_range(w, range)?;
@@ -1841,7 +1841,7 @@ fn dump_range_list<R: Reader, W: Write>(
                 let begin_val = unit.address(begin)?;
                 write!(
                     w,
-                    "<startx-length [{}]0x{:08x}, 0x{:08x}>",
+                    "<startx-length [{}]{:#x}, {:#x}>",
                     begin.0, begin_val, length,
                 )?;
                 dump_range(w, range)?;
@@ -1849,17 +1849,17 @@ fn dump_range_list<R: Reader, W: Write>(
             }
             gimli::RawRngListEntry::AddressOrOffsetPair { begin, end }
             | gimli::RawRngListEntry::OffsetPair { begin, end } => {
-                write!(w, "<offset-pair 0x{:08x}, 0x{:08x}>", begin, end)?;
+                write!(w, "<offset-pair {:#x}, {:#x}>", begin, end)?;
                 dump_range(w, range)?;
                 writeln!(w)?;
             }
             gimli::RawRngListEntry::StartEnd { begin, end } => {
-                write!(w, "<start-end 0x{:08x}, 0x{:08x}>", begin, end)?;
+                write!(w, "<start-end {:#x}, {:#x}>", begin, end)?;
                 dump_range(w, range)?;
                 writeln!(w)?;
             }
             gimli::RawRngListEntry::StartLength { begin, length } => {
-                write!(w, "<start-length 0x{:08x}, 0x{:08x}>", begin, length)?;
+                write!(w, "<start-length {:#x}, {:#x}>", begin, length)?;
                 dump_range(w, range)?;
                 writeln!(w)?;
             }
@@ -2061,7 +2061,7 @@ fn dump_line_program<R: Reader, W: Write>(w: &mut W, unit: gimli::UnitRef<R>) ->
                     }
                     LineInstruction::EndSequence => write!(w, "{}", constants::DW_LNE_end_sequence),
                     LineInstruction::SetAddress(address) => {
-                        write!(w, "{} to {}", constants::DW_LNE_set_address, address)
+                        write!(w, "{} to {:#x}", constants::DW_LNE_set_address, address)
                     }
                     LineInstruction::DefineFile(_) => {
                         write!(w, "{}", constants::DW_LNE_define_file)
@@ -2089,7 +2089,7 @@ fn dump_line_program<R: Reader, W: Write>(w: &mut W, unit: gimli::UnitRef<R>) ->
                 gimli::ColumnType::Column(column) => column.get(),
                 gimli::ColumnType::LeftEdge => 0,
             };
-            write!(w, "0x{:08x}  [{:4},{:2}]", row.address(), line, column)?;
+            write!(w, "{:#x}  [{:4},{:2}]", row.address(), line, column)?;
             if row.is_stmt() {
                 write!(w, " NS")?;
             }
@@ -2219,7 +2219,7 @@ fn dump_aranges<R: Reader, W: Write>(
         let mut aranges = header.entries();
         while let Some(arange) = aranges.next()? {
             let range = arange.range();
-            writeln!(w, "[0x{:016x},  0x{:016x})", range.begin, range.end)?;
+            writeln!(w, "[{:#x}, {:#x})", range.begin, range.end)?;
         }
     }
     Ok(())

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1,7 +1,5 @@
 use alloc::vec::Vec;
-use core::fmt;
 use core::num::{NonZeroU64, Wrapping};
-use core::result;
 
 use crate::common::{
     DebugLineOffset, DebugLineStrOffset, DebugStrOffset, DebugStrOffsetsIndex, Encoding, Format,
@@ -512,58 +510,6 @@ where
                     }
                 }
             }
-        }
-    }
-}
-
-impl<R, Offset> fmt::Display for LineInstruction<R, Offset>
-where
-    R: Reader<Offset = Offset>,
-    Offset: ReaderOffset,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
-        match *self {
-            LineInstruction::Special(opcode) => write!(f, "Special opcode {}", opcode),
-            LineInstruction::Copy => write!(f, "{}", constants::DW_LNS_copy),
-            LineInstruction::AdvancePc(advance) => {
-                write!(f, "{} by {}", constants::DW_LNS_advance_pc, advance)
-            }
-            LineInstruction::AdvanceLine(increment) => {
-                write!(f, "{} by {}", constants::DW_LNS_advance_line, increment)
-            }
-            LineInstruction::SetFile(file) => {
-                write!(f, "{} to {}", constants::DW_LNS_set_file, file)
-            }
-            LineInstruction::SetColumn(column) => {
-                write!(f, "{} to {}", constants::DW_LNS_set_column, column)
-            }
-            LineInstruction::NegateStatement => write!(f, "{}", constants::DW_LNS_negate_stmt),
-            LineInstruction::SetBasicBlock => write!(f, "{}", constants::DW_LNS_set_basic_block),
-            LineInstruction::ConstAddPc => write!(f, "{}", constants::DW_LNS_const_add_pc),
-            LineInstruction::FixedAddPc(advance) => {
-                write!(f, "{} by {}", constants::DW_LNS_fixed_advance_pc, advance)
-            }
-            LineInstruction::SetPrologueEnd => write!(f, "{}", constants::DW_LNS_set_prologue_end),
-            LineInstruction::SetEpilogueBegin => {
-                write!(f, "{}", constants::DW_LNS_set_epilogue_begin)
-            }
-            LineInstruction::SetIsa(isa) => write!(f, "{} to {}", constants::DW_LNS_set_isa, isa),
-            LineInstruction::UnknownStandard0(opcode) => write!(f, "Unknown {}", opcode),
-            LineInstruction::UnknownStandard1(opcode, arg) => {
-                write!(f, "Unknown {} with operand {}", opcode, arg)
-            }
-            LineInstruction::UnknownStandardN(opcode, ref args) => {
-                write!(f, "Unknown {} with operands {:?}", opcode, args)
-            }
-            LineInstruction::EndSequence => write!(f, "{}", constants::DW_LNE_end_sequence),
-            LineInstruction::SetAddress(address) => {
-                write!(f, "{} to {}", constants::DW_LNE_set_address, address)
-            }
-            LineInstruction::DefineFile(_) => write!(f, "{}", constants::DW_LNE_define_file),
-            LineInstruction::SetDiscriminator(discr) => {
-                write!(f, "{} to {}", constants::DW_LNE_set_discriminator, discr)
-            }
-            LineInstruction::UnknownExtended(opcode, _) => write!(f, "Unknown {}", opcode),
         }
     }
 }


### PR DESCRIPTION
This allows replacing addresses with another type.

Also some other small changes, see commits.