### PR TITLE
Add no_std support for write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ rust-version = "1.88"
 
 [dependencies]
 fallible-iterator = { version = "0.3.0", default-features = false, optional = true }
-fnv = { version = "1.0.7", optional = true }
-indexmap = { version = "2.0.0", optional = true }
+fnv = { version = "1.0.7", default-features = false, optional = true }
+hashbrown = { version = "0.16.0", default-features = false, optional = true }
+indexmap = { version = "2.0.0", default-features = false, optional = true }
 stable_deref_trait = { version = "1.1.0", default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
@@ -40,7 +41,7 @@ read = ["read-core"]
 read-all = ["read", "std", "endian-reader"]
 endian-reader = ["read", "dep:stable_deref_trait"]
 fallible-iterator = ["dep:fallible-iterator"]
-write = ["dep:fnv", "dep:indexmap"]
+write = ["dep:fnv", "dep:hashbrown", "dep:indexmap"]
 std = ["stable_deref_trait?/std"]
 default = ["read-all", "write"]
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["read", "std"]
 
 [[bin]]
 name = "simple_write"
-required-features = ["write"]
+required-features = ["write", "std"]
 
 [[bin]]
 name = "simple_convert"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,22 @@
 //!
 //! Cargo features that can be enabled with `gimli`:
 //!
-//! * `std`: Enabled by default. Use the `std` library. Disabling this feature
-//!   allows using `gimli` in embedded environments that do not have access to
-//!   `std`. Note that even when `std` is disabled, `gimli` still requires an
-//!   implementation of the `alloc` crate.
+//! * `std`: Enabled by default. Use the `std` library. Disabling this feature allows
+//!   using `gimli` in embedded environments that do not have access to `std`.
 //!
-//! * `read`: Enabled by default. Enables the `read` module. Use of `std` is
-//!   optional.
+//! * `read`: Enabled by default. Enables the `read` module. Use of `std` is optional.
+//!   Requires the `alloc` crate.
 //!
-//! * `write`: Enabled by default. Enables the `write` module. Always uses
-//!   the `std` library.
+//! * `read-core`: Enabled by default. Enables a subset of the `read` module that does
+//!   not require the `alloc` crate.
+//!
+//! * `endian-reader`: Enabled by default. Enables the [`EndianReader`] trait. This is
+//!   a separate feature because it also depends on the `stable_deref_trait` crate.
+//!
+//! * `write`: Enabled by default. Enables the `write` module. Use of `std` is optional.
+//!   Requires the `alloc` crate. Enabling both `read` and `write` will also enable
+//!   conversion functionality in the `write` module.
+//!
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 // Selectively enable rust 2018 warnings
@@ -45,7 +51,7 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(any(feature = "std", feature = "write"))]
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -129,10 +129,11 @@
 //!   `DebugLine` represents the `.debug_line` section. There are similar types
 //!   for offsets relative to a compilation unit rather than a section.
 
+use core::error;
 use core::fmt::{self, Debug};
 use core::result;
 #[cfg(feature = "std")]
-use std::{error, io};
+use std::io;
 
 use crate::common::{Register, SectionId};
 use crate::constants;
@@ -579,7 +580,6 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for Error {}
 
 #[cfg(feature = "std")]

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -2944,10 +2944,10 @@ mod tests {
                 AssemblerEntry::U32(num) => push(&mut result, u64::from(num), 4),
                 AssemblerEntry::U64(num) => push(&mut result, num, 8),
                 AssemblerEntry::Uleb(num) => {
-                    leb128::write::unsigned(&mut result, num).unwrap();
+                    result.extend(leb128::write::Leb128::unsigned(num).bytes());
                 }
                 AssemblerEntry::Sleb(num) => {
-                    leb128::write::signed(&mut result, num as i64).unwrap();
+                    result.extend(leb128::write::Leb128::signed(num as i64).bytes());
                 }
             }
         }

