### PR TITLE
Remove `#[non_exhaustive]` from `read::RegisterRule`

### DIFF
--- a/src/read/cfi.rs
+++ b/src/read/cfi.rs
@@ -2912,7 +2912,6 @@ impl<T: ReaderOffset> CfaRule<T> {
 /// has been saved and the rule to find the value for the register in the
 /// previous frame."
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum RegisterRule<T: ReaderOffset> {
     /// > A register that has this rule has no recoverable value in the previous
     /// > frame. (By convention, it is not preserved by a callee.)


### PR DESCRIPTION
We previously did this for `read::CallFrameInstruction` in #764. Do this `RegisterRule` too because at least one user wants it:
https://github.com/nbdd0121/unwinding/blob/3bc28cec6c30eade0e1caa094b49db78101b19ef/src/unwinder/frame.rs#L148