### PR TITLE
Make EndianSlice::new() a const function

### DIFF
--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -29,7 +29,7 @@ where
 {
     /// Construct a new `EndianSlice` with the given slice and endianity.
     #[inline]
-    pub fn new(slice: &'input [u8], endian: Endian) -> EndianSlice<'input, Endian> {
+    pub const fn new(slice: &'input [u8], endian: Endian) -> EndianSlice<'input, Endian> {
         EndianSlice { slice, endian }
     }
 


### PR DESCRIPTION
Declare `EndianSlice::new()` as a const function, to make it usable from const contexts.