### PR TITLE
Remove #[non_exhaustive] from read::CallFrameInstruction

### DIFF
--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -2958,7 +2958,6 @@ impl<T: ReaderOffset> RegisterRule<T> {
 
 /// A parsed call frame instruction.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum CallFrameInstruction<T: ReaderOffset> {
     // 6.4.2.1 Row Creation Methods
     /// > 1. DW_CFA_set_loc


### PR DESCRIPTION
Using `#[non_exhaustive]` disallows users of the library from exhaustively matching the enum. This is nice for semver, but terrible for library users who are now in the awkward position of having to remember to update their exhaustive match when updating gimli.

This is less than ideal. I would know, as I now have to deal with it.

PS: `RegisterRule` is also highly suspect, but as it hasn't yet created problems (for me at least), so I'll leave it be for now.