### PR TITLE
write/unit: ignore DW_AT_GNU_locviews when converting attributes

### DIFF
--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1709,6 +1709,9 @@ pub(crate) mod convert {
                 if from_attr.name() == constants::DW_AT_sibling {
                     // This may point to a null entry, so we have to treat it differently.
                     self.set_sibling(true);
+                } else if from_attr.name() == constants::DW_AT_GNU_locviews {
+                    // This is a GNU extension that is not supported, and is safe to ignore.
+                    // TODO: remove this when we support it.
                 } else if let Some(attr) = Attribute::from(context, &from_attr)? {
                     self.set(attr.name, attr.value);
                 }


### PR DESCRIPTION
We don't yet support parsing the .debug_loc entries for DW_AT_GNU_locviews, and adding support for it is a low priority. DW_AT_GNU_locviews was designed so that consumers which don't understand it can ignore it, so this commit does that for the case of converting attributes in `write::UnitTable::from`.

Closes #766 cc @crzysdrs 