### PR TITLE
read/lookup: remove unneeded traits

### DIFF
--- a/src/read/lookup.rs
+++ b/src/read/lookup.rs
@@ -1,101 +1,45 @@
-use core::marker::PhantomData;
-
 use crate::common::{DebugInfoOffset, Format};
 use crate::read::{Error, Reader, ReaderOffset, Result, UnitOffset};
 
-// The various "Accelerated Access" sections (DWARF standard v4 Section 6.1) all have
-// similar structures. They consist of a header with metadata and an offset into the
-// .debug_info section for the entire compilation unit, and a series
-// of following entries that list addresses (for .debug_aranges) or names
-// (for .debug_pubnames and .debug_pubtypes) that are covered.
+// Common parsing for the `.debug_pub*` sections (DWARF v4 Section 6.1.1, Lookup by Name).
 //
-// Because these three tables all have similar structures, we abstract out some of
-// the parsing mechanics.
-
-pub trait LookupParser<R: Reader> {
-    /// The type of the produced header.
-    type Header;
-    /// The type of the produced entry.
-    type Entry;
-
-    /// Parse a header from `input`. Returns a tuple of `input` sliced to contain just the entries
-    /// corresponding to this header (without the header itself), and the parsed representation of
-    /// the header itself.
-    fn parse_header(input: &mut R) -> Result<(R, Self::Header)>;
-
-    /// Parse a single entry from `input`. Returns either a parsed representation of the entry
-    /// or None if `input` is exhausted.
-    fn parse_entry(input: &mut R, header: &Self::Header) -> Result<Option<Self::Entry>>;
-}
+// These sections consist of sets of data. Each set has a header with metadata followed by
+// a series of entries.
 
 #[derive(Clone, Debug)]
