### PR TITLE
Delete `AddressOrOffsetPair` for range and location lists

### DIFF
--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -1841,12 +1841,7 @@ fn dump_loc_list<R: Reader, W: Write>(
                 dump_exprloc(w, unit, data)?;
                 writeln!(w)?;
             }
-            gimli::RawLocListEntry::AddressOrOffsetPair {
-                begin,
-                end,
-                ref data,
-            }
-            | gimli::RawLocListEntry::OffsetPair {
+            gimli::RawLocListEntry::OffsetPair {
                 begin,
                 end,
                 ref data,
@@ -1936,8 +1931,7 @@ fn dump_range_list<R: Reader, W: Write>(
                 dump_range(w, range)?;
                 writeln!(w)?;
             }
-            gimli::RawRngListEntry::AddressOrOffsetPair { begin, end }
-            | gimli::RawRngListEntry::OffsetPair { begin, end } => {
+            gimli::RawRngListEntry::OffsetPair { begin, end } => {
                 write!(w, "<offset-pair {:#x}, {:#x}>", begin, end)?;
                 dump_range(w, range)?;
                 writeln!(w)?;

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -539,7 +539,23 @@ pub trait Reader: Debug + Clone {
     }
 
     /// Read an address-sized integer, and return it as a `u64`.
+    ///
+    /// This is an absolute address, and may have a relocation in
+    /// relocatable object files.
     fn read_address(&mut self, address_size: u8) -> Result<u64> {
+        match address_size {
+            1 => self.read_u8().map(u64::from),
+            2 => self.read_u16().map(u64::from),
+            4 => self.read_u32().map(u64::from),
+            8 => self.read_u64(),
+            otherwise => Err(Error::UnsupportedAddressSize(otherwise)),
+        }
+    }
+
+    /// Read an address-sized integer, and return it as a `u64`.
+    ///
+    /// This is an offset from an address, and will not have a relocation.
+    fn read_address_offset(&mut self, address_size: u8) -> Result<u64> {
         match address_size {
             1 => self.read_u8().map(u64::from),
             2 => self.read_u16().map(u64::from),

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -345,8 +345,6 @@ mod convert {
         InvalidUnitRef,
         /// A `.debug_info` reference is invalid.
         InvalidDebugInfoRef,
-        /// Invalid relative address in a range list.
-        InvalidRangeRelativeAddress,
         /// Writing this CFI instruction is not implemented yet.
         UnsupportedCfiInstruction,
         /// Writing indirect pointers is not implemented yet.
@@ -399,9 +397,6 @@ mod convert {
                 InvalidLineRef => write!(f, "A `.debug_line` reference is invalid."),
                 InvalidUnitRef => write!(f, "A `.debug_info` unit entry reference is invalid."),
                 InvalidDebugInfoRef => write!(f, "A `.debug_info` reference is invalid."),
-                InvalidRangeRelativeAddress => {
-                    write!(f, "Invalid relative address in a range list.")
-                }
                 UnsupportedCfiInstruction => {
                     write!(f, "Writing this CFI instruction is not implemented yet.")
                 }

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -3419,14 +3419,14 @@ mod tests {
             LittleEndian,
         ));
 
-        let range = RangeList(vec![Range::StartEnd {
-            begin: Address::Constant(0x1234),
-            end: Address::Constant(0x2345),
+        let range = RangeList(vec![Range::OffsetPair {
+            begin: 0x1234,
+            end: 0x2345,
         }]);
 
-        let location = LocationList(vec![Location::StartEnd {
-            begin: Address::Constant(0x1234),
-            end: Address::Constant(0x2345),
+        let location = LocationList(vec![Location::OffsetPair {
+            begin: 0x1234,
+            end: 0x2345,
             data: expression.clone(),
         }]);
 
@@ -3442,6 +3442,10 @@ mod tests {
                     let mut dwarf = Dwarf::new();
                     let unit = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
                     let unit = dwarf.units.get_mut(unit);
+                    unit.get_mut(unit.root()).set(
+                        constants::DW_AT_low_pc,
+                        AttributeValue::Address(Address::Constant(0)),
+                    );
                     let loc_id = unit.locations.add(location.clone());
                     let range_id = unit.ranges.add(range.clone());
                     // Create a string with a non-zero id/offset.


### PR DESCRIPTION
`AddressOrOffsetPair` was a hack to handle the way we always used `Reader::read_address` for ranges in DWARF version <= 4. We were doing this because we needed to use `read_address` for the case where the range is setting a base address.

A better way to handle this is to only use `read_address` if the first value is !0, signifying that the next value is a base address.

As part of this change, we no longer support writing `StartEnd` or `StartLength` for DWARF version <= 4. Our previous support for this wasn't correct, because consumers would still add the base address.

Closes #810. Originally added in #368.