### PR TITLE
Keep the string form of `DW_LNCT_LLVM_source` on conversion

### DIFF
--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -1204,7 +1204,7 @@ where
             .any(|x| x.content_type == constants::DW_LNCT_LLVM_source)
     }
 
-    pub(crate) fn source_form(&self) -> Option<constants::DwForm> {
+    pub(crate) fn file_source_form(&self) -> Option<constants::DwForm> {
         self.file_name_entry_format
             .iter()
             .find(|x| x.content_type == constants::DW_LNCT_LLVM_source)


### PR DESCRIPTION
With the existing conversion from a readable DWARF representation to one that is writable the `DW_LNCT_LLVM_source` string form is kept. When an empty source string is needed, it currently uses `DW_FORM_string` and a mismatch with `DW_LNCT_LLVM_source` results in an error when serializing.

Instead of always using `DW_FORM_string` when emitting empty source entries, use the same form as `DW_LNCT_LLVM_source` has.  This is only done on conversion, when creating a writable DWARF the existing logic is kept, and source expects `DW_FORM_string`.