### PR TITLE
Implement Iterator and remove use of FallibleIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ test-assembler = "0.1.3"
 [features]
 read-core = []
 read = ["read-core"]
-read-all = ["read", "std", "fallible-iterator", "endian-reader"]
+read-all = ["read", "std", "endian-reader"]
 endian-reader = ["read", "dep:stable_deref_trait"]
 fallible-iterator = ["dep:fallible-iterator"]
 write = ["dep:fnv", "dep:indexmap"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -779,7 +779,6 @@ fn bench_evaluating_debug_loc_expressions(b: &mut Bencher) {
 
 mod cfi {
     use super::*;
-    use fallible_iterator::FallibleIterator;
 
     use gimli::{
         BaseAddresses, CieOrFde, EhFrame, FrameDescriptionEntry, LittleEndian, UnwindContext,
@@ -944,7 +943,7 @@ mod cfi {
         fde: &FrameDescriptionEntry<R>,
     ) -> usize {
         fde.instructions(eh_frame, bases)
-            .fold(0, |count, _| Ok(count + 1))
+            .try_fold(0, |count, i| i.map(|_| count + 1))
             .expect("fold over instructions OK")
     }
 

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -115,6 +115,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for AddrHeaderIter<R> {
     }
 }
 
+impl<R: Reader> Iterator for AddrHeaderIter<R> {
+    type Item = Result<AddrHeader<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        AddrHeaderIter::next(self).transpose()
+    }
+}
+
 /// A header for a set of entries in the `.debug_addr` section.
 ///
 /// These entries all belong to a single unit.
@@ -210,9 +218,6 @@ where
 }
 
 /// An iterator over the addresses from a `.debug_addr` section.
-///
-/// Can be [used with
-/// `FallibleIterator`](./index.html#using-with-fallibleiterator).
 #[derive(Debug, Clone)]
 pub struct AddrEntryIter<R: Reader> {
     input: R,
@@ -248,6 +253,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for AddrEntryIter<R> {
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         AddrEntryIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for AddrEntryIter<R> {
+    type Item = Result<u64>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        AddrEntryIter::next(self).transpose()
     }
 }
 

--- a/src/read/aranges.rs
+++ b/src/read/aranges.rs
@@ -124,6 +124,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for ArangeHeaderIter<R> {
     }
 }
 
+impl<R: Reader> Iterator for ArangeHeaderIter<R> {
+    type Item = Result<ArangeHeader<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        ArangeHeaderIter::next(self).transpose()
+    }
+}
+
 /// A header for a set of entries in the `.debug_arange` section.
 ///
 /// These entries all belong to a single unit.
@@ -232,9 +240,6 @@ where
 }
 
 /// An iterator over the aranges from a `.debug_aranges` section.
