### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ stable_deref_trait = { version = "1.1.0", default-features = false, optional = t
 # stable interface of this crate.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
-compiler_builtins = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 test-assembler = "0.1.3"
@@ -45,7 +44,7 @@ default = ["read-all", "write"]
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ["dep:core", "dep:alloc", "dep:compiler_builtins"]
+rustc-dep-of-std = ["dep:core", "dep:alloc"]
 
 [profile.test]
 split-debuginfo = "packed"


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993