### PR TITLE
Remove unnecessary clone

### DIFF
--- a/crates/examples/src/bin/convert.rs
+++ b/crates/examples/src/bin/convert.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     };
 
     // Try to load a .dwp file.
-    let mut dwp_path = read_path.clone();
+    let mut dwp_path = read_path;
     dwp_path.push(".dwp");
     let dwp_file = fs::File::open(&dwp_path).ok();
     let dwp_mmap = dwp_file


### PR DESCRIPTION
If I am not overlooking anything, this clone can be removed, and `read_path` can instead be moved.

CC @nunoplopes