### PR TITLE
read: .debug_gnu_pubnames and .debug_gnu_pubtypes support

### DIFF
--- a/crates/examples/src/bin/dwarfdump.rs
+++ b/crates/examples/src/bin/dwarfdump.rs
@@ -185,6 +185,8 @@ impl<'a, R: gimli::Reader<Offset = usize> + Send + Sync> Reader for Relocate<'a,
 struct Flags<'a> {
     addr: bool,
     aranges: bool,
+    gnupubnames: bool,
+    gnupubtypes: bool,
     info: bool,
     line: bool,
     names: bool,
@@ -215,6 +217,16 @@ fn main() {
     opts.optflag("i", "", "print .debug_info and .debug_types sections");
     opts.optflag("", "debug-addr", "print .debug_addr section");
     opts.optflag("r", "debug-aranges", "print .debug_aranges section");
+    opts.optflag(
+        "",
+        "debug-gnu-pubnames",
+        "print .debug_gnu_pubnames section",
+    );
+    opts.optflag(
+        "",
+        "debug-gnu-pubtypes",
+        "print .debug_gnu_pubtypes section",
+    );
     opts.optflagopt("", "debug-info", "print .debug_info section", "OFFSET");
     opts.optflag("l", "debug-line", "print .debug_line section");
     opts.optflag("", "debug-names", "print .debug_names section");
@@ -276,6 +288,14 @@ fn main() {
         flags.aranges = true;
         all = false;
     }
+    if matches.opt_present("debug-gnu-pubnames") {
+        flags.gnupubnames = true;
+        all = false;
+    }
+    if matches.opt_present("debug-gnu-pubtypes") {
+        flags.gnupubtypes = true;
+        all = false;
+    }
     if matches.opt_present("debug-info") {
         flags.info = true;
         if let Some(offset) = matches.opt_str("debug-info") {
@@ -330,6 +350,8 @@ fn main() {
         // cosmetic flags like -G must be set explicitly too.
         flags.addr = true;
         flags.aranges = true;
+        flags.gnupubnames = true;
+        flags.gnupubtypes = true;
         flags.info = true;
         flags.line = true;
         flags.names = true;
@@ -571,9 +593,17 @@ where
         let debug_pubnames = &gimli::Section::load(load_section).unwrap();
         dump_pubnames(w, debug_pubnames)?;
     }
+    if flags.gnupubnames {
+        let debug_gnu_pubnames = &gimli::Section::load(load_section).unwrap();
+        dump_gnu_pubnames(w, debug_gnu_pubnames)?;
+    }
     if flags.pubtypes {
         let debug_pubtypes = &gimli::Section::load(load_section).unwrap();
         dump_pubtypes(w, debug_pubtypes)?;
+    }
+    if flags.gnupubtypes {
+        let debug_gnu_pubtypes = &gimli::Section::load(load_section).unwrap();
+        dump_gnu_pubtypes(w, debug_gnu_pubtypes)?;
     }
     if flags.names {
         dump_names(w, &dwarf)?;
@@ -2239,13 +2269,10 @@ fn dump_line_program<R: Reader, W: Write>(w: &mut W, unit: gimli::UnitRef<R>) ->
     Ok(())
 }
 
-fn dump_pubnames<R: Reader, W: Write>(
-    w: &mut W,
-    debug_pubnames: &gimli::DebugPubNames<R>,
-) -> Result<()> {
+fn dump_pubnames<R: Reader, W: Write>(w: &mut W, section: &gimli::DebugPubNames<R>) -> Result<()> {
     writeln!(w, "\n.debug_pubnames")?;
 
-    let mut sets = debug_pubnames.sets();
+    let mut sets = section.sets();
     while let Some(set) = sets.next()? {
         dump_pub_set_header(
             w,
@@ -2254,6 +2281,7 @@ fn dump_pubnames<R: Reader, W: Write>(
             set.unit_header_offset(),
             set.unit_length(),
             set.length(),
+            false,
         )?;
         let mut entries = set.items();
         while let Some(entry) = entries.next()? {
@@ -2263,13 +2291,13 @@ fn dump_pubnames<R: Reader, W: Write>(
     Ok(())
 }
 
-fn dump_pubtypes<R: Reader, W: Write>(
+fn dump_gnu_pubnames<R: Reader, W: Write>(
     w: &mut W,
-    debug_pubtypes: &gimli::DebugPubTypes<R>,
+    section: &gimli::DebugGnuPubNames<R>,
 ) -> Result<()> {
-    writeln!(w, "\n.debug_pubtypes")?;
+    writeln!(w, "\n.debug_gnu_pubnames")?;
 
-    let mut sets = debug_pubtypes.sets();
+    let mut sets = section.sets();
     while let Some(set) = sets.next()? {
         dump_pub_set_header(
             w,
@@ -2278,10 +2306,70 @@ fn dump_pubtypes<R: Reader, W: Write>(
             set.unit_header_offset(),
             set.unit_length(),
             set.length(),
+            true,
+        )?;
+        let mut entries = set.items();
+        while let Some(entry) = entries.next()? {
+            dump_gnu_pub_entry(
+                w,
+                entry.die_offset(),
+                entry.is_static(),
+                entry.kind(),
+                entry.name(),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn dump_pubtypes<R: Reader, W: Write>(w: &mut W, section: &gimli::DebugPubTypes<R>) -> Result<()> {
+    writeln!(w, "\n.debug_pubtypes")?;
+
+    let mut sets = section.sets();
+    while let Some(set) = sets.next()? {
+        dump_pub_set_header(
+            w,
+            set.format(),
+            set.version(),
+            set.unit_header_offset(),
+            set.unit_length(),
+            set.length(),
+            false,
         )?;
         let mut entries = set.items();
         while let Some(entry) = entries.next()? {
             dump_pub_entry(w, entry.die_offset(), entry.name())?;
+        }
+    }
+    Ok(())
+}
+
+fn dump_gnu_pubtypes<R: Reader, W: Write>(
+    w: &mut W,
+    section: &gimli::DebugGnuPubTypes<R>,
+) -> Result<()> {
+    writeln!(w, "\n.debug_gnu_pubtypes")?;
+
+    let mut sets = section.sets();
+    while let Some(set) = sets.next()? {
+        dump_pub_set_header(
+            w,
+            set.format(),
+            set.version(),
+            set.unit_header_offset(),
+            set.unit_length(),
+            set.length(),
+            true,
+        )?;
+        let mut entries = set.items();
+        while let Some(entry) = entries.next()? {
+            dump_gnu_pub_entry(
+                w,
+                entry.die_offset(),
+                entry.is_static(),
+                entry.kind(),
+                entry.name(),
+            )?;
         }
     }
     Ok(())
@@ -2294,13 +2382,18 @@ fn dump_pub_set_header<W: Write>(
     unit_offset: gimli::DebugInfoOffset,
     unit_length: usize,
     length: usize,
+    is_gnu: bool,
 ) -> Result<()> {
     writeln!(
         w,
         "\nlength = 0x{:x}, format = {:?}, version = {}, unit_offset = 0x{:08x}, unit_length = 0x{:x}",
         length, format, version, unit_offset.0, unit_length,
     )?;
-    writeln!(w, "Offset     Name")?;
+    if is_gnu {
+        writeln!(w, "Offset     Linkage  Kind     Name")?;
+    } else {
+        writeln!(w, "Offset     Name")?;
+    }
     Ok(())
 }
 
@@ -2310,6 +2403,35 @@ fn dump_pub_entry<R: Reader, W: Write>(
     name: &R,
 ) -> Result<()> {
     writeln!(w, "0x{:08x} \"{}\"", offset.0, name.to_string_lossy()?)?;
+    Ok(())
+}
+
+fn dump_gnu_pub_entry<R: Reader, W: Write>(
+    w: &mut W,
+    offset: UnitOffset<R::Offset>,
+    is_static: bool,
+    kind: gimli::GdbIndexSymbolKind,
+    name: &R,
+) -> Result<()> {
+    writeln!(
+        w,
+        "0x{:08x} {:8} {:8} \"{}\"",
+        offset.0,
+        if is_static { "STATIC" } else { "EXTERNAL" },
+        match kind {
+            gimli::GDB_INDEX_SYMBOL_KIND_NONE => "NONE",
+            gimli::GDB_INDEX_SYMBOL_KIND_TYPE => "TYPE",
+            gimli::GDB_INDEX_SYMBOL_KIND_VARIABLE => "VARIABLE",
+            gimli::GDB_INDEX_SYMBOL_KIND_FUNCTION => "FUNCTION",
+            gimli::GDB_INDEX_SYMBOL_KIND_OTHER => "OTHER",
+            gimli::GDB_INDEX_SYMBOL_KIND_UNUSED5 => "UNUSED5",
+            gimli::GDB_INDEX_SYMBOL_KIND_UNUSED6 => "UNUSED6",
+            gimli::GDB_INDEX_SYMBOL_KIND_UNUSED7 => "UNUSED7",
+            _ => "UNKNOWN",
+        },
+        name.to_string_lossy()?
+    )?;
+
     Ok(())
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -239,6 +239,10 @@ pub enum SectionId {
     EhFrame,
     /// The `.eh_frame_hdr` section.
     EhFrameHdr,
+    /// The `.debug_gnu_pubnames` section.
+    DebugGnuPubNames,
+    /// The `.debug_gnu_pubtypes` section.
+    DebugGnuPubTypes,
     /// The `.debug_info` section.
     DebugInfo,
     /// The `.debug_line` section.
@@ -284,6 +288,8 @@ impl SectionId {
             SectionId::DebugFrame => ".debug_frame",
             SectionId::EhFrame => ".eh_frame",
             SectionId::EhFrameHdr => ".eh_frame_hdr",
+            SectionId::DebugGnuPubNames => ".debug_gnu_pubnames",
+            SectionId::DebugGnuPubTypes => ".debug_gnu_pubtypes",
             SectionId::DebugInfo => ".debug_info",
             SectionId::DebugLine => ".debug_line",
             SectionId::DebugLineStr => ".debug_line_str",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1454,6 +1454,19 @@ impl DwEhPe {
     }
 }
 
+dw!(
+/// The kind for a symbol in .gdb_index, .debug_gnu_pubnames, or .debug_gnu_pubtypes.
+GdbIndexSymbolKind(u8) {
+  GDB_INDEX_SYMBOL_KIND_NONE = 0,
+  GDB_INDEX_SYMBOL_KIND_TYPE = 1,
+  GDB_INDEX_SYMBOL_KIND_VARIABLE = 2,
+  GDB_INDEX_SYMBOL_KIND_FUNCTION = 3,
+  GDB_INDEX_SYMBOL_KIND_OTHER = 4,
+  GDB_INDEX_SYMBOL_KIND_UNUSED5 = 5,
+  GDB_INDEX_SYMBOL_KIND_UNUSED6 = 6,
+  GDB_INDEX_SYMBOL_KIND_UNUSED7 = 7
+});
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/read/lookup.rs
+++ b/src/read/lookup.rs
@@ -1,4 +1,5 @@
 use crate::common::{DebugInfoOffset, Format};
+use crate::constants::GdbIndexSymbolKind;
 use crate::read::{Error, Reader, ReaderOffset, Result, UnitOffset};
 
 // Common parsing for the `.debug_pub*` sections (DWARF v4 Section 6.1.1, Lookup by Name).
@@ -12,16 +13,17 @@ pub(crate) struct DebugPubSet<R: Reader> {
 }
 
 impl<R: Reader> DebugPubSet<R> {
-    pub(crate) fn sets(&self) -> PubSetIter<R> {
+    pub(crate) fn sets(&self, is_gnu: bool) -> PubSetIter<R> {
         PubSetIter {
             input: self.section.clone(),
+            is_gnu,
         }
     }
 
-    pub(crate) fn items(&self) -> PubSetEntryIter<R> {
+    pub(crate) fn items(&self, is_gnu: bool) -> PubSetEntryIter<R> {
         PubSetEntryIter {
             current_set: None,
-            sets: self.sets(),
+            sets: self.sets(is_gnu),
         }
     }
 }
@@ -29,6 +31,7 @@ impl<R: Reader> DebugPubSet<R> {
 #[derive(Clone, Debug)]
 pub(crate) struct PubSetIter<R: Reader> {
     input: R,
+    is_gnu: bool,
 }
 
 impl<R: Reader> PubSetIter<R> {
@@ -43,7 +46,11 @@ impl<R: Reader> PubSetIter<R> {
             return Ok(None);
         }
         match PubSetHeader::parse(&mut self.input) {
-            Ok((header, entries)) => Ok(Some(PubSet { header, entries })),
+            Ok((header, entries)) => Ok(Some(PubSet {
+                header,
+                entries,
+                is_gnu: self.is_gnu,
+            })),
             Err(e) => {
                 self.input.empty();
                 Err(e)
@@ -73,7 +80,7 @@ impl<R: Reader> PubSetEntryIter<R> {
             if let Some(set) = &mut self.current_set
                 && !set.entries.is_empty()
             {
-                match PubSetEntry::parse(&mut set.entries, &set.header) {
+                match PubSetEntry::parse(&mut set.entries, &set.header, set.is_gnu) {
                     Ok(Some(entry)) => return Ok(Some(entry)),
                     Ok(None) => {
                         self.current_set = None;
@@ -98,6 +105,7 @@ impl<R: Reader> PubSetEntryIter<R> {
 pub(crate) struct PubSet<R: Reader> {
     pub(crate) header: PubSetHeader<R::Offset>,
     entries: R,
+    is_gnu: bool,
 }
 
 impl<R: Reader> PubSet<R> {
@@ -106,7 +114,10 @@ impl<R: Reader> PubSet<R> {
         // Empty set iterator.
         let mut set_input = self.entries.clone();
         set_input.empty();
-        let sets = PubSetIter { input: set_input };
+        let sets = PubSetIter {
+            input: set_input,
+            is_gnu: self.is_gnu,
+        };
 
         PubSetEntryIter {
             sets,
@@ -154,22 +165,37 @@ pub(crate) struct PubSetEntry<R: Reader> {
     pub(crate) unit_header_offset: DebugInfoOffset<R::Offset>,
     pub(crate) die_offset: UnitOffset<R::Offset>,
     pub(crate) name: R,
+    flags: u8,
 }
 
 impl<R: Reader> PubSetEntry<R> {
+    pub(crate) fn is_static(&self) -> bool {
+        self.flags & 0x80 != 0
+    }
+
+    pub(crate) fn kind(&self) -> GdbIndexSymbolKind {
+        GdbIndexSymbolKind((self.flags >> 4) & 7)
+    }
+
     /// Parse a single set entry. Return `None` for the null entry.
-    fn parse(input: &mut R, header: &PubSetHeader<R::Offset>) -> Result<Option<PubSetEntry<R>>> {
+    fn parse(
+        input: &mut R,
+        header: &PubSetHeader<R::Offset>,
+        is_gnu: bool,
+    ) -> Result<Option<PubSetEntry<R>>> {
         let offset = input.read_offset(header.format)?;
         if offset.into_u64() == 0 {
             input.empty();
-            Ok(None)
-        } else {
-            let name = input.read_null_terminated_slice()?;
-            Ok(Some(PubSetEntry {
-                die_offset: UnitOffset(offset),
-                name,
-                unit_header_offset: header.unit_offset,
-            }))
+            return Ok(None);
         }
+
+        let flags = if is_gnu { input.read_u8()? } else { 0 };
+        let name = input.read_null_terminated_slice()?;
+        Ok(Some(PubSetEntry {
+            die_offset: UnitOffset(offset),
+            name,
+            flags,
+            unit_header_offset: header.unit_offset,
+        }))
     }
 }

--- a/src/read/pubnames.rs
+++ b/src/read/pubnames.rs
@@ -1,4 +1,5 @@
 use crate::common::{DebugInfoOffset, Format, SectionId};
+use crate::constants::GdbIndexSymbolKind;
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugPubSet, PubSet, PubSetEntry, PubSetEntryIter, PubSetIter};
 use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
@@ -49,7 +50,7 @@ impl<R: Reader> DebugPubNames<R> {
     /// }
     /// ```
     pub fn items(&self) -> PubNamesEntryIter<R> {
-        PubNamesEntryIter(self.0.items())
+        PubNamesEntryIter(self.0.items(false))
     }
 
     /// Iterate the sets of entries in the `.debug_pubnames` section.
@@ -57,7 +58,7 @@ impl<R: Reader> DebugPubNames<R> {
     /// Each set corresponds to a single unit, and contains the header for that
     /// unit followed by its entries.
     pub fn sets(&self) -> PubNamesSetIter<R> {
-        PubNamesSetIter(self.0.sets())
+        PubNamesSetIter(self.0.sets(false))
     }
 }
 
@@ -77,7 +78,81 @@ impl<R: Reader> From<R> for DebugPubNames<R> {
     }
 }
 
-/// An iterator over the pubnames from a `.debug_pubnames` section.
+/// The `DebugGnuPubNames` struct represents the DWARF public names information
+/// found in the `.debug_gnu_pubnames` section.
+#[derive(Debug, Clone)]
+pub struct DebugGnuPubNames<R: Reader>(DebugPubSet<R>);
+
+impl<'input, Endian> DebugGnuPubNames<EndianSlice<'input, Endian>>
+where
+    Endian: Endianity,
+{
+    /// Construct a new `DebugGnuPubNames` instance from the data in the `.debug_gnu_pubnames`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_gnu_pubnames` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on macOS, etc.
+    ///
+    /// ```
+    /// use gimli::{DebugGnuPubNames, LittleEndian};
+    ///
+    /// # let buf = [];
+    /// # let read_debug_gnu_pubnames_section_somehow = || &buf;
+    /// let debug_gnu_pubnames =
+    ///     DebugGnuPubNames::new(read_debug_gnu_pubnames_section_somehow(), LittleEndian);
+    /// ```
+    pub fn new(section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianSlice::new(section, endian))
+    }
+}
+
+impl<R: Reader> DebugGnuPubNames<R> {
+    /// Iterate the pubnames in the `.debug_gnu_pubnames` section.
+    ///
+    /// ```
+    /// use gimli::{DebugGnuPubNames, EndianSlice, LittleEndian};
+    ///
+    /// # let buf = [];
+    /// # let read_debug_gnu_pubnames_section_somehow = || &buf;
+    /// let debug_gnu_pubnames =
+    ///     DebugGnuPubNames::new(read_debug_gnu_pubnames_section_somehow(), LittleEndian);
+    ///
+    /// let mut iter = debug_gnu_pubnames.items();
+    /// while let Some(pubname) = iter.next().unwrap() {
+    ///   println!("pubname {} found!", pubname.name().to_string_lossy());
+    /// }
+    /// ```
+    pub fn items(&self) -> PubNamesEntryIter<R> {
+        PubNamesEntryIter(self.0.items(true))
+    }
+
+    /// Iterate the sets of entries in the `.debug_gnu_pubnames` section.
+    ///
+    /// Each set corresponds to a single unit, and contains the header for that
+    /// unit followed by its entries.
+    pub fn sets(&self) -> PubNamesSetIter<R> {
+        PubNamesSetIter(self.0.sets(true))
+    }
+}
+
+impl<R: Reader> Section<R> for DebugGnuPubNames<R> {
+    fn id() -> SectionId {
+        SectionId::DebugGnuPubNames
+    }
+
+    fn reader(&self) -> &R {
+        &self.0.section
+    }
+}
+
+impl<R: Reader> From<R> for DebugGnuPubNames<R> {
+    fn from(section: R) -> Self {
+        DebugGnuPubNames(DebugPubSet { section })
+    }
+}
+
+/// An iterator over the pubnames from a `.debug_pubnames` or `.debug_gnu_pubnames` section.
 #[derive(Debug, Clone)]
 pub struct PubNamesSetIter<R: Reader>(PubSetIter<R>);
 
@@ -111,7 +186,7 @@ impl<R: Reader> Iterator for PubNamesSetIter<R> {
     }
 }
 
-/// A set of entries that share a header in a `.debug_pubnames` section.
+/// A set of entries that share a header in a `.debug_pubnames` or `.debug_gnu_pubnames` section.
 ///
 /// These entries all belong to a single unit.
 #[derive(Debug, Clone)]
@@ -151,7 +226,7 @@ impl<R: Reader> PubNamesSet<R> {
     }
 }
 
-/// An iterator over the pubnames from a `.debug_pubnames` section.
+/// An iterator over the pubnames from a `.debug_pubnames` or `.debug_gnu_pubnames` section.
 #[derive(Debug, Clone)]
 pub struct PubNamesEntryIter<R: Reader>(PubSetEntryIter<R>);
 
@@ -207,12 +282,30 @@ impl<R: Reader> PubNamesEntry<R> {
     pub fn die_offset(&self) -> UnitOffset<R::Offset> {
         self.0.die_offset
     }
+
+    /// Return the symbol kind.
+    ///
+    /// The compiler derives this from the tag of the DIE.
+    ///
+    /// Only .debug_gnu_pubnames entries contain this value.
+    /// Always returns `GDB_INDEX_SYMBOL_KIND_NONE` for a .debug_pubnames entry.
+    pub fn kind(&self) -> GdbIndexSymbolKind {
+        self.0.kind()
+    }
+
+    /// Return true if the symbol is static.
+    ///
+    /// Always returns false for a .debug_pubnames entry.
+    pub fn is_static(&self) -> bool {
+        self.0.is_static()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::common::DebugInfoOffset;
+    use crate::constants::*;
     use crate::test_util::GimliSectionMethods;
     use crate::{Format, LittleEndian};
     use test_assembler::{Endian, Label, LabelMaker, Section};
@@ -265,6 +358,8 @@ mod tests {
             assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
             assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
             assert_eq!(entry.die_offset(), UnitOffset(0x02));
+            assert_eq!(entry.kind(), GDB_INDEX_SYMBOL_KIND_NONE);
+            assert!(!entry.is_static());
 
             let entry = items.next().unwrap().unwrap();
             assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
@@ -311,6 +406,50 @@ mod tests {
             assert!(matches!(items.next(), Ok(None)));
 
             assert!(matches!(sets.next(), Ok(None)));
+        }
+    }
+
+    #[test]
+    fn test_gnu_pubnames() {
+        for format in [Format::Dwarf32, Format::Dwarf64] {
+            let size = format.word_size();
+
+            let length = Label::new();
+            let start = Label::new();
+            let section = Section::with_endian(Endian::Little)
+                .initial_length(format, &length, &start)
+                .D16(2) // Version
+                .word(size, 0x10) // Unit header offset
+                .word(size, 0x20) // Unit length
+                // Entry 1
+                .word(size, 0x02)
+                .D8(0xb0) // static (0x80) | function (3 << 4)
+                .append_bytes(b"foo\0")
+                // Entry 2
+                .word(size, 0x04)
+                .D8(0x20) // global (0x00) | variable (2 << 4) = 0x20.
+                .append_bytes(b"bar\0")
+                // Null entry
+                .word(size, 0)
+                .set_initial_length(&length, &start);
+
+            let section = section.get_contents().unwrap();
+            let debug_gnu_pubnames = DebugGnuPubNames::new(&section, LittleEndian);
+            let mut items = debug_gnu_pubnames.items();
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(entry.die_offset(), UnitOffset(0x02));
+            assert_eq!(entry.kind(), GDB_INDEX_SYMBOL_KIND_FUNCTION);
+            assert!(entry.is_static());
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
+            assert_eq!(entry.kind(), GDB_INDEX_SYMBOL_KIND_VARIABLE);
+            assert!(!entry.is_static());
+
+            assert!(matches!(items.next(), Ok(None)));
         }
     }
 }

--- a/src/read/pubtypes.rs
+++ b/src/read/pubtypes.rs
@@ -1,10 +1,11 @@
 use crate::common::{DebugInfoOffset, Format, SectionId};
+use crate::constants::GdbIndexSymbolKind;
 use crate::endianity::Endianity;
 use crate::read::lookup::{DebugPubSet, PubSet, PubSetEntry, PubSetEntryIter, PubSetIter};
 use crate::read::{EndianSlice, Reader, Result, Section, UnitOffset};
 
 /// The `DebugPubTypes` struct represents the DWARF public types information
-/// found in the `.debug_info` section.
+/// found in the `.debug_pubtypes` section.
 #[derive(Debug, Clone)]
 pub struct DebugPubTypes<R: Reader>(DebugPubSet<R>);
 
@@ -49,7 +50,7 @@ impl<R: Reader> DebugPubTypes<R> {
     /// }
     /// ```
     pub fn items(&self) -> PubTypesEntryIter<R> {
-        PubTypesEntryIter(self.0.items())
+        PubTypesEntryIter(self.0.items(false))
     }
 
     /// Iterate the sets of entries in the `.debug_pubtypes` section.
@@ -57,7 +58,7 @@ impl<R: Reader> DebugPubTypes<R> {
     /// Each set corresponds to a single unit, and contains the header for that
     /// unit followed by its entries.
     pub fn sets(&self) -> PubTypesSetIter<R> {
-        PubTypesSetIter(self.0.sets())
+        PubTypesSetIter(self.0.sets(false))
     }
 }
 
@@ -77,7 +78,81 @@ impl<R: Reader> From<R> for DebugPubTypes<R> {
     }
 }
 
-/// An iterator over the pubtypes from a `.debug_pubtypes` section.
+/// The `DebugGnuPubTypes` struct represents the DWARF public types information
+/// found in the `.debug_gnu_pubtypes` section.
+#[derive(Debug, Clone)]
+pub struct DebugGnuPubTypes<R: Reader>(DebugPubSet<R>);
+
+impl<'input, Endian> DebugGnuPubTypes<EndianSlice<'input, Endian>>
+where
+    Endian: Endianity,
+{
+    /// Construct a new `DebugGnuPubTypes` instance from the data in the `.debug_gnu_pubtypes`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_gnu_pubtypes` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on macOS, etc.
+    ///
+    /// ```
+    /// use gimli::{DebugGnuPubTypes, LittleEndian};
+    ///
+    /// # let buf = [];
+    /// # let read_debug_gnu_pubtypes_somehow = || &buf;
+    /// let debug_gnu_pubtypes =
+    ///     DebugGnuPubTypes::new(read_debug_gnu_pubtypes_somehow(), LittleEndian);
+    /// ```
+    pub fn new(section: &'input [u8], endian: Endian) -> Self {
+        Self::from(EndianSlice::new(section, endian))
+    }
+}
+
+impl<R: Reader> DebugGnuPubTypes<R> {
+    /// Iterate the pubtypes in the `.debug_gnu_pubtypes` section.
+    ///
+    /// ```
+    /// use gimli::{DebugGnuPubTypes, EndianSlice, LittleEndian};
+    ///
+    /// # let buf = [];
+    /// # let read_debug_gnu_pubtypes_section_somehow = || &buf;
+    /// let debug_gnu_pubtypes =
+    ///     DebugGnuPubTypes::new(read_debug_gnu_pubtypes_section_somehow(), LittleEndian);
+    ///
+    /// let mut iter = debug_gnu_pubtypes.items();
+    /// while let Some(pubtype) = iter.next().unwrap() {
+    ///   println!("pubtype {} found!", pubtype.name().to_string_lossy());
+    /// }
+    /// ```
+    pub fn items(&self) -> PubTypesEntryIter<R> {
+        PubTypesEntryIter(self.0.items(true))
+    }
+
+    /// Iterate the sets of entries in the `.debug_gnu_pubtypes` section.
+    ///
+    /// Each set corresponds to a single unit, and contains the header for that
+    /// unit followed by its entries.
+    pub fn sets(&self) -> PubTypesSetIter<R> {
+        PubTypesSetIter(self.0.sets(true))
+    }
+}
+
+impl<R: Reader> Section<R> for DebugGnuPubTypes<R> {
+    fn id() -> SectionId {
+        SectionId::DebugGnuPubTypes
+    }
+
+    fn reader(&self) -> &R {
+        &self.0.section
+    }
+}
+
+impl<R: Reader> From<R> for DebugGnuPubTypes<R> {
+    fn from(section: R) -> Self {
+        DebugGnuPubTypes(DebugPubSet { section })
+    }
+}
+
+/// An iterator over the pubtypes from a `.debug_pubtypes` or `.debug_gnu_pubtypes` section.
 #[derive(Debug, Clone)]
 pub struct PubTypesSetIter<R: Reader>(PubSetIter<R>);
 
@@ -111,7 +186,7 @@ impl<R: Reader> Iterator for PubTypesSetIter<R> {
     }
 }
 
-/// A set of entries that share a header in a `.debug_pubtypes` section.
+/// A set of entries that share a header in a `.debug_pubtypes` or `.debug_gnu_pubtypes` section.
 ///
 /// These entries all belong to a single unit.
 #[derive(Debug, Clone)]
@@ -151,7 +226,7 @@ impl<R: Reader> PubTypesSet<R> {
     }
 }
 
-/// An iterator over the pubtypes from a `.debug_pubtypes` section.
+/// An iterator over the pubtypes from a `.debug_pubtypes` or `.debug_gnu_pubtypes` section.
 #[derive(Debug, Clone)]
 pub struct PubTypesEntryIter<R: Reader>(PubSetEntryIter<R>);
 
@@ -207,12 +282,30 @@ impl<R: Reader> PubTypesEntry<R> {
     pub fn die_offset(&self) -> UnitOffset<R::Offset> {
         self.0.die_offset
     }
+
+    /// Return the symbol kind.
+    ///
+    /// The compiler derives this from the tag of the DIE.
+    ///
+    /// Only .debug_gnu_pubtypes entries contain this value.
+    /// Always returns `GDB_INDEX_SYMBOL_KIND_NONE` for a .debug_pubtypes entry.
+    pub fn kind(&self) -> GdbIndexSymbolKind {
+        self.0.kind()
+    }
+
+    /// Return true if the symbol is static.
+    ///
+    /// Always returns false for a .debug_pubtypes entry.
+    pub fn is_static(&self) -> bool {
+        self.0.is_static()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::common::DebugInfoOffset;
+    use crate::constants::*;
     use crate::test_util::GimliSectionMethods;
     use crate::{Format, LittleEndian};
     use test_assembler::{Endian, Label, LabelMaker, Section};
@@ -265,6 +358,8 @@ mod tests {
             assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
             assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
             assert_eq!(entry.die_offset(), UnitOffset(0x02));
+            assert_eq!(entry.kind(), GDB_INDEX_SYMBOL_KIND_NONE);
+            assert!(!entry.is_static());
 
             let entry = items.next().unwrap().unwrap();
             assert_eq!(entry.name(), &EndianSlice::new(b"bar", LittleEndian));
@@ -311,6 +406,41 @@ mod tests {
             assert!(matches!(items.next(), Ok(None)));
 
             assert!(matches!(sets.next(), Ok(None)));
+        }
+    }
+
+    #[test]
+    fn test_gnu_pubtypes() {
+        for format in [Format::Dwarf32, Format::Dwarf64] {
+            let size = format.word_size();
+
+            let length = Label::new();
+            let start = Label::new();
+            let section = Section::with_endian(Endian::Little)
+                .initial_length(format, &length, &start)
+                .D16(2) // Version
+                .word(size, 0x10) // Unit header offset
+                .word(size, 0x20) // Unit length
+                // Entry 1
+                .word(size, 0x02)
+                .D8(0x90) // static (0x80) | type (1 << 4) = 0x90.
+                .append_bytes(b"foo\0")
+                // Null entry
+                .word(size, 0)
+                .set_initial_length(&length, &start);
+
+            let section = section.get_contents().unwrap();
+            let debug_gnu_pubtypes = DebugGnuPubTypes::new(&section, LittleEndian);
+            let mut items = debug_gnu_pubtypes.items();
+
+            let entry = items.next().unwrap().unwrap();
+            assert_eq!(entry.name(), &EndianSlice::new(b"foo", LittleEndian));
+            assert_eq!(entry.unit_header_offset(), DebugInfoOffset(0x10));
+            assert_eq!(entry.die_offset(), UnitOffset(0x02));
+            assert_eq!(entry.kind(), GDB_INDEX_SYMBOL_KIND_TYPE);
+            assert!(entry.is_static());
+
+            assert!(matches!(items.next(), Ok(None)));
         }
     }
 }


### PR DESCRIPTION
Breaking change: new SectionId variants

Closes #879 