### PR TITLE
Add constants obsolete after DWARF 1.1

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -209,6 +209,13 @@ dw!(
 DwTag(u16) {
     DW_TAG_null = 0x00,
 
+// DWARF 1 only, obsolete in DWARF 2+.
+    DW_TAG_global_subroutine = 0x06,
+    DW_TAG_global_variable = 0x07,
+    DW_TAG_local_variable = 0x0c,
+    DW_TAG_subroutine = 0x14,
+
+// DWARF 1.
     DW_TAG_array_type = 0x01,
     DW_TAG_class_type = 0x02,
     DW_TAG_entry_point = 0x03,
@@ -237,6 +244,8 @@ DwTag(u16) {
     DW_TAG_set_type = 0x20,
     DW_TAG_subrange_type = 0x21,
     DW_TAG_with_stmt = 0x22,
+
+// DWARF 2.
     DW_TAG_access_declaration = 0x23,
     DW_TAG_base_type = 0x24,
     DW_TAG_catch_block = 0x25,
@@ -354,6 +363,16 @@ dw!(
 DwAt(u16) {
     DW_AT_null = 0x00,
 
+// DWARF 1 only, obsolete in DWARF 2+.
+    DW_AT_fund_type = 0x05,
+    DW_AT_mod_fund_type = 0x06,
+    DW_AT_user_def_type = 0x07,
+    DW_AT_mod_u_d_type = 0x08,
+    DW_AT_subscr_data = 0x0a,
+    DW_AT_element_list = 0x0f,
+    DW_AT_member = 0x14,
+
+// DWARF 1.
     DW_AT_sibling = 0x01,
     DW_AT_location = 0x02,
     DW_AT_name = 0x03,
@@ -384,6 +403,8 @@ DwAt(u16) {
     DW_AT_start_scope = 0x2c,
     DW_AT_bit_stride = 0x2e,
     DW_AT_upper_bound = 0x2f,
+
+// DWARF 2.
     DW_AT_abstract_origin = 0x31,
     DW_AT_accessibility = 0x32,
     DW_AT_address_class = 0x33,
@@ -664,6 +685,10 @@ dw!(
 DwForm(u16) {
     DW_FORM_null = 0x00,
 
+// DWARF 1 only, obsolete in DWARF 2+.
+    DW_FORM_ref = 0x02,
+
+// DWARF 1.
     DW_FORM_addr = 0x01,
     DW_FORM_block2 = 0x03,
     DW_FORM_block4 = 0x04,
@@ -671,6 +696,8 @@ DwForm(u16) {
     DW_FORM_data4 = 0x06,
     DW_FORM_data8 = 0x07,
     DW_FORM_string = 0x08,
+
+// DWARF 2.
     DW_FORM_block = 0x09,
     DW_FORM_block1 = 0x0a,
     DW_FORM_data1 = 0x0b,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -371,6 +371,16 @@ DwAt(u16) {
     DW_AT_subscr_data = 0x0a,
     DW_AT_element_list = 0x0f,
     DW_AT_member = 0x14,
+    DW_AT_friends = 0x1f,
+    DW_AT_program = 0x23,
+    DW_AT_private = 0x24,
+    DW_AT_protected = 0x26,
+    DW_AT_public = 0x28,
+    DW_AT_pure_virtual = 0x29,
+    DW_AT_virtual = 0x30,
+    
+// Moved to 0x47 in DWARF 2+.
+    DW_AT_specification_v1 = 0x2b,
 
 // DWARF 1.
     DW_AT_sibling = 0x01,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -378,7 +378,7 @@ DwAt(u16) {
     DW_AT_public = 0x28,
     DW_AT_pure_virtual = 0x29,
     DW_AT_virtual = 0x30,
-    
+
 // Moved to 0x47 in DWARF 2+.
     DW_AT_specification_v1 = 0x2b,
 


### PR DESCRIPTION
* The DWARF 1.1 specification includes some constants which are only relevant in that spec, and became obsolete in the later revisions of the spec.

* Currently the gimli does not include these constants because since DWARF 1.1 is a different structure and rarely relevant it does not support parsing of DWARF 1.1.

* However DWARF 1.1 is relevant to the decomp community. Since decomp tooling wants to depend on gimli anyways for DWARF 2+, it would be nice if it could also at least use gimli data structures for DWARF 1.1 rather than having to write something bespoke. Including the constants unique to DWARF 1.1 helps with that.

* This is unlikely to cause much confusion about what is supported since anyone who runs into DWARF 1.1 in practice is probably already deep in the weeds.

* The added values can be cross-referenced here in Python elftools to confirm that they are correct: https://github.com/eliben/pyelftools/blob/0c3283b3c872a0424bf4017a95ecee14aa6f17b8/elftools/dwarf/enums.py