### PR TITLE
write: use FNV hash in more places

### DIFF
--- a/src/write/abbrev.rs
+++ b/src/write/abbrev.rs
@@ -1,10 +1,9 @@
 use alloc::vec::Vec;
-use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
 use crate::common::{DebugAbbrevOffset, SectionId};
 use crate::constants;
-use crate::write::{Result, Section, Writer};
+use crate::write::{FnvIndexSet, Result, Section, Writer};
 
 /// A table of abbreviations that will be stored in a `.debug_abbrev` section.
 // Requirements:
@@ -13,7 +12,7 @@ use crate::write::{Result, Section, Writer};
 // - inserting a duplicate returns the code of the existing value
 #[derive(Debug, Default)]
 pub(crate) struct AbbreviationTable {
-    abbrevs: IndexSet<Abbreviation>,
+    abbrevs: FnvIndexSet<Abbreviation>,
 }
 
 impl AbbreviationTable {

--- a/src/write/cfi.rs
+++ b/src/write/cfi.rs
@@ -1,10 +1,9 @@
 use alloc::vec::Vec;
-use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
 use crate::common::{DebugFrameOffset, EhFrameOffset, Encoding, Format, Register, SectionId};
 use crate::constants;
-use crate::write::{Address, BaseId, Error, Expression, Result, Section, Writer};
+use crate::write::{Address, BaseId, Error, Expression, FnvIndexSet, Result, Section, Writer};
 
 define_section!(
     DebugFrame,
@@ -22,7 +21,7 @@ pub struct FrameTable {
     /// Base id for CIEs.
     base_id: BaseId,
     /// The common information entries.
-    cies: IndexSet<CommonInformationEntry>,
+    cies: FnvIndexSet<CommonInformationEntry>,
     /// The frame description entries.
     fdes: Vec<(CieId, FrameDescriptionEntry)>,
 }
@@ -597,7 +596,7 @@ pub(crate) mod convert {
     use super::*;
     use crate::read::{self, Reader};
     use crate::write::{ConvertError, ConvertResult, NoConvertDebugInfoRef};
-    use fnv::FnvHashMap as HashMap;
+    use fnv::FnvHashMap;
     use std::collections::hash_map;
 
     impl FrameTable {
@@ -621,7 +620,7 @@ pub(crate) mod convert {
 
             let mut frame_table = FrameTable::default();
 
-            let mut cie_ids = HashMap::default();
+            let mut cie_ids = FnvHashMap::default();
             let mut entries = frame.entries(&bases);
             while let Some(entry) = entries.next()? {
                 let partial = match entry {

--- a/src/write/line.rs
+++ b/src/write/line.rs
@@ -1,12 +1,12 @@
 use alloc::vec::Vec;
-use indexmap::{IndexMap, IndexSet};
 use std::ops::{Deref, DerefMut};
 
 use crate::common::{DebugLineOffset, Encoding, Format, LineEncoding, SectionId};
 use crate::constants;
 use crate::leb128;
 use crate::write::{
-    Address, Error, LineStringId, LineStringTable, Result, Section, StringId, StringTable, Writer,
+    Address, Error, FnvIndexMap, FnvIndexSet, LineStringId, LineStringTable, Result, Section,
+    StringId, StringTable, Writer,
 };
 
 /// The number assigned to the first special opcode.
@@ -29,7 +29,7 @@ pub struct LineProgram {
     /// directory of the compilation unit.
     ///
     /// The first entry is for the working directory of the compilation unit.
-    directories: IndexSet<LineString>,
+    directories: FnvIndexSet<LineString>,
 
     /// A list of source file entries.
     ///
@@ -39,7 +39,7 @@ pub struct LineProgram {
     /// directory. Otherwise the directory is meaningless.
     ///
     /// Does not include comp_file, even for version >= 5.
-    files: IndexMap<(LineString, DirectoryId), FileInfo>,
+    files: FnvIndexMap<(LineString, DirectoryId), FileInfo>,
 
     /// True if the file entries may have valid timestamps.
     ///
@@ -114,8 +114,8 @@ impl LineProgram {
             none: false,
             encoding,
             line_encoding,
-            directories: IndexSet::new(),
-            files: IndexMap::new(),
+            directories: FnvIndexSet::default(),
+            files: FnvIndexMap::default(),
             prev_row: LineRow::initial_state(encoding, line_encoding),
             row: LineRow::initial_state(encoding, line_encoding),
             instructions: Vec::new(),
@@ -157,8 +157,8 @@ impl LineProgram {
             none: true,
             encoding,
             line_encoding,
-            directories: IndexSet::new(),
-            files: IndexMap::new(),
+            directories: FnvIndexSet::default(),
+            files: FnvIndexMap::default(),
             prev_row: LineRow::initial_state(encoding, line_encoding),
             row: LineRow::initial_state(encoding, line_encoding),
             instructions: Vec::new(),

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -1,11 +1,10 @@
 use alloc::vec::Vec;
-use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
 use crate::common::{Encoding, LocationListsOffset, SectionId};
 use crate::write::{
-    Address, BaseId, DebugInfoFixup, Error, Expression, Result, Section, Sections, UnitOffsets,
-    Writer,
+    Address, BaseId, DebugInfoFixup, Error, Expression, FnvIndexSet, Result, Section, Sections,
+    UnitOffsets, Writer,
 };
 
 define_section!(
@@ -33,7 +32,7 @@ define_id!(
 #[derive(Debug, Default)]
 pub struct LocationListTable {
     base_id: BaseId,
-    locations: IndexSet<LocationList>,
+    locations: FnvIndexSet<LocationList>,
 }
 
 impl LocationListTable {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -65,6 +65,9 @@ use std::result;
 
 use crate::constants;
 
+type FnvIndexMap<T, V> = indexmap::IndexMap<T, V, fnv::FnvBuildHasher>;
+type FnvIndexSet<T> = indexmap::IndexSet<T, fnv::FnvBuildHasher>;
+
 mod endian_vec;
 pub use self::endian_vec::*;
 

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -1,9 +1,8 @@
 use alloc::vec::Vec;
-use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
 use crate::common::{Encoding, RangeListsOffset, SectionId};
-use crate::write::{Address, BaseId, Error, Result, Section, Sections, Writer};
+use crate::write::{Address, BaseId, Error, FnvIndexSet, Result, Section, Sections, Writer};
 
 define_section!(
     DebugRanges,
@@ -30,7 +29,7 @@ define_id!(
 #[derive(Debug, Default)]
 pub struct RangeListTable {
     base_id: BaseId,
-    ranges: IndexSet<RangeList>,
+    ranges: FnvIndexSet<RangeList>,
 }
 
 impl RangeListTable {

--- a/src/write/str.rs
+++ b/src/write/str.rs
@@ -1,9 +1,8 @@
 use alloc::vec::Vec;
-use indexmap::IndexSet;
 use std::ops::{Deref, DerefMut};
 
 use crate::common::{DebugLineStrOffset, DebugStrOffset, SectionId};
-use crate::write::{BaseId, Result, Section, Writer};
+use crate::write::{BaseId, FnvIndexSet, Result, Section, Writer};
 
 // Requirements:
 // - values are `[u8]`, null bytes are not allowed
@@ -23,7 +22,7 @@ macro_rules! define_string_table {
         #[derive(Debug, Default)]
         pub struct $name {
             base_id: BaseId,
-            strings: IndexSet<Vec<u8>>,
+            strings: FnvIndexSet<Vec<u8>>,
             offsets: Vec<$offset>,
             len: usize,
         }

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1530,11 +1530,11 @@ pub(crate) mod convert {
     use crate::write::{
         self, ConvertError, ConvertLineProgram, ConvertResult, Dwarf, LocationList, RangeList,
     };
-    use fnv::FnvHashMap as HashMap;
+    use fnv::FnvHashMap;
 
     #[derive(Debug, Default)]
     struct FilterDependencies {
-        edges: HashMap<UnitSectionOffset, Vec<UnitSectionOffset>>,
+        edges: FnvHashMap<UnitSectionOffset, Vec<UnitSectionOffset>>,
         required: Vec<UnitSectionOffset>,
     }
 
@@ -2050,7 +2050,7 @@ pub(crate) mod convert {
         ///
         /// If this is set then `from_units` will contain exactly one unit.
         from_skeleton_unit: Option<read::UnitRef<'a, R>>,
-        entry_ids: HashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
+        entry_ids: FnvHashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
         dwarf: &'a mut Dwarf,
     }
 
@@ -2065,7 +2065,7 @@ pub(crate) mod convert {
                 from_units: Vec::new(),
                 from_unit_index: 0,
                 from_skeleton_unit: None,
-                entry_ids: HashMap::default(),
+                entry_ids: FnvHashMap::default(),
                 dwarf,
             };
 
@@ -2096,7 +2096,7 @@ pub(crate) mod convert {
                 from_units: Vec::new(),
                 from_unit_index: 0,
                 from_skeleton_unit: filter.skeleton_unit,
-                entry_ids: HashMap::default(),
+                entry_ids: FnvHashMap::default(),
                 dwarf,
             };
 
@@ -2184,7 +2184,7 @@ pub(crate) mod convert {
         from_dwarf: &'a read::Dwarf<R>,
         from_unit: read::Unit<R>,
         from_skeleton_unit: read::UnitRef<'a, R>,
-        entry_ids: HashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
+        entry_ids: FnvHashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
         unit_id: UnitId,
         unit: &'a mut write::Unit,
         line_strings: &'a mut write::LineStringTable,
@@ -2243,7 +2243,7 @@ pub(crate) mod convert {
             let unit_id = skeleton.unit_id;
             let unit = &mut *skeleton.unit;
 
-            let mut entry_ids = HashMap::default();
+            let mut entry_ids = FnvHashMap::default();
             entry_ids.insert(root_offset, (unit_id, unit.root()));
             for offset in offsets {
                 entry_ids.insert(offset, (unit_id, unit.reserve()));
@@ -2387,7 +2387,7 @@ pub(crate) mod convert {
         /// The table containing converted strings.
         pub strings: &'a mut write::StringTable,
         line_program_files: Vec<FileId>,
-        entry_ids: &'a HashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
+        entry_ids: &'a FnvHashMap<UnitSectionOffset, (UnitId, UnitEntryId)>,
         from_entries: read::EntriesRaw<'a, 'a, R>,
         parents: Vec<(isize, UnitEntryId)>,
     }


### PR DESCRIPTION
The abbreviations change noticeably improved performance. The other changes were too small to be sure, but I think it's probably better to switch them all.