### PR TITLE
typo in UnknownCallFrameInstruction error

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -550,7 +550,7 @@ impl Error {
             Error::InvalidDerefSize(_) => {
                 "The size of a deref expression must not be larger than the size of an address."
             }
-            Error::UnknownCallFrameInstruction(_) => "An unknown DW_CFA_* instructiion",
+            Error::UnknownCallFrameInstruction(_) => "An unknown DW_CFA_* instruction",
             Error::InvalidAddressRange => {
                 "The end of an address range must not be before the beginning."
             }


### PR DESCRIPTION
Sorry for the relatively trivial PR but we [ran into](https://github.com/Vector35/binaryninja-api/issues/6605#issuecomment-2802910329) this in a project that uses gimli downstream so I happened to notice it.

Appreciate the great library! 
