### PR TITLE
Optimize unsigned LEB128 decoding more

### DIFF
--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -88,10 +88,6 @@ pub mod read {
 
         loop {
             let byte = r.read_u8()?;
-            if shift == 63 && byte != 0x00 && byte != 0x01 {
-                return Err(Error::BadUnsignedLeb128);
-            }
-
             let low_bits = u64::from(low_bits_of_byte(byte));
             result |= low_bits << shift;
 
@@ -100,7 +96,19 @@ pub mod read {
             }
 
             shift += 7;
+            if shift >= 63 {
+                break;
+            }
         }
+
+        // The 10th byte (shift == 63) can only contribute bit 63.
+        // Valid values are 0x00 or 0x01 (no continuation bit allowed).
+        let byte = r.read_u8()?;
+        if byte != 0x00 && byte != 0x01 {
+            return Err(Error::BadUnsignedLeb128);
+        }
+        result |= u64::from(byte) << 63;
+        Ok(result)
     }
 
     /// Read an LEB128 u16 from the given `Reader` and

--- a/src/read/endian_slice.rs
+++ b/src/read/endian_slice.rs
@@ -230,6 +230,18 @@ where
         self.slice.is_empty()
     }
 
+    // NB: This implementation is not strictly necessary, but it results
+    //     in better code gen than the default.
+    #[inline]
+    fn read_u8(&mut self) -> Result<u8> {
+        if let Some((&byte, rest)) = self.slice.split_first() {
+            self.slice = rest;
+            Ok(byte)
+        } else {
+            Err(Error::UnexpectedEof(self.offset_id()))
+        }
+    }
+
     #[inline]
     fn empty(&mut self) {
         self.slice = &[];


### PR DESCRIPTION
Optimize LEB128 decoding some more (after https://github.com/gimli-rs/gimli/pull/795). Improvements are more significant as per my testing. Please refer to individual commits.