### PR TITLE
Remove check for compilation directory matching first file directory.

### DIFF
--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1024,9 +1024,6 @@ mod convert {
 
                 let comp_name = match from_header.file(0) {
                     Some(comp_file) => {
-                        if comp_file.directory_index() != 0 {
-                            return Err(ConvertError::InvalidDirectoryIndex);
-                        }
                         LineString::from(comp_file.path_name(), dwarf, line_strings, strings)?
                     }
                     None => LineString::new(&[][..], encoding, line_strings),


### PR DESCRIPTION
Fix for issue #765.

Use the directory index zero, which is the correct compilation directory and ignore the compilation file provided index.

In the testcase attached to the issue, the directory that the compilation was invoked in was `/`. The file itself was provided as an absolute path `/usr/src/lfr-test/gdb//fibonacci.c`. It's not strictly the case that the compilation file will have a directory that matches the compilation directory.

Simplified Compilation instruction invoked from `/`:
```
gcc  -gdwarf-5 -fPIC -c -o /tmp/fibonacci.o /usr/src/lfr-test/gdb//fibonacci.c
``` 

However, it does appear that the compilation directory being the first entry in the directories list assumption is upheld.
