### PR TITLE
write: change unneeded `from` methods to private

### DIFF
--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1050,7 +1050,7 @@ mod convert {
         /// Create a line number program by reading the data from the given program.
         ///
         /// Return the program and a mapping from file index to `FileId`.
-        pub fn from<R: Reader<Offset = usize>>(
+        pub(crate) fn from<R: Reader<Offset = usize>>(
             mut from_program: read::IncompleteLineProgram<R>,
             dwarf: &read::Dwarf<R>,
             line_strings: &mut write::LineStringTable,

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1556,7 +1556,7 @@ pub(crate) mod convert {
         /// `Address::Constant(address)`. For relocatable addresses, it is the caller's
         /// responsibility to determine the symbol and addend corresponding to the address
         /// and return `Address::Symbol { symbol, addend }`.
-        pub fn from<R: Reader<Offset = usize>>(
+        pub(crate) fn from<R: Reader<Offset = usize>>(
             dwarf: &read::Dwarf<R>,
             line_strings: &mut write::LineStringTable,
             strings: &mut write::StringTable,


### PR DESCRIPTION
These methods expose too much of the internals of the conversion, and users should only need `Dwarf::from`. Low level conversion alternatives will be provided later.