### PR TITLE
write: fix handling of forward references in expressions

### DIFF
--- a/src/write/cfi.rs
+++ b/src/write/cfi.rs
@@ -455,7 +455,7 @@ impl CallFrameInstruction {
             }
             CallFrameInstruction::CfaExpression(ref expression) => {
                 w.write_u8(constants::DW_CFA_def_cfa_expression.0)?;
-                w.write_uleb128(expression.size(encoding, None) as u64)?;
+                w.write_uleb128(expression.size(encoding, None)? as u64)?;
                 expression.write(w, None, encoding, None)?;
             }
             CallFrameInstruction::Restore(register) => {
@@ -509,13 +509,13 @@ impl CallFrameInstruction {
             CallFrameInstruction::Expression(register, ref expression) => {
                 w.write_u8(constants::DW_CFA_expression.0)?;
                 w.write_uleb128(register.0.into())?;
-                w.write_uleb128(expression.size(encoding, None) as u64)?;
+                w.write_uleb128(expression.size(encoding, None)? as u64)?;
                 expression.write(w, None, encoding, None)?;
             }
             CallFrameInstruction::ValExpression(register, ref expression) => {
                 w.write_u8(constants::DW_CFA_val_expression.0)?;
                 w.write_uleb128(register.0.into())?;
-                w.write_uleb128(expression.size(encoding, None) as u64)?;
+                w.write_uleb128(expression.size(encoding, None)? as u64)?;
                 expression.write(w, None, encoding, None)?;
             }
             CallFrameInstruction::RememberState => {

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -295,7 +295,7 @@ fn write_expression<W: Writer>(
     unit_offsets: Option<&UnitOffsets>,
     val: &Expression,
 ) -> Result<()> {
-    let size = val.size(encoding, unit_offsets) as u64;
+    let size = val.size(encoding, unit_offsets)? as u64;
     if encoding.version <= 4 {
         w.write_udata(size, 2)?;
     } else {


### PR DESCRIPTION
Writing a reference can fail when:
- an expression contains a forward reference to a unit entry
- an expression or attribute contains a reference to a deleted entry

Return an error instead of hitting a debug assertion or writing a zero.

There was code that was meant to handle this already for forward references,
but it was wrong.