### PR TITLE
Rename `write::Reference` to `write::DebugInfoRef`

### DIFF
--- a/src/write/dwarf.rs
+++ b/src/write/dwarf.rs
@@ -100,9 +100,9 @@ impl DwarfUnit {
             &strings,
         )?;
         // None should exist because we didn't give out any UnitId.
-        assert!(sections.debug_info_refs.is_empty());
-        assert!(sections.debug_loc_refs.is_empty());
-        assert!(sections.debug_loclists_refs.is_empty());
+        assert!(sections.debug_info_fixups.is_empty());
+        assert!(sections.debug_loc_fixups.is_empty());
+        assert!(sections.debug_loclists_fixups.is_empty());
 
         abbrevs.write(&mut sections.debug_abbrev)?;
         Ok(())

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::common::{Encoding, LocationListsOffset, SectionId};
 use crate::write::{
-    Address, BaseId, DebugInfoReference, Error, Expression, Result, Section, Sections, UnitOffsets,
+    Address, BaseId, DebugInfoFixup, Error, Expression, Result, Section, Sections, UnitOffsets,
     Writer,
 };
 
@@ -68,13 +68,13 @@ impl LocationListTable {
         match encoding.version {
             2..=4 => self.write_loc(
                 &mut sections.debug_loc,
-                &mut sections.debug_loc_refs,
+                &mut sections.debug_loc_fixups,
                 encoding,
                 unit_offsets,
             ),
             5 => self.write_loclists(
                 &mut sections.debug_loclists,
-                &mut sections.debug_loclists_refs,
+                &mut sections.debug_loclists_fixups,
                 encoding,
                 unit_offsets,
             ),
@@ -86,7 +86,7 @@ impl LocationListTable {
     fn write_loc<W: Writer>(
         &self,
         w: &mut DebugLoc<W>,
-        refs: &mut Vec<DebugInfoReference>,
+        refs: &mut Vec<DebugInfoFixup>,
         encoding: Encoding,
         unit_offsets: Option<&UnitOffsets>,
     ) -> Result<LocationListOffsets> {
@@ -165,7 +165,7 @@ impl LocationListTable {
     fn write_loclists<W: Writer>(
         &self,
         w: &mut DebugLocLists<W>,
-        refs: &mut Vec<DebugInfoReference>,
+        refs: &mut Vec<DebugInfoFixup>,
         encoding: Encoding,
         unit_offsets: Option<&UnitOffsets>,
     ) -> Result<LocationListOffsets> {
@@ -290,7 +290,7 @@ pub enum Location {
 
 fn write_expression<W: Writer>(
     w: &mut W,
-    refs: &mut Vec<DebugInfoReference>,
+    refs: &mut Vec<DebugInfoFixup>,
     encoding: Encoding,
     unit_offsets: Option<&UnitOffsets>,
     val: &Expression,
@@ -496,8 +496,8 @@ mod tests {
 
                     let mut sections = Sections::new(EndianVec::new(LittleEndian));
                     let loc_list_offsets = locations.write(&mut sections, encoding, None).unwrap();
-                    assert!(sections.debug_loc_refs.is_empty());
-                    assert!(sections.debug_loclists_refs.is_empty());
+                    assert!(sections.debug_loc_fixups.is_empty());
+                    assert!(sections.debug_loclists_fixups.is_empty());
 
                     let read_debug_loc =
                         read::DebugLoc::new(sections.debug_loc.slice(), LittleEndian);

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -282,20 +282,6 @@ pub enum Address {
     },
 }
 
-/// A reference to a `.debug_info` entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Reference {
-    /// An external symbol.
-    ///
-    /// The meaning of this value is decided by the writer, but
-    /// will typically be an index into a symbol table.
-    Symbol(usize),
-    /// An entry in the same section.
-    ///
-    /// This only supports references in units that are emitted together.
-    Entry(UnitId, UnitEntryId),
-}
-
 // This type is only used in debug assertions.
 #[cfg(not(debug_assertions))]
 type BaseId = ();

--- a/src/write/section.rs
+++ b/src/write/section.rs
@@ -4,7 +4,7 @@ use std::vec::Vec;
 
 use crate::common::SectionId;
 use crate::write::{
-    DebugAbbrev, DebugFrame, DebugInfo, DebugInfoReference, DebugLine, DebugLineStr, DebugLoc,
+    DebugAbbrev, DebugFrame, DebugInfo, DebugInfoFixup, DebugLine, DebugLineStr, DebugLoc,
     DebugLocLists, DebugRanges, DebugRngLists, DebugStr, EhFrame, Writer,
 };
 
@@ -90,11 +90,11 @@ pub struct Sections<W: Writer> {
     /// The `.eh_frame` section.
     pub eh_frame: EhFrame<W>,
     /// Unresolved references in the `.debug_info` section.
-    pub(crate) debug_info_refs: Vec<DebugInfoReference>,
+    pub(crate) debug_info_fixups: Vec<DebugInfoFixup>,
     /// Unresolved references in the `.debug_loc` section.
-    pub(crate) debug_loc_refs: Vec<DebugInfoReference>,
+    pub(crate) debug_loc_fixups: Vec<DebugInfoFixup>,
     /// Unresolved references in the `.debug_loclists` section.
-    pub(crate) debug_loclists_refs: Vec<DebugInfoReference>,
+    pub(crate) debug_loclists_fixups: Vec<DebugInfoFixup>,
 }
 
 impl<W: Writer + Clone> Sections<W> {
@@ -112,9 +112,9 @@ impl<W: Writer + Clone> Sections<W> {
             debug_str: DebugStr(section.clone()),
             debug_frame: DebugFrame(section.clone()),
             eh_frame: EhFrame(section),
-            debug_info_refs: Vec::new(),
-            debug_loc_refs: Vec::new(),
-            debug_loclists_refs: Vec::new(),
+            debug_info_fixups: Vec::new(),
+            debug_loc_fixups: Vec::new(),
+            debug_loclists_fixups: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
`Reference` was too general a name, and the new name matches its use in `AttributeValue::DebugInfoRef`.

Also rename the private `DebugInfoReference` to `DebugInfoFixup`.