### PR TITLE
read/op: avoid overflow when converting DW_OP_piece size to bits

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -338,6 +338,8 @@ pub enum Error {
     InvalidShiftExpression,
     /// The size of a deref expression must not be larger than the size of an address.
     InvalidDerefSize(u8),
+    /// The byte size of a `DW_OP_piece` is too large to convert to a bit size.
+    InvalidPieceSize(u64),
     /// An unknown DW_CFA_* instruction.
     UnknownCallFrameInstruction(constants::DwCfa),
     /// A `DW_CFA_set_loc` instruction moved the address backward.
@@ -515,6 +517,9 @@ impl fmt::Display for Error {
             }
             Error::InvalidDerefSize(val) => {
                 write!(f, "invalid deref size: {val}")
+            }
+            Error::InvalidPieceSize(val) => {
+                write!(f, "invalid piece size: {val}")
             }
             Error::UnknownCallFrameInstruction(val) => {
                 write!(f, "unknown call frame instruction: 0x{:x}", val.0)

--- a/src/read/op.rs
+++ b/src/read/op.rs
@@ -655,8 +655,9 @@ where
             }
             constants::DW_OP_piece => {
                 let size = bytes.read_uleb128()?;
+                let size_in_bits = size.checked_mul(8).ok_or(Error::InvalidPieceSize(size))?;
                 Ok(Operation::Piece {
-                    size_in_bits: 8 * size,
+                    size_in_bits,
                     bit_offset: None,
                 })
             }
@@ -2617,12 +2618,11 @@ mod tests {
                 ]);
             }
 
-            // FIXME
-            if *value < !0u64 / 8 {
+            if let Some(size_in_bits) = value.checked_mul(8) {
                 inputs.push((
                     constants::DW_OP_piece,
                     Operation::Piece {
-                        size_in_bits: 8 * value,
+                        size_in_bits,
                         bit_offset: None,
                     },
                 ));
@@ -2638,6 +2638,27 @@ mod tests {
                 check_op_parse_simple(&input, expect, encoding);
             }
         }
+    }
+
+    #[test]
+    fn test_op_parse_piece_overflow() {
+        // Doesn't matter for this test.
+        let encoding = encoding4();
+
+        // A `DW_OP_piece` size is given in bytes and converted to bits.
+        // A byte size whose bit size does not fit in a `u64` must be rejected
+        // rather than overflowing the multiplication.
+        let size = !0u64 / 8 + 1;
+        let input = Section::with_endian(Endian::Little)
+            .D8(constants::DW_OP_piece.0)
+            .uleb(size)
+            .get_contents()
+            .unwrap();
+        let mut pc = EndianSlice::new(&input, LittleEndian);
+        assert_eq!(
+            Operation::parse(&mut pc, encoding),
+            Err(Error::InvalidPieceSize(size))
+        );
     }
 
     #[test]


### PR DESCRIPTION
`Operation::parse` handles `DW_OP_piece` by reading a ULEB128 byte size and converting it to bits with `8 * size`. The size comes straight from the expression bytecode and isn't bounded, so any value above `u64::MAX / 8` overflows the multiply: it panics with overflow checks on and silently wraps to a wrong `size_in_bits` in release. The existing parse test already dodged this with a `// FIXME` that skips large sizes.

Compute the bit size with `checked_mul(8)` and return a new `Error::InvalidPieceSize` on overflow, mirroring the existing `InvalidDerefSize` error for a bad operand size. Keeping the check in `Operation::parse` means every consumer of the operation iterator gets a clean error rather than a panic. `DW_OP_bit_piece` reads its bit size directly so it's unaffected; I dropped the `FIXME` and added a regression test for the overflowing size.