### PR TITLE
Reduce the size of `UnitSectionOffset`

### DIFF
--- a/crates/examples/src/bin/convert.rs
+++ b/crates/examples/src/bin/convert.rs
@@ -218,13 +218,9 @@ fn convert_attributes<R: gimli::Reader<Offset = usize>>(
             Ok(value) => unit.unit.get_mut(id).set(attr.name(), value),
             Err(e) => {
                 // Invalid input DWARF has most often been seen for expressions.
-                let unit_offset = match unit.from_unit.header.offset() {
-                    gimli::UnitSectionOffset::DebugInfoOffset(o) => o.0,
-                    gimli::UnitSectionOffset::DebugTypesOffset(o) => o.0,
-                };
                 eprintln!(
                     "Warning: failed to convert attribute for DIE {:x}: {} = {:?}: {}",
-                    unit_offset + entry.offset.0,
+                    unit.from_unit.offset().0 + entry.offset.0,
                     attr.name(),
                     attr.raw_value(),
                     e

--- a/crates/examples/src/bin/dwarf-validate.rs
+++ b/crates/examples/src/bin/dwarf-validate.rs
@@ -156,11 +156,11 @@ fn validate_info<W, R>(
             Ok(None) => break,
             Ok(Some(u)) => u,
         };
-        last_offset = u.offset().as_debug_info_offset().unwrap().0 + u.length_including_self();
+        last_offset = u.offset().0 + u.length_including_self();
         units.push(u);
     }
     let process_unit = |unit: UnitHeader<R>| -> UnitSummary {
-        let unit_offset = unit.offset().as_debug_info_offset().unwrap();
+        let unit_offset = unit.offset().to_debug_info_offset(&unit).unwrap();
         let mut ret = UnitSummary {
             internally_valid: false,
             offset: unit_offset,

--- a/crates/examples/src/bin/simple.rs
+++ b/crates/examples/src/bin/simple.rs
@@ -130,10 +130,7 @@ fn dump_file(
     // Iterate over the compilation units.
     let mut iter = dwarf.units();
     while let Some(header) = iter.next()? {
-        println!(
-            "Unit at <.debug_info+0x{:x}>",
-            header.offset().as_debug_info_offset().unwrap().0
-        );
+        println!("Unit at <.debug_info+0x{:x}>", header.offset().0);
         let unit = dwarf.unit(header)?;
         let unit_ref = unit.unit_ref(&dwarf);
         dump_unit(unit_ref)?;

--- a/crates/examples/src/bin/simple_line.rs
+++ b/crates/examples/src/bin/simple_line.rs
@@ -47,7 +47,7 @@ fn dump_file(
     while let Some(header) = iter.next()? {
         println!(
             "Line number info for unit at <.debug_info+0x{:x}>",
-            header.offset().as_debug_info_offset().unwrap().0
+            header.offset().0
         );
         let unit = dwarf.unit(header)?;
         let unit = unit.unit_ref(&dwarf);

--- a/src/common.rs
+++ b/src/common.rs
@@ -212,45 +212,11 @@ impl<T> From<T> for EhFrameOffset<T> {
 }
 
 /// An offset into the `.debug_info` or `.debug_types` sections.
+///
+/// This type does not store which section the offset applies to. You will need to either
+/// determine that from the context of its use, or store a [`SectionId`] along with it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum UnitSectionOffset<T = usize> {
-    /// An offset into the `.debug_info` section.
-    DebugInfoOffset(DebugInfoOffset<T>),
-    /// An offset into the `.debug_types` section.
-    DebugTypesOffset(DebugTypesOffset<T>),
-}
-
-impl<T> From<DebugInfoOffset<T>> for UnitSectionOffset<T> {
-    fn from(offset: DebugInfoOffset<T>) -> Self {
-        UnitSectionOffset::DebugInfoOffset(offset)
-    }
-}
-
-impl<T> From<DebugTypesOffset<T>> for UnitSectionOffset<T> {
-    fn from(offset: DebugTypesOffset<T>) -> Self {
-        UnitSectionOffset::DebugTypesOffset(offset)
-    }
-}
-
-impl<T> UnitSectionOffset<T>
-where
-    T: Clone,
-{
-    /// Returns the `DebugInfoOffset` inside, or `None` otherwise.
-    pub fn as_debug_info_offset(&self) -> Option<DebugInfoOffset<T>> {
-        match self {
-            UnitSectionOffset::DebugInfoOffset(offset) => Some(offset.clone()),
-            UnitSectionOffset::DebugTypesOffset(_) => None,
-        }
-    }
-    /// Returns the `DebugTypesOffset` inside, or `None` otherwise.
-    pub fn as_debug_types_offset(&self) -> Option<DebugTypesOffset<T>> {
-        match self {
-            UnitSectionOffset::DebugInfoOffset(_) => None,
-            UnitSectionOffset::DebugTypesOffset(offset) => Some(offset.clone()),
-        }
-    }
-}
+pub struct UnitSectionOffset<T = usize>(pub T);
 
 /// An identifier for a DWARF section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]

--- a/src/read/value.rs
+++ b/src/read/value.rs
@@ -887,7 +887,7 @@ impl Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::{DebugAbbrevOffset, DebugInfoOffset, Encoding, Format};
+    use crate::common::{DebugAbbrevOffset, Encoding, Format, SectionId, UnitSectionOffset};
     use crate::endianity::LittleEndian;
     use crate::read::{
         Abbreviation, AttributeSpecification, DebuggingInformationEntry, EndianSlice, UnitHeader,
@@ -907,7 +907,8 @@ mod tests {
             7,
             UnitType::Compilation,
             DebugAbbrevOffset(0),
-            DebugInfoOffset(0).into(),
+            SectionId::DebugInfo,
+            UnitSectionOffset(0),
             EndianSlice::new(&[], LittleEndian),
         );
 

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -439,8 +439,8 @@ mod tests {
     use super::*;
     use crate::LittleEndian;
     use crate::common::{
-        DebugAbbrevOffset, DebugAddrBase, DebugInfoOffset, DebugLocListsBase, DebugRngListsBase,
-        DebugStrOffsetsBase, Format,
+        DebugAbbrevOffset, DebugAddrBase, DebugLocListsBase, DebugRngListsBase,
+        DebugStrOffsetsBase, Format, UnitSectionOffset,
     };
     use crate::read;
     use crate::write::{EndianVec, NoConvertDebugInfoRef};
@@ -512,7 +512,8 @@ mod tests {
                             0,
                             read::UnitType::Compilation,
                             DebugAbbrevOffset(0),
-                            DebugInfoOffset(0).into(),
+                            SectionId::DebugInfo,
+                            UnitSectionOffset(0),
                             read::EndianSlice::default(),
                         ),
                         abbreviations: Arc::new(read::Abbreviations::default()),

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -317,8 +317,8 @@ mod tests {
     use super::*;
     use crate::LittleEndian;
     use crate::common::{
-        DebugAbbrevOffset, DebugAddrBase, DebugInfoOffset, DebugLocListsBase, DebugRngListsBase,
-        DebugStrOffsetsBase, Format,
+        DebugAbbrevOffset, DebugAddrBase, DebugLocListsBase, DebugRngListsBase,
+        DebugStrOffsetsBase, Format, UnitSectionOffset,
     };
     use crate::read;
     use crate::write::{EndianVec, Range, RangeListTable};
@@ -377,7 +377,8 @@ mod tests {
                             0,
                             read::UnitType::Compilation,
                             DebugAbbrevOffset(0),
-                            DebugInfoOffset(0).into(),
+                            SectionId::DebugInfo,
+                            UnitSectionOffset(0),
                             read::EndianSlice::default(),
                         ),
                         abbreviations: Arc::new(read::Abbreviations::default()),


### PR DESCRIPTION
Change `UnitSectionOffset` from an enum to a simple newtype, and store a `SectionId` in `read::UnitHeader` instead.

`UnitSectionOffset` is intended for code that may be handling either `.debug_info` or `.debug_types`. However, you will usually have a `UnitHeader` you can use to determine the section type.

This significantly reduces the memory usage in the conversion code, where we need to store an offset for every entry in the section.

This required some changes to the `UnitSectionOffset` methods. To make things more consistent, I also changed these methods to use `UnitHeader` instead of `Unit`, and added a `Deref` impl to `Unit`.