### PR TITLE
Add support for reading macros from .debug_macro

### DIFF
--- a/src/read/macros.rs
+++ b/src/read/macros.rs
@@ -1,9 +1,10 @@
-use core::fmt::Debug;
-
 use crate::common::{DebugMacinfoOffset, SectionId};
 use crate::endianity::Endianity;
-use crate::read::{EndianSlice, Reader, Section};
-use crate::{constants, DwMacInfo, Error, Result};
+use crate::read::{EndianSlice, Reader, ReaderOffset, Section, UnitRef};
+use crate::{
+    constants, DebugLineOffset, DebugMacroOffset, DebugStrOffset, DebugStrOffsetsIndex, DwMacInfo,
+    DwMacro, Error, Format, Result,
+};
 
 /// The raw contents of the `.debug_macinfo` section.
 #[derive(Debug, Default, Clone, Copy)]
@@ -55,13 +56,10 @@ impl<R: Reader> DebugMacInfo<R> {
     /// }
     /// # Ok(()) }
     /// ```
-    pub fn get_macinfo(
-        &self,
-        offset: DebugMacinfoOffset<R::Offset>,
-    ) -> Result<DebugMacInfoIterator<R>> {
+    pub fn get_macinfo(&self, offset: DebugMacinfoOffset<R::Offset>) -> Result<MacInfoIter<R>> {
         let mut input = self.section.clone();
         input.skip(offset.0)?;
-        Ok(DebugMacInfoIterator { input })
+        Ok(MacInfoIter { input })
     }
 }
 
@@ -97,52 +95,16 @@ impl<R> From<R> for DebugMacInfo<R> {
     }
 }
 
-/// an Entry in the `.debug_macinfo` section.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DebugMacInfoItem<R> {
-    /// A macro definition.
-    Define {
-        /// The line number where the macro is defined.
-        line: u64,
-        /// The text of the macro: The name of the macro followed immediately by any formal
-        /// parameters including the surrounding parentheses, followed by the macro definition.
-        text: R,
-    },
-    /// A macro undefinition.
-    Undef {
-        /// The line number where the macro is undefined.
-        line: u64,
-        /// The name of the macro without the definition.
-        name: R,
-    },
-    /// The start of a file.
-    StartFile {
-        /// Line number of the source file on which the inclusion macro directive occurred.
-        line: u64,
-        /// An index into the line number table of the compilation unit.
-        file: u64,
-    },
-    /// The end of the current included file.
-    EndFile,
-    /// A vendor-specific extension.
-    VendorExt {
-        /// A numeric constant, whose meaning is vendor specific.
-        numeric: u64,
-        /// A string whose meaning is vendor specific.
-        string: R,
-    },
-}
-
 /// Iterator over the entries in the `.debug_macinfo` section.
 #[derive(Clone, Debug)]
