### PR TITLE
Improve simple_write example

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -365,6 +365,13 @@ impl SectionId {
             _ => return None,
         })
     }
+
+    /// Returns true if this is a mergeable string section.
+    ///
+    /// This is useful for determining the correct section flags.
+    pub fn is_string(self) -> bool {
+        matches!(self, SectionId::DebugStr | SectionId::DebugLineStr)
+    }
 }
 
 /// An optionally-provided implementation-defined compilation unit ID to enable


### PR DESCRIPTION
Use the correct relocation kind for COFF, and use the correct string section flags for ELF.

Fixes #746 