-///
-/// Can be [used with
-/// `FallibleIterator`](./index.html#using-with-fallibleiterator).
 #[derive(Debug, Clone)]
 pub struct ArangeEntryIter<R: Reader> {
     input: R,
@@ -310,6 +315,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for ArangeEntryIter<R> {
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         ArangeEntryIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for ArangeEntryIter<R> {
+    type Item = Result<ArangeEntry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        ArangeEntryIter::next(self).transpose()
     }
 }
 

--- a/src/read/dwarf.rs
+++ b/src/read/dwarf.rs
@@ -348,9 +348,6 @@ impl<R: Reader> Dwarf<R> {
     }
 
     /// Iterate the unit headers in the `.debug_info` section.
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     #[inline]
     pub fn units(&self) -> DebugInfoUnitHeadersIter<R> {
         self.debug_info.units()
@@ -363,9 +360,6 @@ impl<R: Reader> Dwarf<R> {
     }
 
     /// Iterate the type-unit headers in the `.debug_types` section.
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     #[inline]
     pub fn type_units(&self) -> DebugTypesUnitHeadersIter<R> {
         self.debug_types.units()
@@ -1631,6 +1625,15 @@ impl<R: Reader> fallible_iterator::FallibleIterator for RangeIter<R> {
     #[inline]
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         RangeIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for RangeIter<R> {
+    type Item = Result<Range>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        RangeIter::next(self).transpose()
     }
 }
 

--- a/src/read/line.rs
+++ b/src/read/line.rs
@@ -221,7 +221,7 @@ where
     /// an instruction, then `Err(e)` is returned.
     ///
     /// Unfortunately, the references mean that this cannot be a
-    /// `FallibleIterator`.
+    /// `Iterator`.
     pub fn next_row(&mut self) -> Result<Option<(&LineProgramHeader<R, Offset>, &LineRow)>> {
         // Perform any reset that was required after copying the previous row.
         self.row.reset(self.program.header());
@@ -533,7 +533,7 @@ impl<R: Reader> LineInstructions<R> {
     /// `Ok(None)`.
     ///
     /// Unfortunately, the `header` parameter means that this cannot be a
-    /// `FallibleIterator`.
+    /// `Iterator`.
     #[inline(always)]
     pub fn next_instruction(
         &mut self,

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -195,9 +195,6 @@ impl<R: Reader> LocationLists<R> {
     /// The `base_address` should be obtained from the `DW_AT_low_pc` attribute in the
     /// `DW_TAG_compile_unit` entry for the compilation unit that contains this location
     /// list.
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn locations(
         &self,
         offset: LocationListsOffset<R::Offset>,
@@ -240,9 +237,6 @@ impl<R: Reader> LocationLists<R> {
     ///
     /// This iterator does not perform any processing of the location entries,
     /// such as handling base addresses.
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn raw_locations(
         &self,
         offset: LocationListsOffset<R::Offset>,
@@ -527,6 +521,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for RawLocListIter<R> {
     }
 }
 
+impl<R: Reader> Iterator for RawLocListIter<R> {
+    type Item = Result<RawLocListEntry<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        RawLocListIter::next(self).transpose()
+    }
+}
+
 /// An iterator over a location list.
 ///
 /// This iterator internally handles processing of base address selection entries
@@ -671,6 +673,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for LocListIter<R> {
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         LocListIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for LocListIter<R> {
+    type Item = Result<LocationListEntry<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        LocListIter::next(self).transpose()
     }
 }
 

--- a/src/read/lookup.rs
+++ b/src/read/lookup.rs
@@ -90,8 +90,6 @@ where
     /// parsed and yielded. If an error occurs while parsing the next entry,
     /// then this error is returned as `Err(e)`, and all subsequent calls return
     /// `Ok(None)`.
-    ///
-    /// Can be [used with `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn next(&mut self) -> Result<Option<Parser::Entry>> {
         loop {
             if let Some((ref mut input, ref header)) = self.current_set

--- a/src/read/macros.rs
+++ b/src/read/macros.rs
@@ -447,6 +447,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for MacroIter<R> {
     }
 }
 
+impl<R: Reader> Iterator for MacroIter<R> {
+    type Item = Result<MacroEntry<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        MacroIter::next(self).transpose()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -2,7 +2,6 @@
 //!
 //! * [Example Usage](#example-usage)
 //! * [API Structure](#api-structure)
-//! * [Using with `FallibleIterator`](#using-with-fallibleiterator)
 //!
 //! ## Example Usage
 //!
@@ -129,51 +128,6 @@
 //!   used to index into the [`DebugLine`](./struct.DebugLine.html) type because
 //!   `DebugLine` represents the `.debug_line` section. There are similar types
 //!   for offsets relative to a compilation unit rather than a section.
-//!
-//! ## Using with `FallibleIterator`
-//!
-//! The standard library's `Iterator` trait and related APIs do not play well
-//! with iterators where the `next` operation is fallible. One can make the
-//! `Iterator`'s associated `Item` type be a `Result<T, E>`, however the
-//! provided methods cannot gracefully handle the case when an `Err` is
-//! returned.
-//!
-//! This situation led to the
-//! [`fallible-iterator`](https://crates.io/crates/fallible-iterator) crate's
-//! existence. You can read more of the rationale for its existence in its
-//! docs. The crate provides the helpers you have come to expect (eg `map`,
-//! `filter`, etc) for iterators that can fail.
-//!
-//! `gimli`'s many lazy parsing iterators are a perfect match for the
-//! `fallible-iterator` crate's `FallibleIterator` trait because parsing is not
-//! done eagerly. Parse errors later in the input might only be discovered after
-//! having iterated through many items.
-//!
-//! To use `gimli` iterators with `FallibleIterator`, import the crate and trait
-//! into your code:
-//!
-//! ```
-//! # #[cfg(feature = "fallible-iterator")]
-//! # fn foo() {
-//! // Use the `FallibleIterator` trait so its methods are in scope!
-//! use fallible_iterator::FallibleIterator;
-//! use gimli::{DebugAranges, EndianSlice, LittleEndian};
-//!
-//! fn find_sum_of_address_range_lengths(aranges: DebugAranges<EndianSlice<LittleEndian>>)
-//!     -> gimli::Result<u64>
-//! {
-//!     // `DebugAranges::headers` returns a `FallibleIterator`!
-//!     aranges.headers()
-//!         // `flat_map` is provided by `FallibleIterator`!
-//!         .flat_map(|header| Ok(header.entries()))
-//!         // `map` is provided by `FallibleIterator`!
-//!         .map(|arange| Ok(arange.length()))
-//!         // `fold` is provided by `FallibleIterator`!
-//!         .fold(0, |sum, len| Ok(sum + len))
-//! }
-//! # }
-//! # fn main() {}
-//! ```
 
 use core::fmt::{self, Debug};
 use core::result;

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -1013,6 +1013,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for OperationIter<R> {
     }
 }
 
+impl<R: Reader> Iterator for OperationIter<R> {
+    type Item = Result<Operation<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        OperationIter::next(self).transpose()
+    }
+}
+
 /// Specification of what storage should be used for [`Evaluation`].
 ///
 #[cfg_attr(

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -111,9 +111,6 @@ impl<R: Reader> From<R> for DebugPubNames<R> {
 }
 
 /// An iterator over the pubnames from a `.debug_pubnames` section.
-///
-/// Can be [used with
-/// `FallibleIterator`](./index.html#using-with-fallibleiterator).
 #[derive(Debug, Clone)]
 pub struct PubNamesEntryIter<R: Reader>(LookupEntryIter<R, PubStuffParser<R, PubNamesEntry<R>>>);
 
@@ -137,5 +134,13 @@ impl<R: Reader> fallible_iterator::FallibleIterator for PubNamesEntryIter<R> {
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()
+    }
+}
+
+impl<R: Reader> Iterator for PubNamesEntryIter<R> {
+    type Item = Result<PubNamesEntry<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().transpose()
     }
 }

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -111,9 +111,6 @@ impl<R: Reader> From<R> for DebugPubTypes<R> {
 }
 
 /// An iterator over the pubtypes from a `.debug_pubtypes` section.
-///
-/// Can be [used with
-/// `FallibleIterator`](./index.html#using-with-fallibleiterator).
 #[derive(Debug, Clone)]
 pub struct PubTypesEntryIter<R: Reader>(LookupEntryIter<R, PubStuffParser<R, PubTypesEntry<R>>>);
 
@@ -137,5 +134,13 @@ impl<R: Reader> fallible_iterator::FallibleIterator for PubTypesEntryIter<R> {
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         self.0.next()
+    }
+}
+
+impl<R: Reader> Iterator for PubTypesEntryIter<R> {
+    type Item = Result<PubTypesEntry<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().transpose()
     }
 }

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -213,9 +213,6 @@ impl<R: Reader> RangeLists<R> {
     ///
     /// The `base_address` should be obtained from the `DW_AT_low_pc` attribute in the
     /// `DW_TAG_compile_unit` entry for the compilation unit that contains this range list.
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn ranges(
         &self,
         offset: RangeListsOffset<R::Offset>,
@@ -239,9 +236,6 @@ impl<R: Reader> RangeLists<R> {
     ///
     /// This iterator does not perform any processing of the range entries,
     /// such as handling base addresses.
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn raw_ranges(
         &self,
         offset: RangeListsOffset<R::Offset>,
@@ -464,6 +458,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for RawRngListIter<R> {
     }
 }
 
+impl<R: Reader> Iterator for RawRngListIter<R> {
+    type Item = Result<RawRngListEntry<R::Offset>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        RawRngListIter::next(self).transpose()
+    }
+}
+
 /// An iterator over an address range list.
 ///
 /// This iterator internally handles processing of base addresses and different
@@ -590,6 +592,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for RngListIter<R> {
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         RngListIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for RngListIter<R> {
+    type Item = Result<Range>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        RngListIter::next(self).transpose()
     }
 }
 

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -211,9 +211,6 @@ impl<R: Reader> DebugInfo<R> {
     ///     println!("unit's length is {}", unit.unit_length());
     /// }
     /// ```
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn units(&self) -> DebugInfoUnitHeadersIter<R> {
         DebugInfoUnitHeadersIter {
             input: self.debug_info_section.clone(),
@@ -299,6 +296,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for DebugInfoUnitHeadersIter
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         DebugInfoUnitHeadersIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for DebugInfoUnitHeadersIter<R> {
+    type Item = Result<UnitHeader<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        DebugInfoUnitHeadersIter::next(self).transpose()
     }
 }
 
@@ -3107,9 +3112,6 @@ impl<R: Reader> DebugTypes<R> {
     ///     println!("unit's length is {}", unit.unit_length());
     /// }
     /// ```
-    ///
-    /// Can be [used with
-    /// `FallibleIterator`](./index.html#using-with-fallibleiterator).
     pub fn units(&self) -> DebugTypesUnitHeadersIter<R> {
         DebugTypesUnitHeadersIter {
             input: self.debug_types_section.clone(),
@@ -3157,6 +3159,14 @@ impl<R: Reader> fallible_iterator::FallibleIterator for DebugTypesUnitHeadersIte
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
         DebugTypesUnitHeadersIter::next(self)
+    }
+}
+
+impl<R: Reader> Iterator for DebugTypesUnitHeadersIter<R> {
+    type Item = Result<UnitHeader<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        DebugTypesUnitHeadersIter::next(self).transpose()
     }
 }
 


### PR DESCRIPTION
The Rust ecosystem in general hasn't taken up use of `FallibleIterator`, preferring instead to use `Iterator` with `Item=Result<_>`.

Our own uses aren't hard to convert to use `Iterator` with the std library alone. There may be other crates that can help too, such as itertools.

We still implement `FallibleIterator` for existing users that want it, but don't enable it by default or document it.

Closes #620 (@khuey)