### PR TITLE
read: avoid overflow when computing index-based section offsets

### DIFF
--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -31,7 +31,11 @@ impl<R: Reader> DebugAddr<R> {
         let input = &mut self.section.clone();
         input.skip(base.0)?;
         input.skip(R::Offset::from_u64(
-            index.0.into_u64() * u64::from(address_size),
+            index
+                .0
+                .into_u64()
+                .checked_mul(u64::from(address_size))
+                .ok_or(Error::UnsupportedOffset)?,
         )?)?;
         input.read_address(address_size)
     }
@@ -308,6 +312,19 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_get_address_index_overflow() {
+        // `index * address_size` must not overflow when the index is attacker
+        // controlled; it should be reported as an unsupported offset instead.
+        let buf = [0u8; 64];
+        let debug_addr = DebugAddr::from(EndianSlice::new(&buf, LittleEndian));
+        let index = DebugAddrIndex(0x2000_0000_0000_0000usize);
+        assert_eq!(
+            debug_addr.get_address(8, DebugAddrBase(0), index),
+            Err(Error::UnsupportedOffset)
+        );
     }
 
     #[test]

--- a/src/read/addr.rs
+++ b/src/read/addr.rs
@@ -315,9 +315,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_get_address_index_overflow() {
-        // `index * address_size` must not overflow when the index is attacker
-        // controlled; it should be reported as an unsupported offset instead.
+        // `index * address_size` must not overflow; it should be reported as an
+        // unsupported offset instead.
         let buf = [0u8; 64];
         let debug_addr = DebugAddr::from(EndianSlice::new(&buf, LittleEndian));
         let index = DebugAddrIndex(0x2000_0000_0000_0000usize);

--- a/src/read/loclists.rs
+++ b/src/read/loclists.rs
@@ -291,7 +291,11 @@ impl<R: Reader> LocationLists<R> {
         let input = &mut self.debug_loclists.section.clone();
         input.skip(base.0)?;
         input.skip(R::Offset::from_u64(
-            index.0.into_u64() * u64::from(format.word_size()),
+            index
+                .0
+                .into_u64()
+                .checked_mul(u64::from(format.word_size()))
+                .ok_or(Error::UnsupportedOffset)?,
         )?)?;
         input
             .read_offset(format)

--- a/src/read/rnglists.rs
+++ b/src/read/rnglists.rs
@@ -269,7 +269,11 @@ impl<R: Reader> RangeLists<R> {
         let input = &mut self.debug_rnglists.section.clone();
         input.skip(base.0)?;
         input.skip(R::Offset::from_u64(
-            index.0.into_u64() * u64::from(format.word_size()),
+            index
+                .0
+                .into_u64()
+                .checked_mul(u64::from(format.word_size()))
+                .ok_or(Error::UnsupportedOffset)?,
         )?)?;
         input
             .read_offset(format)

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -4,7 +4,7 @@ use crate::common::{
     Encoding, SectionId,
 };
 use crate::endianity::Endianity;
-use crate::read::{EndianSlice, Reader, ReaderOffset, Result, Section};
+use crate::read::{EndianSlice, Error, Reader, ReaderOffset, Result, Section};
 
 /// The `DebugStr` struct represents the DWARF strings
 /// found in the `.debug_str` section.
@@ -118,7 +118,11 @@ impl<R: Reader> DebugStrOffsets<R> {
         let input = &mut self.section.clone();
         input.skip(base.0)?;
         input.skip(R::Offset::from_u64(
-            index.0.into_u64() * u64::from(format.word_size()),
+            index
+                .0
+                .into_u64()
+                .checked_mul(u64::from(format.word_size()))
+                .ok_or(Error::UnsupportedOffset)?,
         )?)?;
         input.read_offset(format).map(DebugStrOffset)
     }
@@ -287,5 +291,18 @@ mod tests {
                 Ok(DebugStrOffset(1019))
             );
         }
+    }
+
+    #[test]
+    fn test_get_str_offset_index_overflow() {
+        // `index * word_size` must not overflow when the index is attacker
+        // controlled; it should be reported as an unsupported offset instead.
+        let buf = [0u8; 64];
+        let debug_str_offsets = DebugStrOffsets::from(EndianSlice::new(&buf, LittleEndian));
+        let index = DebugStrOffsetsIndex(0x4000_0000_0000_0000usize);
+        assert_eq!(
+            debug_str_offsets.get_str_offset(Format::Dwarf64, DebugStrOffsetsBase(0), index),
+            Err(Error::UnsupportedOffset)
+        );
     }
 }

--- a/src/read/str.rs
+++ b/src/read/str.rs
@@ -294,9 +294,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_get_str_offset_index_overflow() {
-        // `index * word_size` must not overflow when the index is attacker
-        // controlled; it should be reported as an unsupported offset instead.
+        // `index * word_size` must not overflow; it should be reported as an
+        // unsupported offset instead.
         let buf = [0u8; 64];
         let debug_str_offsets = DebugStrOffsets::from(EndianSlice::new(&buf, LittleEndian));
         let index = DebugStrOffsetsIndex(0x4000_0000_0000_0000usize);


### PR DESCRIPTION
Repro: resolve a `DW_FORM_addrx`/`strx`/`loclistx`/`rnglistx` whose index is around `0x2000_0000_0000_0000` via `DebugAddr::get_address` / `DebugStrOffsets::get_str_offset` / `LocationLists::get_offset` / `RangeLists::get_offset`.
Cause: each computes `index * size` (address size or DWARF word size) as an unchecked `u64` multiply before `from_u64`, so a large index wraps. With overflow checks that panics; in release it skips to a wrong in-bounds offset.
Fix: use `checked_mul` and return `Error::UnsupportedOffset` on overflow, the same way an out-of-range offset is already reported.