### PR TITLE
read: add iterators for pubnames/pubtypes sets

### DIFF
--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -183,16 +183,17 @@ impl<'a, R: gimli::Reader<Offset = usize> + Send + Sync> Reader for Relocate<'a,
 
 #[derive(Default)]
 struct Flags<'a> {
-    eh_frame: bool,
-    goff: bool,
+    addr: bool,
+    aranges: bool,
     info: bool,
-    types: bool,
     line: bool,
+    names: bool,
     pubnames: bool,
     pubtypes: bool,
-    aranges: bool,
-    addr: bool,
-    names: bool,
+    types: bool,
+    eh_frame: bool,
+
+    goff: bool,
     dwo: bool,
     dwp: bool,
     dwo_parent: Option<object::File<'a>>,
@@ -210,20 +211,17 @@ fn print_usage(opts: &getopts::Options) -> ! {
 
 fn main() {
     let mut opts = getopts::Options::new();
-    opts.optflag(
-        "",
-        "eh-frame",
-        "print .eh-frame exception handling frame information",
-    );
     opts.optflag("G", "", "show global die offsets");
     opts.optflag("i", "", "print .debug_info and .debug_types sections");
-    opts.optflagopt("", "debug-info", "print .debug_info section", "OFFSET");
-    opts.optflag("l", "", "print .debug_line section");
-    opts.optflag("p", "", "print .debug_pubnames section");
-    opts.optflag("r", "", "print .debug_aranges section");
-    opts.optflag("y", "", "print .debug_pubtypes section");
     opts.optflag("", "debug-addr", "print .debug_addr section");
+    opts.optflag("r", "debug-aranges", "print .debug_aranges section");
+    opts.optflagopt("", "debug-info", "print .debug_info section", "OFFSET");
+    opts.optflag("l", "debug-line", "print .debug_line section");
     opts.optflag("", "debug-names", "print .debug_names section");
+    opts.optflag("p", "debug-pubnames", "print .debug_pubnames section");
+    opts.optflag("y", "debug-pubtypes", "print .debug_pubtypes section");
+    opts.optflag("", "debug-types", "print .debug_types section");
+    opts.optflag("", "eh-frame", "print .eh_frame section");
     opts.optflag(
         "",
         "dwo",
@@ -262,16 +260,20 @@ fn main() {
 
     let mut all = true;
     let mut flags = Flags::default();
-    if matches.opt_present("eh-frame") {
-        flags.eh_frame = true;
-        all = false;
-    }
     if matches.opt_present("G") {
         flags.goff = true;
     }
     if matches.opt_present("i") {
         flags.info = true;
         flags.types = true;
+        all = false;
+    }
+    if matches.opt_present("debug-addr") {
+        flags.addr = true;
+        all = false;
+    }
+    if matches.opt_present("debug-aranges") {
+        flags.aranges = true;
         all = false;
     }
     if matches.opt_present("debug-info") {
@@ -290,28 +292,28 @@ fn main() {
         }
         all = false;
     }
-    if matches.opt_present("l") {
+    if matches.opt_present("debug-line") {
         flags.line = true;
-        all = false;
-    }
-    if matches.opt_present("p") {
-        flags.pubnames = true;
-        all = false;
-    }
-    if matches.opt_present("y") {
-        flags.pubtypes = true;
-        all = false;
-    }
-    if matches.opt_present("r") {
-        flags.aranges = true;
-        all = false;
-    }
-    if matches.opt_present("debug-addr") {
-        flags.addr = true;
         all = false;
     }
     if matches.opt_present("debug-names") {
         flags.names = true;
+        all = false;
+    }
+    if matches.opt_present("debug-pubnames") {
+        flags.pubnames = true;
+        all = false;
+    }
+    if matches.opt_present("debug-pubtypes") {
+        flags.pubtypes = true;
+        all = false;
+    }
+    if matches.opt_present("debug-types") {
+        flags.types = true;
+        all = false;
+    }
+    if matches.opt_present("eh-frame") {
+        flags.eh_frame = true;
         all = false;
     }
     if matches.opt_present("dwo") {
@@ -326,14 +328,14 @@ fn main() {
     if all {
         // .eh_frame is excluded even when printing all information.
         // cosmetic flags like -G must be set explicitly too.
+        flags.addr = true;
+        flags.aranges = true;
         flags.info = true;
-        flags.types = true;
         flags.line = true;
+        flags.names = true;
         flags.pubnames = true;
         flags.pubtypes = true;
-        flags.aranges = true;
-        flags.addr = true;
-        flags.names = true;
+        flags.types = true;
     }
     flags.match_units = if let Some(r) = matches.opt_str("u") {
         match Regex::new(&r) {
@@ -550,10 +552,6 @@ where
 
     dwarf.populate_abbreviations_cache(gimli::AbbreviationsCacheStrategy::All);
 
-    if flags.eh_frame {
-        let eh_frame = gimli::EhFrame::load(load_section).unwrap();
-        dump_eh_frame(w, file, eh_frame)?;
-    }
     if flags.info {
         dump_info(w, &dwarf, dwo_parent_units, flags)?;
     }
@@ -571,14 +569,18 @@ where
     }
     if flags.pubnames {
         let debug_pubnames = &gimli::Section::load(load_section).unwrap();
-        dump_pubnames(w, debug_pubnames, &dwarf.debug_info)?;
+        dump_pubnames(w, debug_pubnames)?;
     }
     if flags.pubtypes {
         let debug_pubtypes = &gimli::Section::load(load_section).unwrap();
-        dump_pubtypes(w, debug_pubtypes, &dwarf.debug_info)?;
+        dump_pubtypes(w, debug_pubtypes)?;
     }
     if flags.names {
         dump_names(w, &dwarf)?;
+    }
+    if flags.eh_frame {
+        let eh_frame = gimli::EhFrame::load(load_section).unwrap();
+        dump_eh_frame(w, file, eh_frame)?;
     }
     w.flush()?;
     Ok(())
@@ -2240,31 +2242,23 @@ fn dump_line_program<R: Reader, W: Write>(w: &mut W, unit: gimli::UnitRef<R>) ->
 fn dump_pubnames<R: Reader, W: Write>(
     w: &mut W,
     debug_pubnames: &gimli::DebugPubNames<R>,
-    debug_info: &gimli::DebugInfo<R>,
 ) -> Result<()> {
     writeln!(w, "\n.debug_pubnames")?;
 
-    let mut cu_offset;
-    let mut cu_die_offset = gimli::DebugInfoOffset(0);
-    let mut prev_cu_offset = None;
-    let mut pubnames = debug_pubnames.items();
-    while let Some(pubname) = pubnames.next()? {
-        cu_offset = pubname.unit_header_offset();
-        if Some(cu_offset) != prev_cu_offset {
-            let cu = debug_info.header_from_offset(cu_offset)?;
-            cu_die_offset = gimli::DebugInfoOffset(cu_offset.0 + cu.header_size());
-            prev_cu_offset = Some(cu_offset);
-        }
-        let die_in_cu = pubname.die_offset();
-        let die_in_sect = cu_offset.0 + die_in_cu.0;
-        writeln!(w,
-            "global die-in-sect 0x{:08x}, cu-in-sect 0x{:08x}, die-in-cu 0x{:08x}, cu-header-in-sect 0x{:08x} '{}'",
-            die_in_sect,
-            cu_die_offset.0,
-            die_in_cu.0,
-            cu_offset.0,
-            pubname.name().to_string_lossy()?
+    let mut sets = debug_pubnames.sets();
+    while let Some(set) = sets.next()? {
+        dump_pub_set_header(
+            w,
+            set.format(),
+            set.version(),
+            set.unit_header_offset(),
+            set.unit_length(),
+            set.length(),
         )?;
+        let mut entries = set.items();
+        while let Some(entry) = entries.next()? {
+            dump_pub_entry(w, entry.die_offset(), entry.name())?;
+        }
     }
     Ok(())
 }
@@ -2272,32 +2266,50 @@ fn dump_pubnames<R: Reader, W: Write>(
 fn dump_pubtypes<R: Reader, W: Write>(
     w: &mut W,
     debug_pubtypes: &gimli::DebugPubTypes<R>,
-    debug_info: &gimli::DebugInfo<R>,
 ) -> Result<()> {
     writeln!(w, "\n.debug_pubtypes")?;
 
-    let mut cu_offset;
-    let mut cu_die_offset = gimli::DebugInfoOffset(0);
-    let mut prev_cu_offset = None;
-    let mut pubtypes = debug_pubtypes.items();
-    while let Some(pubtype) = pubtypes.next()? {
-        cu_offset = pubtype.unit_header_offset();
-        if Some(cu_offset) != prev_cu_offset {
-            let cu = debug_info.header_from_offset(cu_offset)?;
-            cu_die_offset = gimli::DebugInfoOffset(cu_offset.0 + cu.header_size());
-            prev_cu_offset = Some(cu_offset);
-        }
-        let die_in_cu = pubtype.die_offset();
-        let die_in_sect = cu_offset.0 + die_in_cu.0;
-        writeln!(w,
-            "pubtype die-in-sect 0x{:08x}, cu-in-sect 0x{:08x}, die-in-cu 0x{:08x}, cu-header-in-sect 0x{:08x} '{}'",
-            die_in_sect,
-            cu_die_offset.0,
-            die_in_cu.0,
-            cu_offset.0,
-            pubtype.name().to_string_lossy()?
+    let mut sets = debug_pubtypes.sets();
+    while let Some(set) = sets.next()? {
+        dump_pub_set_header(
+            w,
+            set.format(),
+            set.version(),
+            set.unit_header_offset(),
+            set.unit_length(),
+            set.length(),
         )?;
+        let mut entries = set.items();
+        while let Some(entry) = entries.next()? {
+            dump_pub_entry(w, entry.die_offset(), entry.name())?;
+        }
     }
+    Ok(())
+}
+
+fn dump_pub_set_header<W: Write>(
+    w: &mut W,
+    format: gimli::Format,
+    version: u16,
+    unit_offset: gimli::DebugInfoOffset,
+    unit_length: usize,
+    length: usize,
+) -> Result<()> {
+    writeln!(
+        w,
+        "\nlength = 0x{:x}, format = {:?}, version = {}, unit_offset = 0x{:08x}, unit_length = 0x{:x}",
+        length, format, version, unit_offset.0, unit_length,
+    )?;
+    writeln!(w, "Offset     Name")?;
+    Ok(())
+}
+
+fn dump_pub_entry<R: Reader, W: Write>(
+    w: &mut W,
+    offset: UnitOffset<R::Offset>,
+    name: &R,
+) -> Result<()> {
+    writeln!(w, "0x{:08x} \"{}\"", offset.0, name.to_string_lossy()?)?;
     Ok(())
 }
 

--- a/src/read/lookup.rs
+++ b/src/read/lookup.rs
@@ -12,18 +12,52 @@ pub(crate) struct DebugPubSet<R: Reader> {
 }
 
 impl<R: Reader> DebugPubSet<R> {
+    pub(crate) fn sets(&self) -> PubSetIter<R> {
+        PubSetIter {
+            input: self.section.clone(),
+        }
+    }
+
     pub(crate) fn items(&self) -> PubSetEntryIter<R> {
         PubSetEntryIter {
             current_set: None,
-            remaining_input: self.section.clone(),
+            sets: self.sets(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PubSetIter<R: Reader> {
+    input: R,
+}
+
+impl<R: Reader> PubSetIter<R> {
+    /// Advance the iterator and return the next set.
+    ///
+    /// Returns the newly parsed set as `Ok(Some(PubSet))`. Returns `Ok(None)` when
+    /// iteration is complete. If an error occurs while parsing the next header,
+    /// then this error is returned as `Err(e)`, and all subsequent calls return
+    /// `Ok(None)`.
+    pub(crate) fn next(&mut self) -> Result<Option<PubSet<R>>> {
+        if self.input.is_empty() {
+            return Ok(None);
+        }
+        match PubSetHeader::parse(&mut self.input) {
+            Ok((header, entries)) => Ok(Some(PubSet { header, entries })),
+            Err(e) => {
+                self.input.empty();
+                Err(e)
+            }
         }
     }
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct PubSetEntryIter<R: Reader> {
-    current_set: Option<(R, PubSetHeader<R::Offset>)>, // Only none at the very beginning and end.
-    remaining_input: R,
+    // Only none at the very beginning and end.
+    // PubSet::entries is consumed as we iterate.
+    current_set: Option<PubSet<R>>,
+    sets: PubSetIter<R>,
 }
 
 impl<R: Reader> PubSetEntryIter<R> {
@@ -36,50 +70,63 @@ impl<R: Reader> PubSetEntryIter<R> {
     /// `Ok(None)`.
     pub(crate) fn next(&mut self) -> Result<Option<PubSetEntry<R>>> {
         loop {
-            if let Some((ref mut input, ref header)) = self.current_set
-                && !input.is_empty()
+            if let Some(set) = &mut self.current_set
+                && !set.entries.is_empty()
             {
-                match PubSetEntry::parse(input, header) {
+                match PubSetEntry::parse(&mut set.entries, &set.header) {
                     Ok(Some(entry)) => return Ok(Some(entry)),
-                    Ok(None) => {}
+                    Ok(None) => {
+                        self.current_set = None;
+                    }
                     Err(e) => {
-                        input.empty();
-                        self.remaining_input.empty();
+                        self.sets.input.empty();
+                        self.current_set = None;
                         return Err(e);
                     }
                 }
             }
-            if self.remaining_input.is_empty() {
-                self.current_set = None;
-                return Ok(None);
-            }
-            match PubSetHeader::parse(&mut self.remaining_input) {
-                Ok(set) => {
-                    self.current_set = Some(set);
-                }
-                Err(e) => {
-                    self.current_set = None;
-                    self.remaining_input.empty();
-                    return Err(e);
-                }
+            match self.sets.next() {
+                Ok(Some(set)) => self.current_set = Some(set),
+                Ok(None) => return Ok(None),
+                Err(e) => return Err(e),
             }
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
+pub(crate) struct PubSet<R: Reader> {
+    pub(crate) header: PubSetHeader<R::Offset>,
+    entries: R,
+}
+
+impl<R: Reader> PubSet<R> {
+    /// Return an iterator over just the entries in this set.
+    pub(crate) fn items(&self) -> PubSetEntryIter<R> {
+        // Empty set iterator.
+        let mut set_input = self.entries.clone();
+        set_input.empty();
+        let sets = PubSetIter { input: set_input };
+
+        PubSetEntryIter {
+            sets,
+            current_set: Some(self.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct PubSetHeader<T = usize> {
-    format: Format,
-    length: T,
-    version: u16,
-    unit_offset: DebugInfoOffset<T>,
-    unit_length: T,
+    pub(crate) format: Format,
+    pub(crate) length: T,
+    pub(crate) version: u16,
+    pub(crate) unit_offset: DebugInfoOffset<T>,
+    pub(crate) unit_length: T,
 }
 
 impl<T: ReaderOffset> PubSetHeader<T> {
-    /// Parse a set header. Returns a tuple of the entry data to be parsed for
-    /// this set, and the newly created `PubSetHeader` struct.
-    fn parse<R: Reader<Offset = T>>(input: &mut R) -> Result<(R, PubSetHeader<R::Offset>)> {
+    /// Parse a set header. Returns a tuple of the set header and the entry data.
+    fn parse<R: Reader<Offset = T>>(input: &mut R) -> Result<(PubSetHeader<R::Offset>, R)> {
         let (length, format) = input.read_initial_length()?;
         let mut rest = input.split(length)?;
 
@@ -98,7 +145,7 @@ impl<T: ReaderOffset> PubSetHeader<T> {
             unit_offset,
             unit_length,
         };
-        Ok((rest, header))
+        Ok((header, rest))
     }
 }
 

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -1,30 +1,7 @@
-use crate::common::{DebugInfoOffset, SectionId};
+use crate::common::{DebugInfoOffset, Format, SectionId};
 use crate::endianity::Endianity;
-use crate::read::lookup::{DebugPubSet, PubSetEntry, PubSetEntryIter};
+use crate::read::lookup::{DebugPubSet, PubSet, PubSetEntry, PubSetEntryIter, PubSetIter};
 use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
-
-/// A single parsed pubname.
-#[derive(Debug, Clone)]
-pub struct PubNamesEntry<R: Reader>(PubSetEntry<R>);
-
-impl<R: Reader> PubNamesEntry<R> {
-    /// Returns the name this entry refers to.
-    pub fn name(&self) -> &R {
-        &self.0.name
-    }
-
-    /// Returns the offset into the .debug_info section for the header of the compilation unit
-    /// which contains this name.
-    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
-        self.0.unit_header_offset
-    }
-
-    /// Returns the offset into the compilation unit for the debugging information entry which
-    /// has this name.
-    pub fn die_offset(&self) -> UnitOffset<R::Offset> {
-        self.0.die_offset
-    }
-}
 
 /// The `DebugPubNames` struct represents the DWARF public names information
 /// found in the `.debug_pubnames` section.
@@ -74,6 +51,14 @@ impl<R: Reader> DebugPubNames<R> {
     pub fn items(&self) -> PubNamesEntryIter<R> {
         PubNamesEntryIter(self.0.items())
     }
+
+    /// Iterate the sets of entries in the `.debug_pubnames` section.
+    ///
+    /// Each set corresponds to a single unit, and contains the header for that
+    /// unit followed by its entries.
+    pub fn sets(&self) -> PubNamesSetIter<R> {
+        PubNamesSetIter(self.0.sets())
+    }
 }
 
 impl<R: Reader> Section<R> for DebugPubNames<R> {
@@ -89,6 +74,80 @@ impl<R: Reader> Section<R> for DebugPubNames<R> {
 impl<R: Reader> From<R> for DebugPubNames<R> {
     fn from(section: R) -> Self {
         DebugPubNames(DebugPubSet { section })
+    }
+}
+
+/// An iterator over the pubnames from a `.debug_pubnames` section.
+#[derive(Debug, Clone)]
+pub struct PubNamesSetIter<R: Reader>(PubSetIter<R>);
+
+impl<R: Reader> PubNamesSetIter<R> {
+    /// Advance the iterator and return the next set.
+    ///
+    /// Returns the newly parsed set as `Ok(Some(set))`. Returns `Ok(None)` when
+    /// iteration is complete. If an error occurs while parsing the next header,
+    /// then this error is returned as `Err(e)`, and all subsequent calls return
+    /// `Ok(None)`.
+    pub fn next(&mut self) -> Result<Option<PubNamesSet<R>>> {
+        self.0.next().map(|x| x.map(PubNamesSet))
+    }
+}
+
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for PubNamesSetIter<R> {
+    type Item = PubNamesSet<R>;
+    type Error = crate::read::Error;
+
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
+        self.next()
+    }
+}
+
+impl<R: Reader> Iterator for PubNamesSetIter<R> {
+    type Item = Result<PubNamesSet<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
+    }
+}
+
+/// A set of entries that share a header in a `.debug_pubnames` section.
+///
+/// These entries all belong to a single unit.
+#[derive(Debug, Clone)]
+pub struct PubNamesSet<R: Reader>(PubSet<R>);
+
+impl<R: Reader> PubNamesSet<R> {
+    /// Returns the offset into the `.debug_info` section for the header of the
+    /// compilation unit which contains these names.
+    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
+        self.0.header.unit_offset
+    }
+
+    /// Returns the length of the compilation unit in the `.debug_info` section
+    /// which contains these names.
+    pub fn unit_length(&self) -> R::Offset {
+        self.0.header.unit_length
+    }
+
+    /// Returns the version of the set.
+    pub fn version(&self) -> u16 {
+        self.0.header.version
+    }
+
+    /// Returns the DWARF format of the set.
+    pub fn format(&self) -> Format {
+        self.0.header.format
+    }
+
+    /// Returns the length of the set, including the header.
+    pub fn length(&self) -> R::Offset {
+        self.0.header.length
+    }
+
+    /// Iterate the entries in this set.
+    pub fn items(&self) -> PubNamesEntryIter<R> {
+        PubNamesEntryIter(self.0.items())
     }
 }
 
@@ -124,5 +183,134 @@ impl<R: Reader> Iterator for PubNamesEntryIter<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next().transpose()
+    }
+}
+
+/// A single parsed pubname.
+#[derive(Debug, Clone)]
+pub struct PubNamesEntry<R: Reader>(PubSetEntry<R>);
+
+impl<R: Reader> PubNamesEntry<R> {
+    /// Returns the name this entry refers to.
+    pub fn name(&self) -> &R {
+        &self.0.name
+    }
+
+    /// Returns the offset into the .debug_info section for the header of the compilation unit
+    /// which contains this name.
+    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
+        self.0.unit_header_offset
+    }
+
+    /// Returns the offset into the compilation unit for the debugging information entry which
+    /// has this name.
+    pub fn die_offset(&self) -> UnitOffset<R::Offset> {
+        self.0.die_offset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::DebugInfoOffset;
+    use crate::test_util::GimliSectionMethods;
+    use crate::{Format, LittleEndian};
+    use test_assembler::{Endian, Label, LabelMaker, Section};
+
+    #[test]
+    fn test_pubnames() {
+        for format in [Format::Dwarf32, Format::Dwarf64] {
+            let size = format.word_size();
+
+            // Set 1, with two entries.
+            let length = Label::new();
+            let start = Label::new();
+            let section = Section::with_endian(Endian::Little)
+                .initial_length(format, &length, &start)
+                .D16(2) // Version
+                .word(size, 0x10) // Unit header offset
+                .word(size, 0x20) // Unit length
+                // Entry 1
+                .word(size, 0x02) // DIE offset
+                .append_bytes(b"foo\0")
+                // Entry 2
+                .word(size, 0x04) // DIE offset
+                .append_bytes(b"bar\0")
+                // Null entry
+                .word(size, 0)
+                .set_initial_length(&length, &start);
+
+            // Set 2, with one entry.
+            let length = Label::new();
+            let start = Label::new();
+            let section = section
+                .initial_length(format, &length, &start)
+                .D16(2) // Version
+                .word(size, 0x40) // Unit header offset
+                .word(size, 0x30) // Unit length
+                // Entry 1
+                .word(size, 0x06) // DIE offset
+                .append_bytes(b"baz\0")
+                // Null entry
+                .word(size, 0)
+                .set_initial_length(&length, &start);
+
+            let section = section.get_contents().unwrap();
+            let debug_pubnames = DebugPubNames::new(&section, LittleEndian);
+
+            // Iterate all entries.
+            let mut items = debug_pubnames.items();
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(entry.die_offset(), UnitOffset(0x02));
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(entry.die_offset(), UnitOffset(0x04));
+
+            // Iteration continues into the next set.
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"baz", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x40));
+            assert_eq!(entry.die_offset(), UnitOffset(0x06));
+
+            assert!(matches!(items.next(), Ok(None)));
+
+            // Iterate entries within sets.
+            let mut sets = debug_pubnames.sets();
+
+            // Set 1.
+            let set = sets.next().unwrap().unwrap();
+            assert_eq!(set.version(), 2);
+            assert_eq!(set.format(), format);
+            assert_eq!(set.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(set.unit_length(), 0x20);
+
+            let mut items = set.items();
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
+            assert_eq!(entry.die_offset(), UnitOffset(0x02));
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
+            assert_eq!(entry.die_offset(), UnitOffset(0x04));
+            // Iteration stops at the end of this set.
+            assert!(matches!(items.next(), Ok(None)));
+
+            // Set 2.
+            let set = sets.next().unwrap().unwrap();
+            assert_eq!(set.unit_header_offset(), DebugInfoOffset(0x40));
+            assert_eq!(set.unit_length(), 0x30);
+
+            let mut items = set.items();
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"baz", LittleEndian));
+            assert_eq!(entry.die_offset(), UnitOffset(0x06));
+            assert!(matches!(items.next(), Ok(None)));
+
+            assert!(matches!(sets.next(), Ok(None)));
+        }
     }
 }

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -1,30 +1,7 @@
-use crate::common::{DebugInfoOffset, SectionId};
+use crate::common::{DebugInfoOffset, Format, SectionId};
 use crate::endianity::Endianity;
-use crate::read::lookup::{DebugPubSet, PubSetEntry, PubSetEntryIter};
+use crate::read::lookup::{DebugPubSet, PubSet, PubSetEntry, PubSetEntryIter, PubSetIter};
 use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
-
-/// A single parsed pubtype.
-#[derive(Debug, Clone)]
-pub struct PubTypesEntry<R: Reader>(PubSetEntry<R>);
-
-impl<R: Reader> PubTypesEntry<R> {
-    /// Returns the name of the type this entry refers to.
-    pub fn name(&self) -> &R {
-        &self.0.name
-    }
-
-    /// Returns the offset into the .debug_info section for the header of the compilation unit
-    /// which contains the type with this name.
-    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
-        self.0.unit_header_offset
-    }
-
-    /// Returns the offset into the compilation unit for the debugging information entry which
-    /// the type with this name.
-    pub fn die_offset(&self) -> UnitOffset<R::Offset> {
-        self.0.die_offset
-    }
-}
 
 /// The `DebugPubTypes` struct represents the DWARF public types information
 /// found in the `.debug_info` section.
@@ -74,6 +51,14 @@ impl<R: Reader> DebugPubTypes<R> {
     pub fn items(&self) -> PubTypesEntryIter<R> {
         PubTypesEntryIter(self.0.items())
     }
+
+    /// Iterate the sets of entries in the `.debug_pubtypes` section.
+    ///
+    /// Each set corresponds to a single unit, and contains the header for that
+    /// unit followed by its entries.
+    pub fn sets(&self) -> PubTypesSetIter<R> {
+        PubTypesSetIter(self.0.sets())
+    }
 }
 
 impl<R: Reader> Section<R> for DebugPubTypes<R> {
@@ -89,6 +74,80 @@ impl<R: Reader> Section<R> for DebugPubTypes<R> {
 impl<R: Reader> From<R> for DebugPubTypes<R> {
     fn from(section: R) -> Self {
         DebugPubTypes(DebugPubSet { section })
+    }
+}
+
+/// An iterator over the pubtypes from a `.debug_pubtypes` section.
+#[derive(Debug, Clone)]
+pub struct PubTypesSetIter<R: Reader>(PubSetIter<R>);
+
+impl<R: Reader> PubTypesSetIter<R> {
+    /// Advance the iterator and return the next set.
+    ///
+    /// Returns the newly parsed set as `Ok(Some(set))`. Returns `Ok(None)` when
+    /// iteration is complete. If an error occurs while parsing the next header,
+    /// then this error is returned as `Err(e)`, and all subsequent calls return
+    /// `Ok(None)`.
+    pub fn next(&mut self) -> Result<Option<PubTypesSet<R>>> {
+        self.0.next().map(|x| x.map(PubTypesSet))
+    }
+}
+
+#[cfg(feature = "fallible-iterator")]
+impl<R: Reader> fallible_iterator::FallibleIterator for PubTypesSetIter<R> {
+    type Item = PubTypesSet<R>;
+    type Error = crate::read::Error;
+
+    fn next(&mut self) -> ::core::result::Result<Option<Self::Item>, Self::Error> {
+        self.next()
+    }
+}
+
+impl<R: Reader> Iterator for PubTypesSetIter<R> {
+    type Item = Result<PubTypesSet<R>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
+    }
+}
+
+/// A set of entries that share a header in a `.debug_pubtypes` section.
+///
+/// These entries all belong to a single unit.
+#[derive(Debug, Clone)]
+pub struct PubTypesSet<R: Reader>(PubSet<R>);
+
+impl<R: Reader> PubTypesSet<R> {
+    /// Returns the offset into the `.debug_info` section for the header of the
+    /// compilation unit which contains these types.
+    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
+        self.0.header.unit_offset
+    }
+
+    /// Returns the length of the compilation unit in the `.debug_info` section
+    /// which contains these types.
+    pub fn unit_length(&self) -> R::Offset {
+        self.0.header.unit_length
+    }
+
+    /// Returns the version of the set.
+    pub fn version(&self) -> u16 {
+        self.0.header.version
+    }
+
+    /// Returns the DWARF format of the set.
+    pub fn format(&self) -> Format {
+        self.0.header.format
+    }
+
+    /// Returns the length of the set, including the header.
+    pub fn length(&self) -> R::Offset {
+        self.0.header.length
+    }
+
+    /// Iterate the entries in this set.
+    pub fn items(&self) -> PubTypesEntryIter<R> {
+        PubTypesEntryIter(self.0.items())
     }
 }
 
@@ -124,5 +183,134 @@ impl<R: Reader> Iterator for PubTypesEntryIter<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next().transpose()
+    }
+}
+
+/// A single parsed pubtype.
+#[derive(Debug, Clone)]
+pub struct PubTypesEntry<R: Reader>(PubSetEntry<R>);
+
+impl<R: Reader> PubTypesEntry<R> {
+    /// Returns the name of the type this entry refers to.
+    pub fn name(&self) -> &R {
+        &self.0.name
+    }
+
+    /// Returns the offset into the .debug_info section for the header of the compilation unit
+    /// which contains the type with this name.
+    pub fn unit_header_offset(&self) -> DebugInfoOffset<R::Offset> {
+        self.0.unit_header_offset
+    }
+
+    /// Returns the offset into the compilation unit for the debugging information entry which
+    /// the type with this name.
+    pub fn die_offset(&self) -> UnitOffset<R::Offset> {
+        self.0.die_offset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::DebugInfoOffset;
+    use crate::test_util::GimliSectionMethods;
+    use crate::{Format, LittleEndian};
+    use test_assembler::{Endian, Label, LabelMaker, Section};
+
+    #[test]
+    fn test_pubtypes() {
+        for format in [Format::Dwarf32, Format::Dwarf64] {
+            let size = format.word_size();
+
+            // Set 1, with two entries.
+            let length = Label::new();
+            let start = Label::new();
+            let section = Section::with_endian(Endian::Little)
+                .initial_length(format, &length, &start)
+                .D16(2) // Version
+                .word(size, 0x10) // Unit header offset
+                .word(size, 0x20) // Unit length
+                // Entry 1
+                .word(size, 0x02) // DIE offset
+                .append_bytes(b"foo\0")
+                // Entry 2
+                .word(size, 0x04) // DIE offset
+                .append_bytes(b"bar\0")
+                // Null entry
+                .word(size, 0)
+                .set_initial_length(&length, &start);
+
+            // Set 2, with one entry.
+            let length = Label::new();
+            let start = Label::new();
+            let section = section
+                .initial_length(format, &length, &start)
+                .D16(2) // Version
+                .word(size, 0x40) // Unit header offset
+                .word(size, 0x20) // Unit length
+                // Entry 1
+                .word(size, 0x06) // DIE offset
+                .append_bytes(b"baz\0")
+                // Null entry
+                .word(size, 0)
+                .set_initial_length(&length, &start);
+
+            let section = section.get_contents().unwrap();
+            let debug_pubtypes = DebugPubTypes::new(&section, LittleEndian);
+
+            // Iterate all entries.
+            let mut items = debug_pubtypes.items();
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(entry.die_offset(), UnitOffset(0x02));
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(entry.die_offset(), UnitOffset(0x04));
+
+            // Iteration continues into the next set.
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"baz", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x40));
+            assert_eq!(entry.die_offset(), UnitOffset(0x06));
+
+            assert!(matches!(items.next(), Ok(None)));
+
+            // Iterate entries within sets.
+            let mut sets = debug_pubtypes.sets();
+
+            // Set 1.
+            let set = sets.next().unwrap().unwrap();
+            assert_eq!(set.version(), 2);
+            assert_eq!(set.format(), format);
+            assert_eq!(set.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(set.unit_length(), 0x20);
+
+            let mut items = set.items();
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
+            assert_eq!(entry.die_offset(), UnitOffset(0x02));
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
+            assert_eq!(entry.die_offset(), UnitOffset(0x04));
+            // Iteration stops at the end of this set.
+            assert!(matches!(items.next(), Ok(None)));
+
+            // Set 2.
+            let set = sets.next().unwrap().unwrap();
+            assert_eq!(set.unit_header_offset(), DebugInfoOffset(0x40));
+            assert_eq!(set.unit_length(), 0x20);
+
+            let mut items = set.items();
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"baz", LittleEndian));
+            assert_eq!(entry.die_offset(), UnitOffset(0x06));
+            assert!(matches!(items.next(), Ok(None)));
+
+            assert!(matches!(sets.next(), Ok(None)));
+        }
     }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,12 +1,13 @@
 #![allow(missing_docs)]
 
 use crate::Format;
-use test_assembler::{Label, Section};
+use test_assembler::{Label, LabelMaker, Section};
 
 pub trait GimliSectionMethods {
     fn sleb(self, val: i64) -> Self;
     fn uleb(self, val: u64) -> Self;
     fn initial_length(self, format: Format, length: &Label, start: &Label) -> Self;
+    fn set_initial_length(self, length: &Label, start: &Label) -> Self;
     fn word(self, size: u8, val: u64) -> Self;
     fn word_label(self, size: u8, val: &Label) -> Self;
 }
@@ -33,6 +34,13 @@ impl GimliSectionMethods for Section {
             Format::Dwarf32 => self.D32(length).mark(start),
             Format::Dwarf64 => self.D32(0xffff_ffff).D64(length).mark(start),
         }
+    }
+
+    fn set_initial_length(self, length: &Label, start: &Label) -> Self {
+        let end = Label::new();
+        let result = self.mark(&end);
+        length.set_const((&end - start) as u64);
+        result
     }
 
     fn word(self, size: u8, val: u64) -> Self {


### PR DESCRIPTION
This gives access to more of the set header information.

Also add long names for the dwarfdump section options, and reorder the option handling.