-pub struct DebugLookup<R, Parser>
-where
-    R: Reader,
-    Parser: LookupParser<R>,
-{
-    input_buffer: R,
-    phantom: PhantomData<Parser>,
+pub(crate) struct DebugPubSet<R: Reader> {
+    pub(crate) section: R,
 }
 
-impl<R, Parser> From<R> for DebugLookup<R, Parser>
-where
-    R: Reader,
-    Parser: LookupParser<R>,
-{
-    fn from(input_buffer: R) -> Self {
-        DebugLookup {
-            input_buffer,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<R, Parser> DebugLookup<R, Parser>
-where
-    R: Reader,
-    Parser: LookupParser<R>,
-{
-    pub fn items(&self) -> LookupEntryIter<R, Parser> {
-        LookupEntryIter {
+impl<R: Reader> DebugPubSet<R> {
+    pub(crate) fn items(&self) -> PubSetEntryIter<R> {
+        PubSetEntryIter {
             current_set: None,
-            remaining_input: self.input_buffer.clone(),
+            remaining_input: self.section.clone(),
         }
-    }
-
-    pub fn reader(&self) -> &R {
-        &self.input_buffer
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct LookupEntryIter<R, Parser>
-where
-    R: Reader,
-    Parser: LookupParser<R>,
-{
-    current_set: Option<(R, Parser::Header)>, // Only none at the very beginning and end.
+pub(crate) struct PubSetEntryIter<R: Reader> {
+    current_set: Option<(R, PubSetHeader<R::Offset>)>, // Only none at the very beginning and end.
     remaining_input: R,
 }
 
-impl<R, Parser> LookupEntryIter<R, Parser>
-where
-    R: Reader,
-    Parser: LookupParser<R>,
-{
+impl<R: Reader> PubSetEntryIter<R> {
     /// Advance the iterator and return the next entry.
     ///
-    /// Returns the newly parsed entry as `Ok(Some(Parser::Entry))`. Returns
+    /// Returns the newly parsed entry as `Ok(Some(PubSetEntry))`. Returns
     /// `Ok(None)` when iteration is complete and all entries have already been
     /// parsed and yielded. If an error occurs while parsing the next entry,
     /// then this error is returned as `Err(e)`, and all subsequent calls return
     /// `Ok(None)`.
-    pub fn next(&mut self) -> Result<Option<Parser::Entry>> {
+    pub(crate) fn next(&mut self) -> Result<Option<PubSetEntry<R>>> {
         loop {
             if let Some((ref mut input, ref header)) = self.current_set
                 && !input.is_empty()
             {
-                match Parser::parse_entry(input, header) {
+                match PubSetEntry::parse(input, header) {
                     Ok(Some(entry)) => return Ok(Some(entry)),
                     Ok(None) => {}
                     Err(e) => {
@@ -109,7 +53,7 @@ where
                 self.current_set = None;
                 return Ok(None);
             }
-            match Parser::parse_header(&mut self.remaining_input) {
+            match PubSetHeader::parse(&mut self.remaining_input) {
                 Ok(set) => {
                     self.current_set = Some(set);
                 }
@@ -124,7 +68,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PubStuffHeader<T = usize> {
+pub(crate) struct PubSetHeader<T = usize> {
     format: Format,
     length: T,
     version: u16,
@@ -132,35 +76,10 @@ pub struct PubStuffHeader<T = usize> {
     unit_length: T,
 }
 
-pub trait PubStuffEntry<R: Reader> {
-    fn new(
-        die_offset: UnitOffset<R::Offset>,
-        name: R,
-        unit_header_offset: DebugInfoOffset<R::Offset>,
-    ) -> Self;
-}
-
-#[derive(Clone, Debug)]
-pub struct PubStuffParser<R, Entry>
-where
-    R: Reader,
-    Entry: PubStuffEntry<R>,
-{
-    // This struct is never instantiated.
-    phantom: PhantomData<(R, Entry)>,
-}
-
-impl<R, Entry> LookupParser<R> for PubStuffParser<R, Entry>
-where
-    R: Reader,
-    Entry: PubStuffEntry<R>,
-{
-    type Header = PubStuffHeader<R::Offset>;
-    type Entry = Entry;
-
-    /// Parse an pubthings set header. Returns a tuple of the
-    /// pubthings to be parsed for this set, and the newly created PubThingHeader struct.
-    fn parse_header(input: &mut R) -> Result<(R, Self::Header)> {
+impl<T: ReaderOffset> PubSetHeader<T> {
+    /// Parse a set header. Returns a tuple of the entry data to be parsed for
+    /// this set, and the newly created `PubSetHeader` struct.
+    fn parse<R: Reader<Offset = T>>(input: &mut R) -> Result<(R, PubSetHeader<R::Offset>)> {
         let (length, format) = input.read_initial_length()?;
         let mut rest = input.split(length)?;
 
@@ -172,7 +91,7 @@ where
         let unit_offset = rest.read_offset(format).map(DebugInfoOffset)?;
         let unit_length = rest.read_length(format)?;
 
-        let header = PubStuffHeader {
+        let header = PubSetHeader {
             format,
             length,
             version,
@@ -181,20 +100,29 @@ where
         };
         Ok((rest, header))
     }
+}
 
-    /// Parse a single pubthing. Return `None` for the null pubthing, `Some` for an actual pubthing.
-    fn parse_entry(input: &mut R, header: &Self::Header) -> Result<Option<Self::Entry>> {
+#[derive(Debug, Clone)]
+pub(crate) struct PubSetEntry<R: Reader> {
+    pub(crate) unit_header_offset: DebugInfoOffset<R::Offset>,
+    pub(crate) die_offset: UnitOffset<R::Offset>,
+    pub(crate) name: R,
+}
+
+impl<R: Reader> PubSetEntry<R> {
+    /// Parse a single set entry. Return `None` for the null entry.
+    fn parse(input: &mut R, header: &PubSetHeader<R::Offset>) -> Result<Option<PubSetEntry<R>>> {
         let offset = input.read_offset(header.format)?;
         if offset.into_u64() == 0 {
             input.empty();
             Ok(None)
         } else {
             let name = input.read_null_terminated_slice()?;
-            Ok(Some(Self::Entry::new(
-                UnitOffset(offset),
+            Ok(Some(PubSetEntry {
+                die_offset: UnitOffset(offset),
                 name,
-                header.unit_offset,
-            )))
+                unit_header_offset: header.unit_offset,
+            }))
         }
     }
 }

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -1,53 +1,35 @@
 use crate::common::{DebugInfoOffset, SectionId};
 use crate::endianity::Endianity;
-use crate::read::lookup::{DebugLookup, LookupEntryIter, PubStuffEntry, PubStuffParser};
+use crate::read::lookup::{DebugPubSet, PubSetEntry, PubSetEntryIter};
 use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
 
 /// A single parsed pubname.
 #[derive(Debug, Clone)]
-pub struct PubNamesEntry<R: Reader> {
-    unit_header_offset: DebugInfoOffset<R::Offset>,
-    die_offset: UnitOffset<R::Offset>,
-    name: R,
-}
+pub struct PubNamesEntry<R: Reader>(PubSetEntry<R>);
 
 impl<R: Reader> PubNamesEntry<R> {
     /// Returns the name this entry refers to.
     pub fn name(&self) -> &R {
-        &self.name
+        &self.0.name
     }
 
     /// Returns the offset into the .debug_info section for the header of the compilation unit
     /// which contains this name.
     pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
-        self.unit_header_offset
+        self.0.unit_header_offset
     }
 
     /// Returns the offset into the compilation unit for the debugging information entry which
     /// has this name.
     pub fn die_offset(&self) -> UnitOffset<R::Offset> {
-        self.die_offset
-    }
-}
-
-impl<R: Reader> PubStuffEntry<R> for PubNamesEntry<R> {
-    fn new(
-        die_offset: UnitOffset<R::Offset>,
-        name: R,
-        unit_header_offset: DebugInfoOffset<R::Offset>,
-    ) -> Self {
-        PubNamesEntry {
-            unit_header_offset,
-            die_offset,
-            name,
-        }
+        self.0.die_offset
     }
 }
 
 /// The `DebugPubNames` struct represents the DWARF public names information
 /// found in the `.debug_pubnames` section.
 #[derive(Debug, Clone)]
-pub struct DebugPubNames<R: Reader>(DebugLookup<R, PubStuffParser<R, PubNamesEntry<R>>>);
+pub struct DebugPubNames<R: Reader>(DebugPubSet<R>);
 
 impl<'input, Endian> DebugPubNames<EndianSlice<'input, Endian>>
 where
@@ -68,8 +50,8 @@ where
     /// let debug_pubnames =
     ///     DebugPubNames::new(read_debug_pubnames_section_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_pubnames_section: &'input [u8], endian: Endian) -> Self {
-        Self::from(EndianSlice::new(debug_pubnames_section, endian))
+    pub fn new(section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianSlice::new(section, endian))
     }
 }
 
@@ -100,19 +82,19 @@ impl<R: Reader> Section<R> for DebugPubNames<R> {
     }
 
     fn reader(&self) -> &R {
-        self.0.reader()
+        &self.0.section
     }
 }
 
 impl<R: Reader> From<R> for DebugPubNames<R> {
-    fn from(debug_pubnames_section: R) -> Self {
-        DebugPubNames(DebugLookup::from(debug_pubnames_section))
+    fn from(section: R) -> Self {
+        DebugPubNames(DebugPubSet { section })
     }
 }
 
 /// An iterator over the pubnames from a `.debug_pubnames` section.
 #[derive(Debug, Clone)]
-pub struct PubNamesEntryIter<R: Reader>(LookupEntryIter<R, PubStuffParser<R, PubNamesEntry<R>>>);
+pub struct PubNamesEntryIter<R: Reader>(PubSetEntryIter<R>);
 
 impl<R: Reader> PubNamesEntryIter<R> {
     /// Advance the iterator and return the next pubname.
@@ -123,7 +105,7 @@ impl<R: Reader> PubNamesEntryIter<R> {
     /// then this error is returned as `Err(e)`, and all subsequent calls return
     /// `Ok(None)`.
     pub fn next(&mut self) -> Result<Option<PubNamesEntry<R>>> {
-        self.0.next()
+        self.0.next().map(|x| x.map(PubNamesEntry))
     }
 }
 
@@ -133,7 +115,7 @@ impl<R: Reader> fallible_iterator::FallibleIterator for PubNamesEntryIter<R> {
     type Error = crate::read::Error;
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
-        self.0.next()
+        self.next()
     }
 }
 
@@ -141,6 +123,6 @@ impl<R: Reader> Iterator for PubNamesEntryIter<R> {
     type Item = Result<PubNamesEntry<R>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().transpose()
+        self.next().transpose()
     }
 }

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -1,53 +1,35 @@
 use crate::common::{DebugInfoOffset, SectionId};
 use crate::endianity::Endianity;
-use crate::read::lookup::{DebugLookup, LookupEntryIter, PubStuffEntry, PubStuffParser};
+use crate::read::lookup::{DebugPubSet, PubSetEntry, PubSetEntryIter};
 use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
 
 /// A single parsed pubtype.
 #[derive(Debug, Clone)]
-pub struct PubTypesEntry<R: Reader> {
-    unit_header_offset: DebugInfoOffset<R::Offset>,
-    die_offset: UnitOffset<R::Offset>,
-    name: R,
-}
+pub struct PubTypesEntry<R: Reader>(PubSetEntry<R>);
 
 impl<R: Reader> PubTypesEntry<R> {
     /// Returns the name of the type this entry refers to.
     pub fn name(&self) -> &R {
-        &self.name
+        &self.0.name
     }
 
     /// Returns the offset into the .debug_info section for the header of the compilation unit
     /// which contains the type with this name.
     pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
-        self.unit_header_offset
+        self.0.unit_header_offset
     }
 
     /// Returns the offset into the compilation unit for the debugging information entry which
     /// the type with this name.
     pub fn die_offset(&self) -> UnitOffset<R::Offset> {
-        self.die_offset
-    }
-}
-
-impl<R: Reader> PubStuffEntry<R> for PubTypesEntry<R> {
-    fn new(
-        die_offset: UnitOffset<R::Offset>,
-        name: R,
-        unit_header_offset: DebugInfoOffset<R::Offset>,
-    ) -> Self {
-        PubTypesEntry {
-            unit_header_offset,
-            die_offset,
-            name,
-        }
+        self.0.die_offset
     }
 }
 
 /// The `DebugPubTypes` struct represents the DWARF public types information
 /// found in the `.debug_info` section.
 #[derive(Debug, Clone)]
-pub struct DebugPubTypes<R: Reader>(DebugLookup<R, PubStuffParser<R, PubTypesEntry<R>>>);
+pub struct DebugPubTypes<R: Reader>(DebugPubSet<R>);
 
 impl<'input, Endian> DebugPubTypes<EndianSlice<'input, Endian>>
 where
@@ -68,8 +50,8 @@ where
     /// let debug_pubtypes =
     ///     DebugPubTypes::new(read_debug_pubtypes_somehow(), LittleEndian);
     /// ```
-    pub fn new(debug_pubtypes_section: &'input [u8], endian: Endian) -> Self {
-        Self::from(EndianSlice::new(debug_pubtypes_section, endian))
+    pub fn new(section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianSlice::new(section, endian))
     }
 }
 
@@ -100,19 +82,19 @@ impl<R: Reader> Section<R> for DebugPubTypes<R> {
     }
 
     fn reader(&self) -> &R {
-        self.0.reader()
+        &self.0.section
     }
 }
 
 impl<R: Reader> From<R> for DebugPubTypes<R> {
-    fn from(debug_pubtypes_section: R) -> Self {
-        DebugPubTypes(DebugLookup::from(debug_pubtypes_section))
+    fn from(section: R) -> Self {
+        DebugPubTypes(DebugPubSet { section })
     }
 }
 
 /// An iterator over the pubtypes from a `.debug_pubtypes` section.
 #[derive(Debug, Clone)]
-pub struct PubTypesEntryIter<R: Reader>(LookupEntryIter<R, PubStuffParser<R, PubTypesEntry<R>>>);
+pub struct PubTypesEntryIter<R: Reader>(PubSetEntryIter<R>);
 
 impl<R: Reader> PubTypesEntryIter<R> {
     /// Advance the iterator and return the next pubtype.
@@ -123,7 +105,7 @@ impl<R: Reader> PubTypesEntryIter<R> {
     /// then this error is returned as `Err(e)`, and all subsequent calls return
     /// `Ok(None)`.
     pub fn next(&mut self) -> Result<Option<PubTypesEntry<R>>> {
-        self.0.next()
+        self.0.next().map(|x| x.map(PubTypesEntry))
     }
 }
 
@@ -133,7 +115,7 @@ impl<R: Reader> fallible_iterator::FallibleIterator for PubTypesEntryIter<R> {
     type Error = crate::read::Error;
 
     fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
-        self.0.next()
+        self.next()
     }
 }
 
@@ -141,6 +123,6 @@ impl<R: Reader> Iterator for PubTypesEntryIter<R> {
     type Item = Result<PubTypesEntry<R>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().transpose()
+        self.next().transpose()
     }
 }


### PR DESCRIPTION
These were originally used for .debug_aranges too, but that diverged.