### PR TITLE
write: use FNV for hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rust-version = "1.85"
 
 [dependencies]
 fallible-iterator = { version = "0.3.0", default-features = false, optional = true }
+fnv = { version = "1.0.7", optional = true }
 indexmap = { version = "2.0.0", optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false, optional = true }
 
@@ -38,7 +39,7 @@ read = ["read-core"]
 read-all = ["read", "std", "fallible-iterator", "endian-reader"]
 endian-reader = ["read", "dep:stable_deref_trait"]
 fallible-iterator = ["dep:fallible-iterator"]
-write = ["dep:indexmap"]
+write = ["dep:fnv", "dep:indexmap"]
 std = ["fallible-iterator?/std", "stable_deref_trait?/std"]
 default = ["read-all", "write"]
 

--- a/src/write/cfi.rs
+++ b/src/write/cfi.rs
@@ -597,7 +597,8 @@ pub(crate) mod convert {
     use super::*;
     use crate::read::{self, Reader};
     use crate::write::{ConvertError, ConvertResult, NoConvertDebugInfoRef};
-    use std::collections::{HashMap, hash_map};
+    use fnv::FnvHashMap as HashMap;
+    use std::collections::hash_map;
 
     impl FrameTable {
         /// Create a frame table by reading the data in the given section.
@@ -620,7 +621,7 @@ pub(crate) mod convert {
 
             let mut frame_table = FrameTable::default();
 
-            let mut cie_ids = HashMap::new();
+            let mut cie_ids = HashMap::default();
             let mut entries = frame.entries(&bases);
             while let Some(entry) = entries.next()? {
                 let partial = match entry {

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1523,7 +1523,7 @@ pub(crate) mod convert {
     use crate::write::{
         self, ConvertError, ConvertLineProgram, ConvertResult, Dwarf, LocationList, RangeList,
     };
-    use std::collections::{HashMap, HashSet};
+    use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 
     #[derive(Debug, Default)]
     struct FilterDependencies {
@@ -1537,7 +1537,7 @@ pub(crate) mod convert {
         /// This must be called before adding an edge from an entry.
         fn add_entry(&mut self, entry: UnitSectionOffset) {
             debug_assert!(!self.edges.contains_key(&entry));
-            self.edges.insert(entry, HashSet::new());
+            self.edges.insert(entry, HashSet::default());
         }
 
         /// If `from` is reachable then `to` is also reachable.
@@ -2062,7 +2062,7 @@ pub(crate) mod convert {
                 from_units: Vec::new(),
                 from_unit_index: 0,
                 from_skeleton_unit: None,
-                entry_ids: HashMap::new(),
+                entry_ids: HashMap::default(),
                 dwarf,
             };
 
@@ -2093,7 +2093,7 @@ pub(crate) mod convert {
                 from_units: Vec::new(),
                 from_unit_index: 0,
                 from_skeleton_unit: filter.skeleton_unit,
-                entry_ids: HashMap::new(),
+                entry_ids: HashMap::default(),
                 dwarf,
             };
 
@@ -2240,7 +2240,7 @@ pub(crate) mod convert {
             let unit_id = skeleton.unit_id;
             let unit = &mut *skeleton.unit;
 
-            let mut entry_ids = HashMap::new();
+            let mut entry_ids = HashMap::default();
             entry_ids.insert(root_offset, (unit_id, unit.root()));
             for offset in offsets {
                 entry_ids.insert(offset, (unit_id, unit.reserve()));


### PR DESCRIPTION
This significantly reduces both memory usage and instructions as measured by massif:
	Memory 241MB -> 202MB
	Instructions 10.24Gi -> 7.99 Gi