### PR TITLE
Update changelog to note breaking change in 0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## 0.33.1
 
-Released 2026/03/29.
+~Released 2026/03/29.~ Yanked due to breaking change.
 
-### Added
+### Breaking change
 
 * Added Wasm location support to `read::Evaluation`.
   [#871](https://github.com/gimli-rs/gimli/pull/871)


### PR DESCRIPTION
0.33.1 has been yanked from crates.io. Since the only other change in that release was minor, I'm going to hold off releasing 0.33.2 or 0.34.0 until there is a need.