### PR TITLE
Add `read::UnitHeader::debug_info_offset`

### DIFF
--- a/crates/examples/src/bin/dwarf-validate.rs
+++ b/crates/examples/src/bin/dwarf-validate.rs
@@ -160,7 +160,7 @@ fn validate_info<W, R>(
         units.push(u);
     }
     let process_unit = |unit: UnitHeader<R>| -> UnitSummary {
-        let unit_offset = unit.offset().to_debug_info_offset(&unit).unwrap();
+        let unit_offset = unit.debug_info_offset().unwrap();
         let mut ret = UnitSummary {
             internally_valid: false,
             offset: unit_offset,

--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -1073,7 +1073,7 @@ fn dump_unit<R: Reader, W: Write>(
     dwo_parent_units: Option<&HashMap<gimli::DwoId, gimli::Unit<R>>>,
     flags: &Flags,
 ) -> Result<()> {
-    let offset = if let Some(o) = header.offset().to_debug_info_offset(&header) {
+    let offset = if let Some(o) = header.debug_info_offset() {
         if let Some(offset) = flags.info_offset {
             if offset == o {
                 // If the offset points to the very start of the unit, we

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -453,6 +453,20 @@ where
         self.unit_offset
     }
 
+    /// Get the offset of this unit as an offset within the `.debug_info` section.
+    ///
+    /// Returns `None` if this unit is not in the `.debug_info` section.
+    pub fn debug_info_offset(&self) -> Option<DebugInfoOffset<Offset>> {
+        self.unit_offset.to_debug_info_offset(self)
+    }
+
+    /// Get the offset of this unit as an offset within the `.debug_types` section.
+    ///
+    /// Returns `None` if this unit is not in the `.debug_types` section.
+    pub fn debug_types_offset(&self) -> Option<DebugTypesOffset<Offset>> {
+        self.unit_offset.to_debug_types_offset(self)
+    }
+
     /// Return the serialized size of the common unit header for the given
     /// DWARF format.
     pub fn size_of_header(&self) -> usize {


### PR DESCRIPTION
This is simpler than calling `UnitHeader::offset` and converting.