### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/examples/src/bin/dwarf-validate.rs
+++ b/crates/examples/src/bin/dwarf-validate.rs
@@ -1,5 +1,7 @@
 // Allow clippy lints when building without clippy.
 #![allow(unknown_lints)]
+// style: allow verbose lifetimes
+#![allow(clippy::needless_lifetimes)]
 
 use gimli::{AttributeValue, UnitHeader};
 use object::{Object, ObjectSection};

--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -1,5 +1,7 @@
 // Allow clippy lints when building without clippy.
 #![allow(unknown_lints)]
+// style: allow verbose lifetimes
+#![allow(clippy::needless_lifetimes)]
 
 use fallible_iterator::FallibleIterator;
 use gimli::{Section, UnitHeader, UnitOffset, UnitSectionOffset, UnitType, UnwindSection};

--- a/crates/examples/src/bin/simple.rs
+++ b/crates/examples/src/bin/simple.rs
@@ -7,6 +7,9 @@
 //! Most of the complexity is due to loading the sections from the object
 //! file and DWP file, which is not something that is provided by gimli itself.
 
+// style: allow verbose lifetimes
+#![allow(clippy::needless_lifetimes)]
+
 use gimli::Reader as _;
 use object::{Object, ObjectSection};
 use std::{borrow, env, error, fs};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::needless_late_init)]
 #![allow(clippy::too_many_arguments)]
+#![allow(clippy::needless_lifetimes)]
 // False positives with `fallible_iterator`.
 #![allow(clippy::should_implement_trait)]
 // False positives.

--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -2233,7 +2233,7 @@ where
         ctx: &'ctx mut UnwindContext<R::Offset, S>,
         fde: &FrameDescriptionEntry<R>,
     ) -> Self {
-        assert!(ctx.stack.len() >= 1);
+        assert!(!ctx.stack.is_empty());
         UnwindTable {
             code_alignment_factor: Wrapping(fde.cie().code_alignment_factor()),
             data_alignment_factor: Wrapping(fde.cie().data_alignment_factor()),
@@ -2253,7 +2253,7 @@ where
         ctx: &'ctx mut UnwindContext<R::Offset, S>,
         cie: &CommonInformationEntry<R>,
     ) -> Self {
-        assert!(ctx.stack.len() >= 1);
+        assert!(!ctx.stack.is_empty());
         UnwindTable {
             code_alignment_factor: Wrapping(cie.code_alignment_factor()),
             data_alignment_factor: Wrapping(cie.data_alignment_factor()),
@@ -2273,7 +2273,7 @@ where
     /// Unfortunately, this cannot be used with `FallibleIterator` because of
     /// the restricted lifetime of the yielded item.
     pub fn next_row(&mut self) -> Result<Option<&UnwindTableRow<R::Offset, S>>> {
-        assert!(self.ctx.stack.len() >= 1);
+        assert!(!self.ctx.stack.is_empty());
         self.ctx.set_start_address(self.next_start_address);
         self.current_row_valid = false;
 


### PR DESCRIPTION
- lifetimes could be omitted or written as '_ in several cases
- x.len() >= 1 was changed to !x.is_empty()