### PR TITLE
read: improve handling of 0 for tombstones

### DIFF
--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -290,6 +290,8 @@ impl<R: Reader> ArangeEntryIter<R> {
     #[doc(hidden)]
     pub fn convert_raw(&self, mut entry: ArangeEntry) -> Result<Option<ArangeEntry>> {
         // Skip tombstone entries.
+        // DWARF specifies a tombstone value of -1, but many linkers use 0.
+        // However, 0 may be a valid address, so the caller must handle that case.
         let address_size = self.encoding.address_size;
         let tombstone_address = !0 >> (64 - self.encoding.address_size * 8);
         if entry.range.begin == tombstone_address {


### PR DESCRIPTION
Where possible, ignore these instead of returning them or returning an error. This often isn't possible because 0 is a valid address, but we can handle it for `DW_LNE_set_address` in the middle of a line sequence, and for address pairs.

This fixes one of the problems reported in https://github.com/gimli-rs/addr2line/issues/326.