### PR TITLE
Fix no_std with write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.88"
 [dependencies]
 fallible-iterator = { version = "0.3.0", default-features = false, optional = true }
 fnv = { version = "1.0.7", optional = true }
-indexmap = { version = "2.0.0", optional = true }
+indexmap = { version = "2.0.0", default-features = false, optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
@@ -41,7 +41,7 @@ read-all = ["read", "std", "endian-reader"]
 endian-reader = ["read", "dep:stable_deref_trait"]
 fallible-iterator = ["dep:fallible-iterator"]
 write = ["dep:fnv", "dep:indexmap"]
-std = ["stable_deref_trait?/std"]
+std = ["stable_deref_trait?/std", "indexmap?/std"]
 default = ["read-all", "write"]
 
 # Internal feature, only used when building as part of libstd, not part of the


### PR DESCRIPTION
This allows for this crate to be use in a no_std environment.

Tbh I haven't tested the changes, only changed import of indexmap 