-pub struct DebugMacInfoIterator<R: Reader> {
+pub struct MacInfoIter<R: Reader> {
     input: R,
 }
 
-impl<R: Reader> DebugMacInfoIterator<R> {
+impl<R: Reader> MacInfoIter<R> {
     /// Advance the iterator to the next entry in the `.debug_macinfo` section.
-    pub fn next(&mut self) -> Result<Option<DebugMacInfoItem<R>>> {
-        // Read the next entry from the input reader and return it as a DebugMacInfoItem.
+    pub fn next(&mut self) -> Result<Option<MacroEntry<R>>> {
+        // Read the next entry from the input reader and return it as a DebugMacroItem.
         let macinfo_type = DwMacInfo(self.input.read_u8()?);
         match macinfo_type {
             constants::DW_MACINFO_null => {
@@ -153,28 +115,34 @@ impl<R: Reader> DebugMacInfoIterator<R> {
             constants::DW_MACINFO_define => {
                 let line = self.input.read_uleb128()?;
                 let text = self.input.read_null_terminated_slice()?;
-                Ok(Some(DebugMacInfoItem::Define { line, text }))
+                Ok(Some(MacroEntry::Define {
+                    line,
+                    text: MacroString::Direct(text),
+                }))
             }
             constants::DW_MACINFO_undef => {
                 let line = self.input.read_uleb128()?;
                 let name = self.input.read_null_terminated_slice()?;
-                Ok(Some(DebugMacInfoItem::Undef { line, name }))
+                Ok(Some(MacroEntry::Undef {
+                    line,
+                    name: MacroString::Direct(name),
+                }))
             }
             constants::DW_MACINFO_start_file => {
                 // two operands: line number (LEB128) and an index into the line number table of the compilation unit (LEB128).
                 let line = self.input.read_uleb128()?;
                 let file = self.input.read_uleb128()?;
-                Ok(Some(DebugMacInfoItem::StartFile { line, file }))
+                Ok(Some(MacroEntry::StartFile { line, file }))
             }
             constants::DW_MACINFO_end_file => {
                 // no operands
-                Ok(Some(DebugMacInfoItem::EndFile))
+                Ok(Some(MacroEntry::EndFile))
             }
             constants::DW_MACINFO_vendor_ext => {
                 // two operands: a constant (LEB128) and a null terminated string, whose meaning is vendor specific
                 let numeric = self.input.read_uleb128()?;
                 let string = self.input.read_null_terminated_slice()?;
-                Ok(Some(DebugMacInfoItem::VendorExt { numeric, string }))
+                Ok(Some(MacroEntry::VendorExt { numeric, string }))
             }
             _ => {
                 self.input.empty();
@@ -185,19 +153,364 @@ impl<R: Reader> DebugMacInfoIterator<R> {
 }
 
 #[cfg(feature = "fallible-iterator")]
-impl<R: Reader> fallible_iterator::FallibleIterator for DebugMacInfoIterator<R> {
-    type Item = DebugMacInfoItem<R>;
+impl<R: Reader> fallible_iterator::FallibleIterator for MacInfoIter<R> {
+    type Item = MacroEntry<R>;
     type Error = Error;
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Error> {
-        DebugMacInfoIterator::next(self)
+        MacInfoIter::next(self)
+    }
+}
+
+/// The raw contents of the `.debug_macro` section.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DebugMacro<R> {
+    pub(crate) section: R,
+}
+
+impl<'input, Endian> DebugMacro<EndianSlice<'input, Endian>>
+where
+    Endian: Endianity,
+{
+    /// Construct a new `DebugMacro` instance from the data in the `.debug_macro`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_macro` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on macOS, etc.
+    ///
+    /// ```
+    /// use gimli::{DebugMacro, LittleEndian};
+    ///
+    /// # let buf = [1, 0, 95, 95, 83, 84, 68, 67, 95, 95, 32, 49, 0];
+    /// # let read_section_somehow = || &buf;
+    /// let debug_str = DebugMacro::new(read_section_somehow(), LittleEndian);
+    /// ```
+    pub fn new(macro_section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianSlice::new(macro_section, endian))
+    }
+}
+
+impl<R: Reader> DebugMacro<R> {
+    /// Look up a macro reference the `.debug_macinfo` section by DebugMacroOffset.
+    ///
+    /// A macinfo offset points to a list of macro information entries in the `.debug_macinfo` section.
+    /// To handle this, the function returns an iterator.
+    ///
+    /// ```
+    /// use gimli::{DebugMacro, DebugMacroOffset, LittleEndian};
+    ///
+    /// # fn main() -> Result<(), gimli::Error> {
+    /// # let buf = [0x05, 0x00, 0x00, 0x01, 0x00, 0x5f, 0x5f, 0x53, 0x54, 0x44, 0x43, 0x5f, 0x5f, 0x20, 0x31, 0x00, 0x00];
+    /// # let offset = DebugMacroOffset(0);
+    /// # let read_section_somehow = || &buf;
+    /// # let debug_macro_offset_somehow = || offset;
+    /// let debug_macro = DebugMacro::new(read_section_somehow(), LittleEndian);
+    /// let mut iter = debug_macro.get_macros(debug_macro_offset_somehow())?;
+    /// while let Some(cur_macro) = iter.next()? {
+    ///     println!("Found macro info {:?}", cur_macro);
+    /// }
+    /// # Ok(()) }
+    /// ```
+    pub fn get_macros(&self, offset: DebugMacroOffset<R::Offset>) -> Result<MacroIter<R>> {
+        let mut input = self.section.clone();
+        input.skip(offset.0)?;
+        let header = MacroUnitHeader::parse(&mut input)?;
+        Ok(MacroIter { input, header })
+    }
+}
+
+impl<T> DebugMacro<T> {
+    /// Create a `DebugMacro` section that references the data in `self`.
+    ///
+    /// This is useful when `R` implements `Reader` but `T` does not.
+    ///
+    /// Used by `DwarfSections::borrow`.
+    pub fn borrow<'a, F, R>(&'a self, mut borrow: F) -> DebugMacro<R>
+    where
+        F: FnMut(&'a T) -> R,
+    {
+        borrow(&self.section).into()
+    }
+}
+
+impl<R> Section<R> for DebugMacro<R> {
+    fn id() -> SectionId {
+        SectionId::DebugMacro
+    }
+
+    fn reader(&self) -> &R {
+        &self.section
+    }
+}
+
+impl<R> From<R> for DebugMacro<R> {
+    fn from(macro_section: R) -> Self {
+        DebugMacro {
+            section: macro_section,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MacroUnitHeader<R: Reader> {
+    /// The version of the macro unit header. At the moment only version 5 is defined.
+    _version: u16,
+    flags: u8,
+    _debug_line_offset: DebugLineOffset<R::Offset>,
+}
+
+impl<R: Reader> MacroUnitHeader<R> {
+    const OFFSET_SIZE_FLAG: u8 = 0b0000_0001;
+    const DEBUG_LINE_OFFSET_FLAG: u8 = 0b0000_0010;
+    const OPCODE_OPERANDS_TABLE_FLAG: u8 = 0b0000_0100;
+
+    fn parse(input: &mut R) -> Result<Self> {
+        let version = input.read_u16()?;
+        let flags = input.read_u8()?;
+        let format = if flags & Self::OFFSET_SIZE_FLAG == 0 {
+            Format::Dwarf32
+        } else {
+            Format::Dwarf64
+        };
+        let _debug_line_offset = if flags & Self::DEBUG_LINE_OFFSET_FLAG != 0 {
+            DebugLineOffset(input.read_offset(format)?)
+        } else {
+            DebugLineOffset(R::Offset::from_u64(0)?)
+        };
+        // if the opcode operands table flag is set, there is a table in the header which currently isn't parsed
+        if flags & Self::OPCODE_OPERANDS_TABLE_FLAG != 0 {
+            return Err(Error::UnsupportedOpcodeOperandsTable);
+        }
+        Ok(MacroUnitHeader {
+            _version: version,
+            flags,
+            _debug_line_offset,
+        })
+    }
+
+    fn format(&self) -> Format {
+        if self.flags & Self::OFFSET_SIZE_FLAG == 0 {
+            Format::Dwarf32
+        } else {
+            Format::Dwarf64
+        }
+    }
+}
+
+/// A string in a macro entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacroString<R, Offset = <R as Reader>::Offset>
+where
+    R: Reader<Offset = Offset>,
+    Offset: ReaderOffset,
+{
+    /// The string is directly embedded in the macro entry
+    Direct(R),
+    /// The macro refers to a string in the `.debug_str` section using a `DebugStrOffset`.
+    StringPointer(DebugStrOffset<Offset>),
+    /// The macro contains an index into an array in the `.debug_str_offsets`
+    /// section, which refers to a string in the `.debug_str` section.
+    IndirectStringPointer(DebugStrOffsetsIndex<Offset>),
+    /// The macro refers to a string in the `.debug_str` section in the supplementary object file
+    Supplementary(DebugStrOffset<Offset>),
+}
+
+impl<R: Reader> MacroString<R> {
+    /// Get the string slice from the macro entry.
+    pub fn string(&self, unit: UnitRef<'_, R>) -> Result<R> {
+        match self {
+            MacroString::Direct(s) => Ok(s.clone()),
+            MacroString::StringPointer(offset) => unit.string(*offset),
+            MacroString::IndirectStringPointer(index) => {
+                let str_offset = unit.string_offset(*index)?;
+                unit.string(str_offset)
+            }
+            MacroString::Supplementary(offset) => unit.sup_string(*offset),
+        }
+    }
+}
+
+/// an Entry in the `.debug_macro` section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacroEntry<R, Offset = <R as Reader>::Offset>
+where
+    R: Reader<Offset = Offset>,
+    Offset: ReaderOffset,
+{
+    /// A macro definition.
+    Define {
+        /// The line number where the macro is defined.
+        line: u64,
+        /// The text of the macro: The name of the macro followed immediately by any formal
+        /// parameters including the surrounding parentheses, followed by the macro definition.
+        text: MacroString<R>,
+    },
+    /// A macro undefinition.
+    Undef {
+        /// The line number where the macro is undefined.
+        line: u64,
+        /// The name of the macro without the definition.
+        name: MacroString<R>,
+    },
+    /// The start of a file.
+    StartFile {
+        /// Line number of the source file on which the inclusion macro directive occurred.
+        line: u64,
+        /// An index into the line number table of the compilation unit.
+        file: u64,
+    },
+    /// The end of the current included file.
+    EndFile,
+    /// import a macro unit
+    Import {
+        /// offset of the macro unit in the `.debug_macro` section
+        offset: DebugMacroOffset<Offset>,
+    },
+    /// import a macro unit from the supplementary object file
+    ImportSup {
+        /// offset of the macro unit in the `.debug_macro` section of the supplementary object file
+        offset: DebugMacroOffset<Offset>,
+    },
+    /// A vendor-specific extension.
+    VendorExt {
+        /// A numeric constant, whose meaning is vendor specific.
+        numeric: u64,
+        /// A string whose meaning is vendor specific.
+        string: R,
+    },
+}
+
+/// Iterator over the entries in the `.debug_macro` section.
+#[derive(Clone, Debug)]
+pub struct MacroIter<R: Reader> {
+    input: R,
+    header: MacroUnitHeader<R>,
+}
+
+impl<R: Reader> MacroIter<R> {
+    /// Advance the iterator to the next entry in the `.debug_macro` section.
+    pub fn next(&mut self) -> Result<Option<MacroEntry<R>>> {
+        // Read the next entry from the input reader and return it as a DebugMacroItem.
+        let macro_type = DwMacro(self.input.read_u8()?);
+        match macro_type {
+            constants::DW_MACRO_define => {
+                let line = self.input.read_uleb128()?;
+                let text = self.input.read_null_terminated_slice()?;
+                Ok(Some(MacroEntry::Define {
+                    line,
+                    text: MacroString::Direct(text),
+                }))
+            }
+            constants::DW_MACRO_undef => {
+                let line = self.input.read_uleb128()?;
+                let name = self.input.read_null_terminated_slice()?;
+                Ok(Some(MacroEntry::Undef {
+                    line,
+                    name: MacroString::Direct(name),
+                }))
+            }
+            constants::DW_MACRO_start_file => {
+                // two operands: line number (LEB128) and an index into the line number table of the compilation unit (LEB128).
+                let line = self.input.read_uleb128()?;
+                let file = self.input.read_uleb128()?;
+                Ok(Some(MacroEntry::StartFile { line, file }))
+            }
+            constants::DW_MACRO_end_file => {
+                // no operands
+                Ok(Some(MacroEntry::EndFile))
+            }
+            constants::DW_MACRO_define_strp => {
+                let line = self.input.read_uleb128()?;
+                let text_offset = DebugStrOffset(self.input.read_offset(self.header.format())?);
+                Ok(Some(MacroEntry::Define {
+                    line,
+                    text: MacroString::StringPointer(text_offset),
+                }))
+            }
+            constants::DW_MACRO_undef_strp => {
+                let line = self.input.read_uleb128()?;
+                let name_offset = DebugStrOffset(self.input.read_offset(self.header.format())?);
+                Ok(Some(MacroEntry::Undef {
+                    line,
+                    name: MacroString::StringPointer(name_offset),
+                }))
+            }
+            constants::DW_MACRO_import => {
+                let offset = DebugMacroOffset(self.input.read_offset(self.header.format())?);
+                Ok(Some(MacroEntry::Import { offset }))
+            }
+            constants::DW_MACRO_define_sup => {
+                let line = self.input.read_uleb128()?;
+                let text_offset = DebugStrOffset(self.input.read_offset(self.header.format())?);
+                Ok(Some(MacroEntry::Define {
+                    line,
+                    text: MacroString::Supplementary(text_offset),
+                }))
+            }
+            constants::DW_MACRO_undef_sup => {
+                let line = self.input.read_uleb128()?;
+                let name_offset = DebugStrOffset(self.input.read_offset(self.header.format())?);
+                Ok(Some(MacroEntry::Undef {
+                    line,
+                    name: MacroString::Supplementary(name_offset),
+                }))
+            }
+            constants::DW_MACRO_import_sup => {
+                let offset = DebugMacroOffset(self.input.read_offset(self.header.format())?);
+                Ok(Some(MacroEntry::ImportSup { offset }))
+            }
+            constants::DW_MACRO_define_strx => {
+                let line = self.input.read_uleb128()?;
+                let index = self.input.read_uleb128().and_then(R::Offset::from_u64)?;
+                let text_index = DebugStrOffsetsIndex(index);
+                Ok(Some(MacroEntry::Define {
+                    line,
+                    text: MacroString::IndirectStringPointer(text_index),
+                }))
+            }
+            constants::DW_MACRO_undef_strx => {
+                let line = self.input.read_uleb128()?;
+                let index = self.input.read_uleb128().and_then(R::Offset::from_u64)?;
+                let name_index = DebugStrOffsetsIndex(index);
+                Ok(Some(MacroEntry::Undef {
+                    line,
+                    name: MacroString::IndirectStringPointer(name_index),
+                }))
+            }
+            other if other.0 == 0 => {
+                // found the end of the unit, return None to stop the iteration
+                self.input.empty();
+                Ok(None)
+            }
+            other if other.0 >= constants::DW_MACRO_lo_user.0 => {
+                // to parse the user defined macro info we would need the opcode operands table.
+                // We should actually never get here since the opcode operands table is not parsed.
+                Err(Error::UnsupportedOpcodeOperandsTable)
+            }
+            _ => {
+                // invalid macro type
+                self.input.empty();
+                Err(Error::InvalidMacroType(macro_type.0))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for MacroIter<R> {
+    type Item = MacroEntry<R>;
+    type Error = Error;
+
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Error> {
+        MacroIter::next(self)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_util::GimliSectionMethods, LittleEndian};
+    use crate::{test_util::GimliSectionMethods, DebugStr, LittleEndian};
     use test_assembler::{Endian, Label, LabelMaker, Section};
 
     #[test]
@@ -239,33 +552,381 @@ mod tests {
         // Test getting macinfo entries
         let entry = iter.next().unwrap().unwrap();
         assert!(
-            matches!(entry, DebugMacInfoItem::Define { line: 0, text } if text.slice() == b"__STDC__ 1")
+            matches!(entry, MacroEntry::Define { line: 0, text: MacroString::Direct(text) } if text.slice() == b"__STDC__ 1")
         );
 
         let entry = iter.next().unwrap().unwrap();
         assert!(
-            matches!(entry, DebugMacInfoItem::Define { line: 1, text } if text.slice() == b"__GNUC__ 1")
+            matches!(entry, MacroEntry::Define { line: 1, text: MacroString::Direct(text) } if text.slice() == b"__GNUC__ 1")
         );
 
         let entry = iter.next().unwrap().unwrap();
         assert!(
-            matches!(entry, DebugMacInfoItem::Undef { line: 2, name } if name.slice() == b"__GNUC__")
+            matches!(entry, MacroEntry::Undef { line: 2, name: MacroString::Direct(name) } if name.slice() == b"__GNUC__")
         );
 
         let entry = iter.next().unwrap().unwrap();
-        assert!(matches!(
-            entry,
-            DebugMacInfoItem::StartFile { line: 3, file: 4 }
-        ));
+        assert!(matches!(entry, MacroEntry::StartFile { line: 3, file: 4 }));
 
         let entry = iter.next().unwrap().unwrap();
-        assert!(matches!(entry, DebugMacInfoItem::EndFile));
+        assert!(matches!(entry, MacroEntry::EndFile));
 
         let entry = iter.next().unwrap().unwrap();
         assert!(
-            matches!(entry, DebugMacInfoItem::VendorExt { numeric: 5, string } if string.slice() == b"foo")
+            matches!(entry, MacroEntry::VendorExt { numeric: 5, string } if string.slice() == b"foo")
         );
 
         assert_eq!(iter.next(), Ok(None));
+    }
+
+    #[test]
+    fn get_macros_1() {
+        let position = Label::new();
+
+        // The test data is originally from the DWARF v5 standard, appendix D.16
+        // 1) Figure D.71, simple DWARF encoding
+        let section = Section::with_endian(Endian::Little)
+            .set_start_const(0)
+            .mark(&position)
+            .D16(5) // Dwarf version
+            .D8(0b0000_0010) // Flags: offset_size = 0 (32-bit), debug_line_offset = 1, opcode_operands_table = 0
+            .D32(0) // debug line offset
+            .D8(crate::DW_MACRO_start_file.0) // start file: "a.c"
+            .uleb(0) // line number
+            .uleb(0) // file number
+            .D8(crate::DW_MACRO_start_file.0) // start file: "a.h"
+            .uleb(1) // line number
+            .uleb(1) // file number
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(1) // line number
+            .append_bytes(b"LONGER_MACRO 1\0") // macro name
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(2) // line number
+            .append_bytes(b"B 2\0") // macro name
+            .D8(crate::DW_MACRO_start_file.0) // start file: "b.h"
+            .uleb(3) // line number
+            .uleb(2) // file number
+            .D8(crate::DW_MACRO_undef.0) // undef
+            .uleb(1) // line number
+            .append_bytes(b"B\0") // macro name
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(2) // line number
+            .append_bytes(b"D 3\0") // macro name
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(3) // line number
+            .append_bytes(b"FUNCTION_LIKE_MACRO(x) 4+x\0") // macro name
+            .D8(crate::DW_MACRO_end_file.0) // end file: "b.h" -> "a.h"
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(4) // line number
+            .append_bytes(b"B 3\0") // macro name
+            .D8(crate::DW_MACRO_end_file.0) // end file: "a.h" -> "a.c"
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(2) // line number
+            .append_bytes(b"FUNCTION_LIKE_MACRO(x) 4+x\0") // macro name
+            .D8(crate::DW_MACRO_start_file.0) // start file: "b.h"
+            .uleb(3) // line number
+            .uleb(2) // file number
+            .D8(crate::DW_MACRO_undef.0) // undef
+            .uleb(1) // line number
+            .append_bytes(b"B\0") // macro name
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(2) // line number
+            .append_bytes(b"D 3\0") // macro name
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(3) // line number
+            .append_bytes(b"FUNCTION_LIKE_MACRO(x) 4+x\0") // macro name
+            .D8(crate::DW_MACRO_end_file.0) // end file: "b.h" -> "a.c"
+            .D8(crate::DW_MACRO_end_file.0) // end file: "a.c" -> ""
+            .D8(0); // end of unit
+
+        // Create a DebugMacro instance from the section
+        let section = section.get_contents().unwrap();
+        let debug_macro = DebugMacro::from(EndianSlice::new(&section, LittleEndian));
+
+        let offset = position.value().unwrap() as usize;
+
+        let mut iter = debug_macro.get_macros(DebugMacroOffset(offset)).unwrap();
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 0, file: 0 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 1, file: 1 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 1, text: MacroString::Direct(text)
+            } if text.slice() == b"LONGER_MACRO 1"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::Direct(text)
+            } if text.slice() == b"B 2"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 3, file: 2 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Undef {
+                line: 1, name: MacroString::Direct(name)
+            } if name.slice() == b"B"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::Direct(text)
+            } if text.slice() == b"D 3"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 3, text: MacroString::Direct(text)
+            } if text.slice() == b"FUNCTION_LIKE_MACRO(x) 4+x"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 4, text: MacroString::Direct(text)
+            } if text.slice() == b"B 3"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::Direct(text)
+            } if text.slice() == b"FUNCTION_LIKE_MACRO(x) 4+x"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 3, file: 2 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Undef {
+                line: 1, name: MacroString::Direct(name)
+            } if name.slice() == b"B"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::Direct(text)
+            } if text.slice() == b"D 3"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 3, text: MacroString::Direct(text)
+            } if text.slice() == b"FUNCTION_LIKE_MACRO(x) 4+x"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        assert_eq!(iter.next(), Ok(None));
+    }
+
+    #[test]
+    fn get_macros_2() {
+        let str_0 = Label::new();
+        let str_1 = Label::new();
+        let macro_unit_0 = Label::new();
+        let macro_unit_1 = Label::new();
+        let macro_unit_2 = Label::new();
+
+        // The test data is originally from the DWARF v5 standard, appendix D.16
+        // 2) Figure D.72, shareable DWARF encoding
+        let str_section = Section::with_endian(Endian::Little)
+            .set_start_const(0)
+            .mark(&str_0)
+            .append_bytes(b"FUNCTION_LIKE_MACRO(x) 4+x\0") // macro name
+            .mark(&str_1)
+            .append_bytes(b"LONGER_MACRO 1\0"); // macro name
+
+        let macro_section = Section::with_endian(Endian::Little)
+            .set_start_const(0)
+            //--------------------unit 0----------------------
+            .mark(&macro_unit_0) // start of unit 0
+            .D16(5) // Dwarf version
+            .D8(0b0000_0010) // Flags: offset_size = 0 (32-bit), debug_line_offset = 1, opcode_operands_table = 0
+            .D32(0) // debug line offset
+            .D8(crate::DW_MACRO_start_file.0) // start file: "a.c"
+            .uleb(0) // line number
+            .uleb(0) // file number
+            .D8(crate::DW_MACRO_start_file.0) // start file: "a.h"
+            .uleb(1) // line number
+            .uleb(1) // file number
+            .D8(crate::DW_MACRO_import.0) // import unit 1
+            .L32(macro_unit_1.clone()) // debug line offset to unit 1
+            .D8(crate::DW_MACRO_start_file.0) // start file: "b.h"
+            .uleb(3) // line number
+            .uleb(2) // file number
+            .D8(crate::DW_MACRO_import.0) // import unit 2
+            .L32(macro_unit_2.clone()) // debug line offset to unit 2
+            .D8(crate::DW_MACRO_end_file.0) // end file: "b.h" -> "a.h"
+            .D8(crate::DW_MACRO_define.0) // define
+            .uleb(4) // line number
+            .append_bytes(b"B 3\0") // macro name
+            .D8(crate::DW_MACRO_end_file.0) // end file: "a.h" -> "a.c"
+            .D8(crate::DW_MACRO_define_strp.0) // define: "FUNCTION_LIKE_MACRO(x) 4+x"
+            .uleb(2) // line number
+            .D32(0) // macro name offset in the string table
+            .D8(crate::DW_MACRO_start_file.0) // start file: "b.h"
+            .uleb(3) // line number
+            .uleb(2) // file number
+            .D8(crate::DW_MACRO_import.0) // import unit 2
+            .L32(&macro_unit_2) // debug line offset to unit 2
+            .D8(crate::DW_MACRO_end_file.0) // end file: "b.h" -> "a.c"
+            .D8(crate::DW_MACRO_end_file.0) // end file: "a.c" -> ""
+            .D8(0)
+            //--------------------unit 1----------------------
+            .mark(&macro_unit_1) // start of unit 1
+            .D16(5) // Dwarf version
+            .D8(0b0000_0000) // Flags: offset_size = 0 (32-bit), debug_line_offset = 0, opcode_operands_table = 0
+            .D8(crate::DW_MACRO_define_strp.0) // define strp: "LONGER_MACRO 1"
+            .uleb(1) // line number
+            .L32(str_0.clone()) // macro name offset in the string table
+            .D8(crate::DW_MACRO_define.0) // define: "B 2"
+            .uleb(2) // line number
+            .append_bytes(b"B 2\0") // macro name
+            .D8(0) // end of unit
+            //---------------------unit 2---------------------
+            .mark(&macro_unit_2) // start of unit 2
+            .D16(5) // Dwarf version
+            .D8(0b0000_0000) // Flags: offset_size = 0 (32-bit), debug_line_offset = 0, opcode_operands_table = 0
+            .D8(crate::DW_MACRO_undef.0) // undef: "B"
+            .uleb(1) // line number
+            .append_bytes(b"B\0") // macro name
+            .D8(crate::DW_MACRO_define.0) // define: "D 3"
+            .uleb(2) // line number
+            .append_bytes(b"D 3\0") // macro name
+            .D8(crate::DW_MACRO_define_strp.0) // define strp: "FUNCTION_LIKE_MACRO(x) 4+x"
+            .uleb(2) // line number
+            .L32(str_1.clone()) // macro name offset in the string table
+            .D8(0); // end of unit
+
+        // Create a DebugMacro instance from the section
+        let str_section = str_section.get_contents().unwrap();
+        let debug_str = DebugStr::from(EndianSlice::new(&str_section, LittleEndian));
+
+        // Create a DebugMacro instance from the section
+        let macro_section = macro_section.get_contents().unwrap();
+        let debug_macro = DebugMacro::from(EndianSlice::new(&macro_section, LittleEndian));
+
+        // check the content of macro unit 0
+        let offset = macro_unit_0.value().unwrap() as usize;
+        let mut iter = debug_macro.get_macros(DebugMacroOffset(offset)).unwrap();
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 0, file: 0 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 1, file: 1 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Import { offset } if offset.0 == macro_unit_1.value().unwrap() as usize
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 3, file: 2 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Import { offset } if offset.0 == macro_unit_2.value().unwrap() as usize
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 4, text: MacroString::Direct(text)
+            } if text.slice() == b"B 3"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::StringPointer(text_offset)
+            } if text_offset.0 == str_0.value().unwrap() as usize
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::StartFile { line: 3, file: 2 }));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Import { offset } if offset.0 == macro_unit_2.value().unwrap() as usize
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(entry, MacroEntry::EndFile));
+        assert_eq!(iter.next(), Ok(None));
+
+        // check the content of macro unit 1
+        let offset = macro_unit_1.value().unwrap() as usize;
+        let mut iter = debug_macro.get_macros(DebugMacroOffset(offset)).unwrap();
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 1, text: MacroString::StringPointer(text_offset)
+            } if text_offset.0 == str_0.value().unwrap() as usize
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::Direct(text)
+            } if text.slice() == b"B 2"
+        ));
+        assert_eq!(iter.next(), Ok(None));
+
+        // check the content of macro unit 2
+        let offset = macro_unit_2.value().unwrap() as usize;
+        let mut iter = debug_macro.get_macros(DebugMacroOffset(offset)).unwrap();
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Undef {
+                line: 1, name: MacroString::Direct(name)
+            } if name.slice() == b"B"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::Direct(text)
+            } if text.slice() == b"D 3"
+        ));
+        let entry = iter.next().unwrap().unwrap();
+        assert!(matches!(
+            entry,
+            MacroEntry::Define {
+                line: 2, text: MacroString::StringPointer(text_offset)
+            } if text_offset.0 == str_1.value().unwrap() as usize
+        ));
+        assert_eq!(iter.next(), Ok(None));
+
+        // check the content of the string table
+        let text_offset = DebugStrOffset(str_0.value().unwrap() as usize);
+        assert_eq!(
+            debug_str.get_str(text_offset).unwrap().slice(),
+            b"FUNCTION_LIKE_MACRO(x) 4+x"
+        );
+        let text_offset = DebugStrOffset(str_1.value().unwrap() as usize);
+        assert_eq!(
+            debug_str.get_str(text_offset).unwrap().slice(),
+            b"LONGER_MACRO 1"
+        );
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -457,6 +457,10 @@ pub enum Error {
     UnknownIndexSectionV2(constants::DwSectV2),
     /// Invalid macinfo type in `.debug_macinfo`.
     InvalidMacinfoType(u8),
+    /// invalid macro type in `.debug_macro`.
+    InvalidMacroType(u8),
+    /// The optional `opcode_operands_table` in `.debug_macro` is currently not supported.
+    UnsupportedOpcodeOperandsTable,
 }
 
 impl fmt::Display for Error {
@@ -611,6 +615,10 @@ impl Error {
             Error::UnknownIndexSection(_) => "Unknown section type in `.dwp` index.",
             Error::UnknownIndexSectionV2(_) => "Unknown section type in version 2 `.dwp` index.",
             Error::InvalidMacinfoType(_) => "Invalid macinfo type in `.debug_macinfo`.",
+            Error::InvalidMacroType(_) => "Invalid macro type in `.debug_macro`.",
+            Error::UnsupportedOpcodeOperandsTable => {
+                "The optional `opcode_operands_table` in `.debug_macro` is currently not supported."
+            }
         }
     }
 }


### PR DESCRIPTION
.debug_macro replaces .debug_macinfo from Dwarf 5 onward.

The implementation is analogous to the code for .debug_macinfo, execpt that more cases need to be handled.

User defined debug_macro opcodes are not supported by this change, and an error would be triggered if one was encountered.
I might be wrong, but I think no one is using this anyway. In any case, it's not useful to me, so I decided not to implement this part of the spec. If turns out that someone _does_ use this after all, it can be added later.

One additional note regarding dwarfdump: it only dumps the .debug_macro units that are directly referenced from compilation units. This is the usual case.
With the new format, macro unit can reference other macro units using `DW_MACRO_import`, but these imported units are not dumped. Doing this would be a whole project, de-duplicating units, sorting units, etc., and I actually have no elf files that use `DW_MACRO_import`, so I wouldn't be able to test it.