--- a/src/read/unit.rs
+++ b/src/read/unit.rs
@@ -3192,7 +3192,7 @@ mod tests {
     use crate::constants;
     use crate::constants::*;
     use crate::endianity::{Endianity, LittleEndian};
-    use crate::leb128;
+    use crate::leb128::write::Leb128;
     use crate::read::abbrev::tests::AbbrevSectionMethods;
     use crate::read::{
         Abbreviation, AttributeSpecification, DebugAbbrev, EndianSlice, Error, Result,
@@ -4404,12 +4404,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_udata() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_udata;
@@ -4419,12 +4417,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_sdata() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::signed(&mut writable, -4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::signed(-4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_sdata;
@@ -4547,12 +4543,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_refudata() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_ref_udata;
@@ -4696,12 +4690,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_strx() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_strx;
@@ -4747,12 +4739,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_addrx() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_addrx;
@@ -4798,12 +4788,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_loclistx() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_loclistx;
@@ -4813,12 +4801,10 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_rnglistx() {
-        let mut buf = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, 4097).expect("should write ok")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(4097).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_rnglistx;
@@ -4828,14 +4814,11 @@ mod tests {
 
     #[test]
     fn test_parse_attribute_indirect() {
-        let mut buf = [0; 100];
-
-        let bytes_written = {
-            let mut writable = &mut buf[..];
-            leb128::write::unsigned(&mut writable, constants::DW_FORM_udata.0.into())
-                .expect("should write udata")
-                + leb128::write::unsigned(&mut writable, 9_999_999).expect("should write value")
-        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(constants::DW_FORM_udata.0.into()).bytes());
+        buf.extend_from_slice(Leb128::unsigned(9_999_999).bytes());
+        let bytes_written = buf.len();
+        buf.extend_from_slice(&[0; 10]);
 
         let unit = test_parse_attribute_unit_default();
         let form = constants::DW_FORM_indirect;
@@ -4850,10 +4833,9 @@ mod tests {
             version: 4,
             address_size: 4,
         };
-        let mut buf = [0; 100];
-        let mut writable = &mut buf[..];
-        leb128::write::unsigned(&mut writable, constants::DW_FORM_implicit_const.0.into())
-            .expect("should write implicit_const");
+        let mut buf = Vec::new();
+        buf.extend_from_slice(Leb128::unsigned(constants::DW_FORM_implicit_const.0.into()).bytes());
+        buf.extend_from_slice(&[0; 10]);
 
         let input = &mut EndianSlice::new(&buf, LittleEndian);
         let spec =

--- a/src/write/abbrev.rs
+++ b/src/write/abbrev.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use crate::common::{DebugAbbrevOffset, SectionId};
 use crate::constants;

--- a/src/write/cfi.rs
+++ b/src/write/cfi.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use crate::common::{DebugFrameOffset, EhFrameOffset, Encoding, Format, Register, SectionId};
 use crate::constants;
@@ -596,8 +596,9 @@ pub(crate) mod convert {
     use super::*;
     use crate::read::{self, Reader};
     use crate::write::{ConvertError, ConvertResult, NoConvertDebugInfoRef};
-    use fnv::FnvHashMap;
-    use std::collections::hash_map;
+    use hashbrown::hash_map;
+
+    type FnvHashMap<K, V> = hashbrown::HashMap<K, V, fnv::FnvBuildHasher>;
 
     impl FrameTable {
         /// Create a frame table by reading the data in the given section.

--- a/src/write/endian_vec.rs
+++ b/src/write/endian_vec.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use std::mem;
+use core::mem;
 
 use crate::endianity::Endianity;
 use crate::write::{Error, Result, Writer};

--- a/src/write/loc.rs
+++ b/src/write/loc.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use crate::common::{Encoding, LocationListsOffset, SectionId};
 use crate::write::{
@@ -436,7 +436,7 @@ mod tests {
     };
     use crate::read;
     use crate::write::{EndianVec, NoConvertDebugInfoRef};
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     #[test]
     fn test_loc_list() {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -59,9 +59,9 @@
 //! #     example().unwrap();
 //! # }
 
-use std::error;
-use std::fmt;
-use std::result;
+use core::error;
+use core::fmt;
+use core::result;
 
 use crate::constants;
 
@@ -297,7 +297,7 @@ struct BaseId(usize);
 #[cfg(debug_assertions)]
 impl Default for BaseId {
     fn default() -> Self {
-        use std::sync::atomic;
+        use core::sync::atomic;
         static BASE_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
         BaseId(BASE_ID.fetch_add(1, atomic::Ordering::Relaxed))
     }

--- a/src/write/range.rs
+++ b/src/write/range.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use crate::common::{Encoding, RangeListsOffset, SectionId};
 use crate::write::{Address, BaseId, Error, FnvIndexSet, Result, Section, Sections, Writer};
@@ -331,7 +331,7 @@ mod tests {
     };
     use crate::read;
     use crate::write::{EndianVec, Range, RangeListTable};
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     #[test]
     fn test_range() {

--- a/src/write/section.rs
+++ b/src/write/section.rs
@@ -1,6 +1,6 @@
-use std::ops::DerefMut;
-use std::result;
-use std::vec::Vec;
+use alloc::vec::Vec;
+use core::ops::DerefMut;
+use core::result;
 
 use crate::common::SectionId;
 use crate::write::{

--- a/src/write/str.rs
+++ b/src/write/str.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use crate::common::{DebugLineStrOffset, DebugStrOffset, SectionId};
 use crate::write::{BaseId, FnvIndexSet, Result, Section, Writer};

--- a/src/write/unit.rs
+++ b/src/write/unit.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
-use std::ops::{Deref, DerefMut};
-use std::slice;
+use core::ops::{Deref, DerefMut};
+use core::slice;
 
 use crate::common::{
     DebugAbbrevOffset, DebugInfoOffset, DebugLineOffset, DebugMacinfoOffset, DebugMacroOffset,
@@ -1555,7 +1555,8 @@ pub(crate) mod convert {
     use crate::write::{
         self, ConvertError, ConvertLineProgram, ConvertResult, Dwarf, LocationList, RangeList,
     };
-    use fnv::FnvHashMap;
+
+    type FnvHashMap<K, V> = hashbrown::HashMap<K, V, fnv::FnvBuildHasher>;
 
     #[derive(Debug, Default)]
     struct FilterDependencies {
@@ -3096,7 +3097,7 @@ mod tests {
     use crate::write::{
         Dwarf, DwarfUnit, EndianVec, LineString, Location, LocationList, Range, RangeList,
     };
-    use std::mem;
+    use core::mem;
 
     #[test]
     fn test_unit_table() {
@@ -3218,10 +3219,6 @@ mod tests {
 
         let mut sections = Sections::new(EndianVec::new(LittleEndian));
         dwarf.write(&mut sections).unwrap();
-
-        println!("{:?}", sections.debug_str);
-        println!("{:?}", sections.debug_info);
-        println!("{:?}", sections.debug_abbrev);
 
         let read_dwarf = sections.read(LittleEndian);
         let mut read_units = read_dwarf.units();
@@ -3793,9 +3790,6 @@ mod tests {
         let mut sections = Sections::new(EndianVec::new(LittleEndian));
         dwarf.write(&mut sections).unwrap();
 
-        println!("{:?}", sections.debug_info);
-        println!("{:?}", sections.debug_abbrev);
-
         let read_dwarf = sections.read(LittleEndian);
         let mut read_units = read_dwarf.units();
 
@@ -3982,9 +3976,6 @@ mod tests {
 
         let mut sections = Sections::new(EndianVec::new(LittleEndian));
         dwarf.write(&mut sections).unwrap();
-
-        println!("{:?}", sections.debug_info);
-        println!("{:?}", sections.debug_abbrev);
 
         let read_dwarf = sections.read(LittleEndian);
         let mut read_units = read_dwarf.units();

--- a/src/write/writer.rs
+++ b/src/write/writer.rs
@@ -1,7 +1,7 @@
 use crate::common::{Format, SectionId};
 use crate::constants;
 use crate::endianity::Endianity;
-use crate::leb128;
+use crate::leb128::write::Leb128;
 use crate::write::{Address, Error, Result};
 
 /// A trait for writing the data to a DWARF section.
@@ -293,18 +293,12 @@ pub trait Writer {
 
     /// Write an unsigned LEB128 encoded integer.
     fn write_uleb128(&mut self, val: u64) -> Result<()> {
-        let mut bytes = [0u8; 10];
-        // bytes is long enough so this will never fail.
-        let len = leb128::write::unsigned(&mut { &mut bytes[..] }, val).unwrap();
-        self.write(&bytes[..len])
+        self.write(Leb128::unsigned(val).bytes())
     }
 
-    /// Read an unsigned LEB128 encoded integer.
+    /// Write a signed LEB128 encoded integer.
     fn write_sleb128(&mut self, val: i64) -> Result<()> {
-        let mut bytes = [0u8; 10];
-        // bytes is long enough so this will never fail.
-        let len = leb128::write::signed(&mut { &mut bytes[..] }, val).unwrap();
-        self.write(&bytes[..len])
+        self.write(Leb128::signed(val).bytes())
     }
 
     /// Write an initial length according to the given DWARF format.


### PR DESCRIPTION
Added leb128::write::Leb128 to allow writing without std::io::Write. Switched to hashbrown for HashMap.