### PR TITLE
Release 0.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 --------------------------------------------------------------------------------
 
+## 0.32.2
+
+Released 2025/08/26.
+
+### Changed
+
+* Removed `PartialEq<Debug*Offset>` implementations for `UnitSectionOffset`.
+  These were an unintended breaking change.
+  [#789](https://github.com/gimli-rs/gimli/pull/789)
+
+--------------------------------------------------------------------------------
+
 ## 0.32.1
 
 Released 2025/08/22.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gimli"
-version = "0.32.1"
+version = "0.32.2"
 categories = ["development-tools::debugging", "development-tools::profiling", "parser-implementations"]
 description = "A library for reading and writing the DWARF debugging format."
 documentation = "https://docs.rs/gimli"

--- a/src/common.rs
+++ b/src/common.rs
@@ -232,30 +232,6 @@ impl<T> From<DebugTypesOffset<T>> for UnitSectionOffset<T> {
     }
 }
 
-impl<T> PartialEq<DebugInfoOffset<T>> for UnitSectionOffset<T>
-where
-    T: PartialEq,
-{
-    fn eq(&self, other: &DebugInfoOffset<T>) -> bool {
-        match self {
-            UnitSectionOffset::DebugInfoOffset(o) => o.eq(other),
-            UnitSectionOffset::DebugTypesOffset(_) => false,
-        }
-    }
-}
-
-impl<T> PartialEq<DebugTypesOffset<T>> for UnitSectionOffset<T>
-where
-    T: PartialEq,
-{
-    fn eq(&self, other: &DebugTypesOffset<T>) -> bool {
-        match self {
-            UnitSectionOffset::DebugInfoOffset(_) => false,
-            UnitSectionOffset::DebugTypesOffset(o) => o.eq(other),
-        }
-    }
-}
-
 impl<T> UnitSectionOffset<T>
 where
     T: Clone,


### PR DESCRIPTION
Remove `PartialEq<Debug*Offset>` implementations for `UnitSectionOffset`. These were an unintended breaking change.