### PR TITLE
Don't depend on fallible-iterator/std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ read-all = ["read", "std", "endian-reader"]
 endian-reader = ["read", "dep:stable_deref_trait"]
 fallible-iterator = ["dep:fallible-iterator"]
 write = ["dep:fnv", "dep:indexmap"]
-std = ["fallible-iterator?/std", "stable_deref_trait?/std"]
+std = ["stable_deref_trait?/std"]
 default = ["read-all", "write"]
 
 # Internal feature, only used when building as part of libstd, not part of the


### PR DESCRIPTION
We don't need it, and this seems to avoid adding fallible-iterator to the Cargo.lock of downstream users when they have std enabled but not fallible-iterator.